### PR TITLE
channels/candidate-4.3: Promote 4.2.16+amd64

### DIFF
--- a/channels/candidate-4.3.yaml
+++ b/channels/candidate-4.3.yaml
@@ -1,5 +1,7 @@
 name: candidate-4.3
 versions:
+# until s390 is released on 4.3 we may not want to include it in 4.3 channels
+- 4.2.16+amd64
 - 4.3.0-rc.0
 # I'm not sure what happened to rc1 and rc2. rc2 was, I think, fine
 # but it never got upgrade tests https://github.com/openshift/cincinnati-graph-data/pull/26


### PR DESCRIPTION
792cc4c3d7 (#40) pulled the block to allow this edge, but to get an edge in a given channel, both the source and target release need to be in that channel.

See also #44, which goes into more detail on 4.2->4.3 failure modes, some of which still occur on 4.2.16->4.3.0.