### PR TITLE
channels/fast-4.2: Promote 4.1.34 to fast-4.2

### DIFF
--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -11,6 +11,7 @@ versions:
 - 4.1.31
 # no 4.1.32 because we didn't cut a release in the week after 4.1.31
 # no 4.1.33 because we didn't cut a release in the week after 4.1.32
+- 4.1.34
 - 4.2.0
 - 4.2.1
 - 4.2.2


### PR DESCRIPTION
It was promoted the feeder candidate-4.2 by 1ecf01587f (Merge pull request #50 from thiagoalessio/candidate-4.1, 2020-02-17).

This promotion is recommeneded via the script in #75, but should still be vetted by comparison with Telemetry/Insights data.