### PR TITLE
raw/metadata.json: add historical metadata from quay

### DIFF
--- a/raw/OWNERS
+++ b/raw/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - release-admins
+reviewers:
+  - cincinnati-graph-data-approvers
+  - cincinnati-graph-data-reviewers
+options:
+  no_parent_owners: true

--- a/raw/metadata.json
+++ b/raw/metadata.json
@@ -1,0 +1,14 @@
+{
+    "4.1.0": {
+      "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.4,4.1.0-rc.9"
+    },
+    "4.1.0-rc.6": {
+      "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.5"
+    },
+    "4.1.0-rc.7": {
+      "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.6"
+    },
+    "4.1.0-rc.9": {
+      "io.openshift.upgrades.graph.previous.add": "4.1.0-rc.7,4.1.0-rc.8"
+    }
+}


### PR DESCRIPTION
The metadata in this has been manually added on quay in the past.  It's
my understanding that we don't plan to a convenient mapping for adding
edges using `previous.add`, so we don't want a convenience structure for
this.

---
 
This is part of https://github.com/openshift/cincinnati/pull/226.
