### PR TITLE
channels: Explain the lack of 4.2.3, 4.2.5, and 4.2.6

### DIFF
--- a/channels/candidate-4.2.yaml
+++ b/channels/candidate-4.2.yaml
@@ -18,7 +18,10 @@ versions:
 - 4.2.0-rc.5
 - 4.2.1
 - 4.2.2
+# no 4.2.3 because it was rolled into 4.2.4
 - 4.2.4
+# no 4.2.5 because it was cut missing some intended update sources
+# no 4.2.6 because it pulled in CI-built images due to due to release job modification for multi-arch
 - 4.2.7
 - 4.2.8
 - 4.2.9

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -12,7 +12,10 @@ versions:
 - 4.2.0
 - 4.2.1
 - 4.2.2
+# no 4.2.3 because it was rolled into 4.2.4
 - 4.2.4
+# no 4.2.5 because it was cut missing some intended update sources
+# no 4.2.6 because it pulled in CI-built images due to due to release job modification for multi-arch
 - 4.2.7
 - 4.2.8
 - 4.2.9

--- a/channels/stable-4.2.yaml
+++ b/channels/stable-4.2.yaml
@@ -10,7 +10,10 @@ versions:
 - 4.2.0
 - 4.2.1
 - 4.2.2
+# no 4.2.3 because it was rolled into 4.2.4
 - 4.2.4
+# no 4.2.5 because it was cut missing some intended update sources
+# no 4.2.6 because it pulled in CI-built images due to due to release job modification for multi-arch
 - 4.2.7
 - 4.2.8
 - 4.2.9


### PR DESCRIPTION
Not too sure about 4.2.3.  I'd guess we delayed it for long enough waiting for some important patch that we decided to just call it 4.2.4.

For 4.2.5:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.5 | grep Upgrades
  Upgrades: 4.1.23, 4.2.4
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.2.7 | grep Upgrades
  Upgrades: 4.1.24, 4.2.0, 4.2.1, 4.2.2, 4.2.4
```

For 4.2.6:

```
$ oc adm release info --pullspecs quay.io/openshift-release-dev/ocp-release:4.2.6 | grep '\.ci\.' | head -n1
  aws-machine-controllers                       registry.svc.ci.openshift.org/ocp/4.2-art-latest-2019-11-13-203727@sha256:3ebe28f0fd7c77c667b787957d28609d5d04fb4ad901805d2af4ef09951c2d7a
```