### PR TITLE
channels: Explain why we skipped 4.2.17

### DIFF
--- a/channels/candidate-4.2.yaml
+++ b/channels/candidate-4.2.yaml
@@ -36,5 +36,6 @@ versions:
 - 4.2.14
 # not 4.2.15 because 4.2.16 was built with the same errata URI
 - 4.2.16
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18
 - 4.2.19

--- a/channels/candidate-4.3.yaml
+++ b/channels/candidate-4.3.yaml
@@ -2,6 +2,7 @@ name: candidate-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 - 4.2.16+amd64
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18+amd64
 - 4.2.19+amd64
 - 4.3.0-rc.0

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -18,7 +18,7 @@ versions:
 - 4.2.9
 - 4.2.10
 - 4.2.10-s390x
-  # - 4.2.11 failed to run tests, we never officially released it, but we accidentally
+# - 4.2.11 failed to run tests, we never officially released it, but we accidentally
 # put it in a channel! (same for s390x)   Now we shouldn't pull it, just in case
 # someone is on it
 - 4.2.11
@@ -31,3 +31,4 @@ versions:
 # not 4.2.14-s390x because of https://bugzilla.redhat.com/show_bug.cgi?id=1789260
 # not 4.2.15 because 4.2.16 was built with the same errata URI
 - 4.2.16
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -2,5 +2,6 @@ name: fast-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 - 4.2.16+amd64
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.3.0
 - 4.3.1

--- a/channels/stable-4.2.yaml
+++ b/channels/stable-4.2.yaml
@@ -15,7 +15,7 @@ versions:
 - 4.2.8
 - 4.2.9
 - 4.2.10
- # - 4.2.11 failed to run tests, we never officially released it, but we accidentally
+# - 4.2.11 failed to run tests, we never officially released it, but we accidentally
 # put it in a channel! (same for s390x)   Now we shouldn't pull it, just in case
 # someone is on it
 - 4.2.11
@@ -28,3 +28,4 @@ versions:
 # not 4.2.14-s390x because of https://bugzilla.redhat.com/show_bug.cgi?id=1789260
 # not 4.2.15 because 4.2.16 was built with the same errata URI
 - 4.2.16
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases

--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -1,5 +1,6 @@
 name: stable-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.3.0
 - 4.3.1


### PR DESCRIPTION
@vikaslaad on 2020-02-10:

> 4.2.17 was skipped due to multiple weeks in between

I'm not entirely clear on the motivation there, but have added a comment about the skip with an attempt at explaining it to all the channels in which 4.2.17 might have appeared.