### PR TITLE
channels: Add 4.2.16+amd64 back to candidate-4.3 and fast-4.3

### DIFF
--- a/channels/candidate-4.3.yaml
+++ b/channels/candidate-4.3.yaml
@@ -2,6 +2,7 @@ name: candidate-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
+- 4.2.16+amd64
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18+amd64
 - 4.2.19+amd64

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -2,6 +2,7 @@ name: fast-4.3
 versions:
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
+- 4.2.16+amd64
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 - 4.2.18+amd64
 - 4.3.0


### PR DESCRIPTION
Once a node enters a channel, we don't want to remove it.  Doing so would leave existing residents in that channel with the `VersionNotFound` error out of the cluster-version operator.  Restore 4.2.16+amd64 to the channels it was in before c22d57ef1b (#59), and rely on `blocked-edges` alone (also from c22d57ef1b) to keep 4.2.16 -> 4.3.0 out of the graph.

Folks on 4.2.16 in candidate-4.3 or fast-4.3 will now be suggested to take the 4.2.16 -> 4.2.18 -> 4.3.1 pathway into 4.3.