### PR TITLE
blocked-edges/4.3.0: Block 4.2.16 and earlier updating to 4.3

### DIFF
--- a/blocked-edges/4.3.0-rc.0.yaml
+++ b/blocked-edges/4.3.0-rc.0.yaml
@@ -2,5 +2,6 @@ to: 4.3.0-rc.0
 from: .*
 # 4.2 -> 4.3 updates occasionally hit FailedCreatePodSandBox events, fixed in rc.3, but in neither 4.2.16 nor rc.0: https://bugzilla.redhat.com/show_bug.cgi?id=1787635
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed degradation, fixed in 4.2.16 and rc.3, but in neither 4.2.13 nor rc.0: https://bugzilla.redhat.com/show_bug.cgi?id=1786993
+# 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed degradation, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # 4.2 -> 4.3 updates occasionally hit RouteHealthDegraded degradation, fixed in rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1790704
-# 4.2.* -> 4.3.0-rc.0 Sometimes workloads on GCP are unreachable during 4.2.x to 4.3.0 upgrade sometimes: https://bugzilla.redhat.com/show_bug.cgi?id=1793635
+# 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635

--- a/blocked-edges/4.3.0-rc.3.yaml
+++ b/blocked-edges/4.3.0-rc.3.yaml
@@ -1,5 +1,6 @@
 to: 4.3.0-rc.3
 from: 4\.2\..*
 # 4.2 -> 4.3 updates occasionally hit FailedCreatePodSandBox events, fixed in rc.3, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1787635
+# 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed degradation, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # 4.2 -> 4.3 updates occasionally hit RouteHealthDegraded degradation, fixed in rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1790704
-# 4.2.* -> 4.3.0-rc.3 Sometimes workloads on GCP are unreachable during 4.2.x to 4.3.0 upgrade sometimes: https://bugzilla.redhat.com/show_bug.cgi?id=1793635
+# 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635

--- a/blocked-edges/4.3.0.yaml
+++ b/blocked-edges/4.3.0.yaml
@@ -1,7 +1,4 @@
-name: stable-4.3
-versions:
-# until s390 is released on 4.3 we may not want to include it in 4.3 channels
+to: 4.3.0
+from: 4\.2\..*
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
-# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
-- 4.3.0
-- 4.3.1
+# 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635

--- a/channels/candidate-4.3.yaml
+++ b/channels/candidate-4.3.yaml
@@ -1,7 +1,7 @@
 name: candidate-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
-- 4.2.16+amd64
+# 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18+amd64
 - 4.2.19+amd64

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -1,7 +1,7 @@
 name: fast-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
-- 4.2.16+amd64
+# 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18+amd64
 - 4.3.0


### PR DESCRIPTION
The 4.2 machine-config fix was [rhbz#1782152][1], [landed in bd358bb][2], which is new in 4.2.18:

```console
$ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.2.16-x86_64 | grep machine-config
  machine-config-operator                       https://github.com/openshift/machine-config-operator                       31fed93186c9f84708f5cdfd0227ffe4f79b31cd
$ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.2.18-x86_64 | grep machine-config
  machine-config-operator                       https://github.com/openshift/machine-config-operator                       9366460085b2a24d825380759f554769ec5ab4f9
$ git --no-pager log --oneline --first-parent -2 9366460085
93664600 Merge pull request #1362 from rphillips/fixes/1787581_4.2
bd358bb7 Merge pull request #1323 from openshift-cherrypick-robot/cherry-pick-1320-to-release-4.2
```

There was no 4.2.17; @vikaslaad on 2020-02-10:

> 4.2.17 was skipped due to multiple weeks in between

I'm not entirely clear on the motivation there, but have added a comment about the skip with an attempt at explaining it.

Updates also need the 4.3 fix from [rhbz#1782149][3], [landed in 9fd53bd][4], which landed early enough for 4.3.0-rc.0:

```console
$ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.0-rc.0-x86_64 | grep machine-config
  machine-config-operator                       https://github.com/openshift/machine-config-operator                       23a6e6fb37e73501bc3216183ef5e6ebb15efc7a
$ git --no-pager log --oneline --first-parent -8 23a6e6fb37
23a6e6fb Merge pull request #1348 from openshift-cherrypick-robot/cherry-pick-1285-to-release-4.3
80c8aed7 Merge pull request #1343 from retroflexer/cherry-pick-backup-restore-kube-static-resources
269990a3 Merge pull request #1344 from openshift-cherrypick-robot/cherry-pick-1296-to-release-4.3
fd3ca395 Merge pull request #1338 from runcom/fix-go-mod
ba304dbb Merge pull request #1333 from openshift-cherrypick-robot/cherry-pick-1278-to-release-4.3
787f3fa9 Merge pull request #1332 from runcom/reserved-cpus-4.3
2b85d6ba Merge pull request #1329 from openshift-cherrypick-robot/cherry-pick-1314-to-release-4.3
9fd53bd5 Merge pull request #1322 from openshift-cherrypick-robot/cherry-pick-1320-to-release-4.3
```

So ideally this pull would block edges from 4.2.16 and earlier into 4.3.  But because `blocked-edges` requires explicit `to`, I've just added the 4.3.0 blocker (other 4.3.z releases either already blocked 4.2.* or only give 4.2.18+ as update sources).

Also simplify the wording on [the GCP bug 1793635][5], which remains unfixed.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1782152
[2]: https://github.com/openshift/machine-config-operator/pull/1323#event-2964203970
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1782149
[4]: https://github.com/openshift/machine-config-operator/pull/1322#event-2876910067
[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1793635