### PR TITLE
WIP: Initial workflow (OWNERS, etc.) only tracking secondary metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# How to Contribute
+
+This project is [Apache 2.0 licensed](LICENSE) and accept contributions via GitHub pull requests.
+This document outlines some of the conventions on development workflow, commit message formatting, contact points and other resources to make it easier to get your contribution accepted.
+
+## Security response
+
+If you've found a security issue that you'd like to disclose confidentially, please contact Red Hat's Product Security team.
+
+## Getting started
+
+- Fork the repository on GitHub.
+- Read the [README](README.md) for build and test instructions.
+- Play with the project, submit bugs, submit patches!
+
+### Contribution flow
+
+Anyone may [file issues][new-issue].
+For contributors who want to work up pull requests, the workflow is roughly:
+
+1. Create a topic branch from where you want to base your work (usually master).
+2. Make commits of logical units.
+3. Make sure your commit messages are in the proper format (see [below](#commit-message-format)).
+4. Push your changes to a topic branch in your fork of the repository.
+5. Make sure the tests pass, and add any new tests as appropriate.
+6. Submit a pull request to the original repository.
+7. The [repo](OWNERS) [owners](OWNERS_ALIASES) will respond to your issue promptly, following [the ususal Prow workflow][prow-review].
+
+Thanks for your contributions!
+
+### Commit message format
+
+We follow a rough convention for commit messages that is designed to answer two questions: what changed and why.
+The subject line should feature the what and the body of the commit should describe the why.
+
+```
+scripts: add the test-cluster command
+
+this uses tmux to set up a test cluster that you can easily kill and
+start for debugging.
+
+Fixes #38
+```
+
+The format can be described more formally as follows:
+
+```
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+The first line is the subject and should be no longer than 70 characters, the second line is always blank, and other lines should be wrapped at 80 characters.
+
+This allows the message to be easier to read on GitHub as well as in various Git tools.
+
+[new-issue]: https://github.com/openshift/cincinnati-graph-data/issues/new
+[prow-review]: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process
+[security]: https://access.redhat.com/security/team/contact

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - cincinnati-graph-data-approvers
+  - release-admins
+reviewers:
+  - cincinnati-graph-data-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  cincinnati-graph-data-approvers:
+    - crawford
+    - lucab
+    - steveeJ
+    - wking
+    - vrutkovs
+  cincinnati-graph-data-reviewers:
+  release-admins:
+    - crawford
+    - derekwaynecarr
+    - eparis
+    - jwforres
+    - smarterclayton

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Cincinnati Graph Data
+
+[Cincinnati][] is an update protocol designed to facilitate automatic updates.
+This repository manages the Cincinnati graph for OpenShift.
+
+## Workflow
+
+The [contributing documentation](CONTRIBUTING.md) covers licencing and the usual Git flow.
+
+FIXME: Document the data flow for this project.
+
+[Cincinnati]: https://github.com/openshift/cincinnati/

--- a/README.md
+++ b/README.md
@@ -15,5 +15,20 @@ Update the local metadata file to match the currently-live metadata with:
 $ hack/pull
 ```
 
+### Make local adjustments
+
+By editing [`metadata.json`](metadata.json) to add or remove labels.
+
+### Push metadata
+
+Update the currently-live metadata to match the local metadata file with:
+
+```console
+$ hack/push --token="${YOUR_TOKEN}"
+```
+
+You can leave `--token` unset for a dry run (the actions the script would take are printed either way, but are only executed if you passed a token).
+
+FIXME: haven't bothered dropping in actual --token support yet.
 
 [Cincinnati]: https://github.com/openshift/cincinnati/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ This repository manages the Cincinnati graph for OpenShift.
 
 The [contributing documentation](CONTRIBUTING.md) covers licencing and the usual Git flow.
 
-FIXME: Document the data flow for this project.
+### Pull metadata
+
+Update the local metadata file to match the currently-live metadata with:
+
+```console
+$ hack/pull
+```
+
 
 [Cincinnati]: https://github.com/openshift/cincinnati/

--- a/hack/pull
+++ b/hack/pull
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import codecs
+import io
+import json
+import tarfile
+
+try:
+    from urllib.request import Request, urlopen  # Python 3
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import HTTPError, Request, urlopen  # Python 2
+
+
+repo = 'openshift-release-dev/ocp-release'
+repo_uri = 'https://quay.io/api/v1/repository/{}'.format(repo)
+meta = {}
+page = 1
+while True:
+    f = urlopen('{}/tag/?page={}'.format(repo_uri, page))
+    tags = json.load(codecs.getreader('utf-8')(f))
+    f.close()  # no context manager with-statement because in Python 2: AttributeError: addinfourl instance has no attribute '__exit__'
+
+    for tag in tags['tags']:
+        if 'expiration' in tag:
+            continue
+
+        version = tag['name']  # FIXME: pull release-meta
+        digest = tag['manifest_digest']
+
+        uri = '{}/manifest/{}/labels'.format(repo_uri, digest)
+        try:
+            f = urlopen(uri)
+        except HTTPError as error:
+            print('failed to pull labels for {} {}: {}'.format(version, uri, error))
+            continue
+        labels = json.load(codecs.getreader('utf-8')(f))
+        f.close()  # no context manager with-statement because in Python 2: AttributeError: addinfourl instance has no attribute '__exit__'
+
+        for label in labels['labels']:
+            if label['source_type'] != 'api':
+                continue
+            if version not in meta:
+                meta[version] = {}
+            meta[version][label['key']] = label['value']
+
+    if tags['has_additional']:
+        page += 1
+        continue
+    break
+
+with open('metadata.json', 'w+') as f:
+    json.dump(
+        meta, f, indent=2, sort_keys=True,
+        separators=(',', ': '),  # only needs to be explicit in Python 2 and <3.4
+    )
+    f.write('\n')

--- a/hack/push
+++ b/hack/push
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import codecs
+import io
+import json
+import tarfile
+
+try:
+    from urllib.request import Request, urlopen  # Python 3
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import HTTPError, Request, urlopen  # Python 2
+
+
+repo = 'openshift-release-dev/ocp-release'
+repo_uri = 'https://quay.io/api/v1/repository/{}'.format(repo)
+
+with open('metadata.json') as f:
+    meta = json.load(f)
+
+page = 1
+while True:
+    f = urlopen('{}/tag/?page={}'.format(repo_uri, page))
+    tags = json.load(codecs.getreader('utf-8')(f))
+    f.close()  # no context manager with-statement because in Python 2: AttributeError: addinfourl instance has no attribute '__exit__'
+
+    for tag in tags['tags']:
+        if 'expiration' in tag:
+            continue
+
+        version = tag['name']  # FIXME: pull release-meta
+        digest = tag['manifest_digest']
+
+        uri = '{}/manifest/{}/labels'.format(repo_uri, digest)
+        try:
+            f = urlopen(uri)
+        except HTTPError as error:
+            print('failed to pull labels for {} {}: {}'.format(version, uri, error))
+            continue
+        labels = json.load(codecs.getreader('utf-8')(f))
+        f.close()  # no context manager with-statement because in Python 2: AttributeError: addinfourl instance has no attribute '__exit__'
+
+        for label in labels['labels']:
+            if label['source_type'] != 'api':
+                continue
+
+            if label['key'] not in meta.get(version, {}):
+                print('{} ({}) delete {}'.format(version, digest, label['key']))
+            elif meta[version][label['key']] == label['value']:
+                del meta[version][label['key']]
+            else:
+                print('{} ({}) update {} from {!r} to {!r}'.format(version, digest, label['key'], label['value'], meta[version][label['key']]))
+                del meta[version][label['key']]
+
+        for key, value in meta.get(version, {}).items():
+            print('{} ({}) create {}: {!r}'.format(version, digest, key, value))
+
+    if tags['has_additional']:
+        page += 1
+        continue
+    break

--- a/metadata.json
+++ b/metadata.json
@@ -80,6 +80,9 @@
   "4.1.20": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.1.21": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
   "4.1.3": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
@@ -109,5 +112,11 @@
   },
   "4.2.0-rc.5": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2,candidate-4.2"
+  },
+  "4.2.1": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2"
+  },
+  "4.2.2": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -93,10 +93,10 @@
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1,stable-4.2"
   },
   "4.1.25": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.26": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1,fast-4.2,stable-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1"
   },
   "4.1.27": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
@@ -131,7 +131,7 @@
   },
   "4.2.0-rc.5": {
     "io.openshift.upgrades.graph.previous.remove": "4.1.18,4.1.20",
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.2,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.2"
   },
   "4.2.1": {
     "io.openshift.upgrades.graph.previous.remove": "*",

--- a/metadata.json
+++ b/metadata.json
@@ -94,5 +94,8 @@
   },
   "4.1.9": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.2.0-rc.0": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,89 @@
+{
+  "4.0.0-0.10": {
+    "com.openshift.upgrades.graph.release.channels": "stable-4.0",
+    "io.openshift.upgrades.graph.release.channels": "stable-4.0"
+  },
+  "4.0.0-0.11": {
+    "com.openshift.upgrades.graph.release.channels": "stable-4.0",
+    "io.openshift.upgrades.graph.release.channels": "stable-4.0"
+  },
+  "4.0.0-0.9": {
+    "com.openshift.upgrades.graph.release.channels": "stable-4.0",
+    "io.openshift.upgrades.graph.release.channels": "stable-4.0"
+  },
+  "4.1.0": {
+    "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.4,4.1.0-rc.9",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.0-rc.0": {
+    "com.openshift.upgrades.graph.release.channels": "prerelease-4.1",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.3": {
+    "com.openshift.upgrades.graph.release.channels": "prerelease-4.1",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.4": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.5": {
+    "io.openshift.upgrades.graph.next.add": "4.1.0-rc.6",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.6": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.7": {
+    "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.6",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.8": {
+    "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.7",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.0-rc.9": {
+    "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.7,4.1.0-rc.8",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
+  "4.1.1": {
+    "io.openshift.upgrades.graph.previous.remove": "*",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.10": {
+    "io.openshift.upgrades.graph.previous.remove": "*",
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.11": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.13": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.14": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.15": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.2": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.3": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.4": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.6": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.7": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.8": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
+  "4.1.9": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -96,7 +96,7 @@
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.26": {
-    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1,stable-4.2"
   },
   "4.1.27": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,9 @@
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.1.20": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+  },
   "4.1.3": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },

--- a/metadata.json
+++ b/metadata.json
@@ -147,9 +147,11 @@
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2"
   },
   "4.2.11": {
+    "io.openshift.upgrades.graph.previous.remove": "*",
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.11-s390x": {
+    "io.openshift.upgrades.graph.previous.remove": "*",
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.12": {

--- a/metadata.json
+++ b/metadata.json
@@ -65,6 +65,9 @@
   "4.1.15": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.1.16": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },

--- a/metadata.json
+++ b/metadata.json
@@ -98,6 +98,9 @@
   "4.1.9": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.2.0": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
   "4.2.0-rc.0": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
   },

--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.16": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"

--- a/metadata.json
+++ b/metadata.json
@@ -68,6 +68,9 @@
   "4.1.16": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.1.17": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.17": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"

--- a/metadata.json
+++ b/metadata.json
@@ -71,6 +71,9 @@
   "4.1.17": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
+  "4.1.18": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+  },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.18": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
   },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
@@ -100,5 +100,8 @@
   },
   "4.2.0-rc.1": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
+  },
+  "4.2.0-rc.5": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.2,candidate-4.2"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -27,10 +27,10 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
   },
   "4.1.0-rc.5": {
-    "io.openshift.upgrades.graph.next.add": "4.1.0-rc.6",
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
   },
   "4.1.0-rc.6": {
+    "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.5",
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
   },
   "4.1.0-rc.7": {
@@ -99,7 +99,10 @@
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1,stable-4.2"
   },
   "4.1.27": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.1.28": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.1.3": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
@@ -130,7 +133,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
   },
   "4.2.0-rc.5": {
-    "io.openshift.upgrades.graph.previous.remove": "4.1.18,4.1.20",
+    "io.openshift.upgrades.graph.previous.remove": "*",
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.2"
   },
   "4.2.1": {
@@ -138,10 +141,22 @@
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.10": {
-    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.10-s390x": {
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2"
+  },
+  "4.2.11": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.11-s390x": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.12": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.12-s390x": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.2": {
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.18": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"

--- a/metadata.json
+++ b/metadata.json
@@ -72,31 +72,31 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.18": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.2": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.20": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.21": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.22": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1,fast-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.23": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,prerelease-4.1,stable-4.1"
   },
   "4.1.24": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2,stable-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,prerelease-4.1,stable-4.1,stable-4.2"
   },
   "4.1.25": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1"
   },
   "4.1.26": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1,fast-4.2,stable-4.2"
   },
   "4.1.27": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
@@ -136,6 +136,12 @@
   "4.2.1": {
     "io.openshift.upgrades.graph.previous.remove": "*",
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.10": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2"
+  },
+  "4.2.10-s390x": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2"
   },
   "4.2.2": {
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"

--- a/metadata.json
+++ b/metadata.json
@@ -97,5 +97,8 @@
   },
   "4.2.0-rc.0": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
+  },
+  "4.2.0-rc.1": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -78,10 +78,28 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.1.20": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
   },
   "4.1.21": {
-    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1"
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2"
+  },
+  "4.1.22": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1,fast-4.2"
+  },
+  "4.1.23": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2"
+  },
+  "4.1.24": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1,candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.1.25": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2,stable-4.1"
+  },
+  "4.1.26": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
+  },
+  "4.1.27": {
+    "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,candidate-4.2"
   },
   "4.1.3": {
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
@@ -102,6 +120,7 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.1,stable-4.1"
   },
   "4.2.0": {
+    "io.openshift.upgrades.graph.previous.remove": "4.1.20",
     "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.0-rc.0": {
@@ -111,12 +130,26 @@
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2"
   },
   "4.2.0-rc.5": {
+    "io.openshift.upgrades.graph.previous.remove": "4.1.18,4.1.20",
     "io.openshift.upgrades.graph.release.channels": "prerelease-4.2,candidate-4.2"
   },
   "4.2.1": {
-    "io.openshift.upgrades.graph.release.channels": "candidate-4.2"
+    "io.openshift.upgrades.graph.previous.remove": "*",
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   },
   "4.2.2": {
-    "io.openshift.upgrades.graph.release.channels": "candidate-4.2"
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.4": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.7": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.8": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
+  },
+  "4.2.9": {
+    "io.openshift.upgrades.graph.release.channels": "candidate-4.2,fast-4.2,stable-4.2"
   }
 }


### PR DESCRIPTION
While #1 is currently only updating Quay lables, there has been some concern around it positioning itself to be the single source of Cincinnati graph-builder data at some future point.  Since my main goal is to get the release-admin workflow into version control, here's a lighter-weight alternative that only manages secondary metadata.  Cincinnati would continue to pull primary metadata dynamically from image `release-metadata` on Quay, and it would get overrides from this repository.

For at least the short term, those overrides would be set in Quay labels just like they are today; we might change that later, but it wouldn't affect the release-admin workflow.

There's also been pushback against hand-edited JSON in #1.  But I'm lazy and want these scripts to work even for folks without PyYAML installed ;).  We can switch to YAML easily later if folks are comfortable with the workflow.