### PR TITLE
Add 4.2 edges into stable-4.3

### DIFF
--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -1,5 +1,11 @@
 name: stable-4.3
 versions:
+# 4.2.16+amd64 - withheld as it's only valid into 4.3.0,4.3.1 people should go direct to 4.3.5
+# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
+# 4.2.18+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
+# 4.2.19+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
+- 4.2.20+amd64
+- 4.2.21+amd64
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases


### PR DESCRIPTION
This introduces edges from 4.2.20, 4.2.21 to 4.3.5.
Earlier versions of 4.2 were tested only against 4.3.0, 4.3.1, 4.3.2, 4.3.3 so withhold those versions. 4.2.20 and 4.2.21 is approximately 20% of the 4.2 fleet today, however 4.2.20 is growing rapidly.