### PR TITLE
channels: Explain why we skipped 4.1.32 and 4.1.33

### DIFF
--- a/channels/candidate-4.2.yaml
+++ b/channels/candidate-4.2.yaml
@@ -13,6 +13,8 @@ versions:
 - 4.1.29
 - 4.1.30
 - 4.1.31
+# no 4.1.32 because we didn't cut a release in the week after 4.1.31
+# no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.1.34
 - 4.2.0
 - 4.2.0-rc.5

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -9,6 +9,8 @@ versions:
 - 4.1.29
 - 4.1.30
 - 4.1.31
+# no 4.1.32 because we didn't cut a release in the week after 4.1.31
+# no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.2.0
 - 4.2.1
 - 4.2.2

--- a/channels/prerelease-4.1.yaml
+++ b/channels/prerelease-4.1.yaml
@@ -37,4 +37,6 @@ versions:
 - 4.1.29
 - 4.1.30
 - 4.1.31
+# no 4.1.32 because we didn't cut a release in the week after 4.1.31
+# no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.1.34

--- a/channels/stable-4.1.yaml
+++ b/channels/stable-4.1.yaml
@@ -29,3 +29,5 @@ versions:
 - 4.1.29
 - 4.1.30
 - 4.1.31
+# no 4.1.32 because we didn't cut a release in the week after 4.1.31
+# no 4.1.33 because we didn't cut a release in the week after 4.1.32

--- a/channels/stable-4.2.yaml
+++ b/channels/stable-4.2.yaml
@@ -7,6 +7,8 @@ versions:
 - 4.1.29
 - 4.1.30
 - 4.1.31
+# no 4.1.32 because we didn't cut a release in the week after 4.1.31
+# no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.2.0
 - 4.2.1
 - 4.2.2


### PR DESCRIPTION
I actually have no idea why we skipped these, but 4.1.34 is the next release after 4.1.31.