### PR TITLE
blocked-edges/OWNERS: Only release-admins can approve

### DIFF
--- a/blocked-edges/OWNERS
+++ b/blocked-edges/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - release-admins
+reviewers:
+  - cincinnati-graph-data-approvers
+  - cincinnati-graph-data-reviewers
+options:
+  no_parent_owners: true


### PR DESCRIPTION
Copied from `channels/OWNERS`.  graph-data folks are responsible for the tooling, but only release-admins get the final say on graph changes.