### PR TITLE
channels: Add candidate-4.4, fast-4.4, and stable-4.4

### DIFF
--- a/channels/candidate-4.4.yaml
+++ b/channels/candidate-4.4.yaml
@@ -1,0 +1,2 @@
+name: candidate-4.4
+versions: []

--- a/channels/fast-4.4.yaml
+++ b/channels/fast-4.4.yaml
@@ -1,0 +1,2 @@
+name: fast-4.4
+versions: []

--- a/channels/stable-4.4.yaml
+++ b/channels/stable-4.4.yaml
@@ -1,0 +1,2 @@
+name: stable-4.4
+versions: []


### PR DESCRIPTION
So that Cincinnati doesn't complain when the console bumps its hard-coded list of channels and starts asking for stable-4.4 (openshift/enhancements#123 is in flight to remove the need for the console to hard-code available channels, but hasn't seen much recent progress).  And even without the console issue, the installer has been putting new clusters in stable-4.4 since openshift/installer@d7fb12c07a (openshift/installer#2940).