### PR TITLE
Backfill stable-4.2 nodes into stable-4.3, block 4.3.1

### DIFF
--- a/blocked-edges/4.3.1.yaml
+++ b/blocked-edges/4.3.1.yaml
@@ -1,0 +1,3 @@
+to: 4.3.1
+from: 4\.2\..*
+# 4.2 -> 4.3 was not deemed stable until 4.3.5

--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -1,14 +1,31 @@
 name: stable-4.3
 versions:
-# 4.2.16+amd64 - withheld as it's only valid into 4.3.0,4.3.1 people should go direct to 4.3.5
+- 4.2.0
+- 4.2.1
+- 4.2.2
+# no 4.2.3 because it was rolled into 4.2.4
+- 4.2.4
+# no 4.2.5 because it was cut missing some intended update sources
+# no 4.2.6 because it pulled in CI-built images due to due to release job modification for multi-arch
+- 4.2.7
+- 4.2.8
+- 4.2.9
+- 4.2.10
+# - 4.2.11 failed to run tests, we never officially released it, but we accidentally
+# put it in a channel! (same for s390x)   Now we shouldn't pull it, just in case
+# someone is on it
+- 4.2.11
+- 4.2.12
+- 4.2.13
+- 4.2.14+amd64
+- 4.2.16+amd64
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
-# 4.2.18+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
-# 4.2.19+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
+- 4.2.18+amd64
+- 4.2.19+amd64
 - 4.2.20+amd64
 - 4.2.21+amd64
 # until s390 is released on 4.3 we may not want to include it in 4.3 channels
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
-# not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
 # 4.2.21 edge into stable-4.3 pending further review
 - 4.3.0
 - 4.3.1


### PR DESCRIPTION
This ensures that those who switched to stable-4.3 with hopes of upgrading to
4.3 but before 4.2.21 will be presented upgrades which will eventually lead to
4.3.5 even though they're on a release that doesn't currently upgrade to 4.3.5.