### PR TITLE
channels: Add candidate-4.5, fast-4.5, and stable-4.5

### DIFF
--- a/channels/candidate-4.5.yaml
+++ b/channels/candidate-4.5.yaml
@@ -1,0 +1,2 @@
+name: candidate-4.5
+versions: []

--- a/channels/fast-4.5.yaml
+++ b/channels/fast-4.5.yaml
@@ -1,0 +1,2 @@
+name: fast-4.5
+versions: []

--- a/channels/stable-4.5.yaml
+++ b/channels/stable-4.5.yaml
@@ -1,0 +1,2 @@
+name: stable-4.5
+versions: []


### PR DESCRIPTION
Like 6947046673 (#111), but for 4.5.  There are no 4.5 consumers yet, but this change sets Cincinnati up for them once they arrive (and now that release-4.4 is no longer being fast-forwarded, the 4.5 consumers may land in the installer and console masters anytime).