### PR TITLE
channels/*-4.2: Explain why we skipped 4.2.15

### DIFF
--- a/channels/candidate-4.2.yaml
+++ b/channels/candidate-4.2.yaml
@@ -33,4 +33,5 @@ versions:
 - 4.2.13
 - 4.2.13-s390x
 - 4.2.14
+# not 4.2.15 because 4.2.16 was built with the same errata URI
 - 4.2.16

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -28,3 +28,4 @@ versions:
 - 4.2.13-s390x
 - 4.2.14+amd64
 # not 4.2.14-s390x because of https://bugzilla.redhat.com/show_bug.cgi?id=1789260
+# not 4.2.15 because 4.2.16 was built with the same errata URI

--- a/channels/stable-4.2.yaml
+++ b/channels/stable-4.2.yaml
@@ -25,3 +25,4 @@ versions:
 - 4.2.13-s390x
 - 4.2.14+amd64
 # not 4.2.14-s390x because of https://bugzilla.redhat.com/show_bug.cgi?id=1789260
+# not 4.2.15 because 4.2.16 was built with the same errata URI


### PR DESCRIPTION
We scrapped 4.2.15 because 4.2.16 (with an additional console fix, openshift/console#3991) recycled its errata link:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.16-x86_64 | grep errata
    url: https://access.redhat.com/errata/RHBA-2020:0107
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.15-x86_64 | grep errata
    url: https://access.redhat.com/errata/RHBA-2020:0107
```

By including a comment about that, we make the reasoning more discoverable for folks who wonder "what happened to 4.2.15?".