### PR TITLE
blocked-edges: Details on bugs for 4.3.2 and 4.3.3

### DIFF
--- a/blocked-edges/4.2.0.yaml
+++ b/blocked-edges/4.2.0.yaml
@@ -1,2 +1,3 @@
 to: 4.2.0
-from: 4\.1\.20
+from: 4\.1\..*
+# 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300

--- a/blocked-edges/4.2.1.yaml
+++ b/blocked-edges/4.2.1.yaml
@@ -1,2 +1,4 @@
 to: 4.2.1
 from: .*
+# 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
+# Not sure why we're blocking 4.2 -> 4.2.1.

--- a/blocked-edges/4.2.10.yaml
+++ b/blocked-edges/4.2.10.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.10
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.11-s390x.yaml
+++ b/blocked-edges/4.2.11-s390x.yaml
@@ -1,2 +1,4 @@
 to: 4.2.11-s390x
 from: .*
+# 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
+# Not sure why we're blocking 4.2 -> 4.2.11 on s390x.

--- a/blocked-edges/4.2.12-s390x.yaml
+++ b/blocked-edges/4.2.12-s390x.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.12-s390x
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.12.yaml
+++ b/blocked-edges/4.2.12.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.12
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.13-s390x.yaml
+++ b/blocked-edges/4.2.13-s390x.yaml
@@ -1,3 +1,4 @@
-# Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1789260
 to: 4.2.13-s390x
 from: .*
+# 4.2.13 cpuinfo panic in node-exporter on s390x, fixed in 4.2.16, https://bugzilla.redhat.com/show_bug.cgi?id=1789260
+# 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300

--- a/blocked-edges/4.2.13.yaml
+++ b/blocked-edges/4.2.13.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.13
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.14.yaml
+++ b/blocked-edges/4.2.14.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.14
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.16.yaml
+++ b/blocked-edges/4.2.16.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.16
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.18.yaml
+++ b/blocked-edges/4.2.18.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.18
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.19.yaml
+++ b/blocked-edges/4.2.19.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.19
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.2.yaml
+++ b/blocked-edges/4.2.2.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.2
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.20.yaml
+++ b/blocked-edges/4.2.20.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.20
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.4.yaml
+++ b/blocked-edges/4.2.4.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.4
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.7.yaml
+++ b/blocked-edges/4.2.7.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.7
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.8.yaml
+++ b/blocked-edges/4.2.8.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.8
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.2.9.yaml
+++ b/blocked-edges/4.2.9.yaml
@@ -1,4 +1,3 @@
-to: 4.2.11
-from: .*
+to: 4.2.9
+from: 4\.1\..*
 # 4.1 -> 4.2 -> 4.3 updates hit TargetDown for ingress-operator, fixed in 4.2.21, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
-# Not sure why we're blocking 4.2 -> 4.2.11.

--- a/blocked-edges/4.3.0.yaml
+++ b/blocked-edges/4.3.0.yaml
@@ -1,4 +1,5 @@
 to: 4.3.0
-from: 4\.2\..*
+from: .*
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635
+# 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.0.yaml
+++ b/blocked-edges/4.3.0.yaml
@@ -1,5 +1,6 @@
 to: 4.3.0
 from: .*
+# 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.1.yaml
+++ b/blocked-edges/4.3.1.yaml
@@ -1,3 +1,5 @@
 to: 4.3.1
-from: 4\.3\..*
+from: .*
+# 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
+# 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.1.yaml
+++ b/blocked-edges/4.3.1.yaml
@@ -1,0 +1,3 @@
+to: 4.3.1
+from: 4\.3\..*
+# 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.2.yaml
+++ b/blocked-edges/4.3.2.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 to: 4.3.2
 from: .*
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.2.yaml
+++ b/blocked-edges/4.3.2.yaml
@@ -1,3 +1,4 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 to: 4.3.2
 from: .*
+# 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.2.yaml
+++ b/blocked-edges/4.3.2.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 to: 4.3.2
 from: .*
+# 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.2.yaml
+++ b/blocked-edges/4.3.2.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 to: 4.3.2
 from: .*
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.3.yaml
+++ b/blocked-edges/4.3.3.yaml
@@ -1,3 +1,4 @@
 # https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 to: 4.3.3
 from: .*
+# 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.3.yaml
+++ b/blocked-edges/4.3.3.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 to: 4.3.3
 from: .*
+# 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.3.yaml
+++ b/blocked-edges/4.3.3.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 to: 4.3.3
 from: .*
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.3.yaml
+++ b/blocked-edges/4.3.3.yaml
@@ -1,4 +1,4 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 to: 4.3.3
 from: .*
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/channels/candidate-4.2.yaml
+++ b/channels/candidate-4.2.yaml
@@ -20,8 +20,8 @@ versions:
 # no 4.1.36 because we didn't cut a release in the week after 4.1.34
 - 4.1.37
 - 4.1.38
-- 4.2.0
 - 4.2.0-rc.5
+- 4.2.0
 - 4.2.1
 - 4.2.2
 # no 4.2.3 because it was rolled into 4.2.4

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -13,7 +13,6 @@ versions:
 # No 4.2.24 because of the service CA rotation issue: https://bugzilla.redhat.com/show_bug.cgi?id=1810036 https://bugzilla.redhat.com/show_bug.cgi?id=1801573
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -13,7 +13,7 @@ versions:
 # No 4.2.24 because of the service CA rotation issue: https://bugzilla.redhat.com/show_bug.cgi?id=1810036 https://bugzilla.redhat.com/show_bug.cgi?id=1801573
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -13,7 +13,7 @@ versions:
 # No 4.2.24 because of the service CA rotation issue: https://bugzilla.redhat.com/show_bug.cgi?id=1810036 https://bugzilla.redhat.com/show_bug.cgi?id=1801573
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726

--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -15,7 +15,7 @@ versions:
 # 4.2.21 edge into stable-4.3 pending further review
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726

--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -15,7 +15,7 @@ versions:
 # 4.2.21 edge into stable-4.3 pending further review
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1805444, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
+# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248, https://bugzilla.redhat.com/show_bug.cgi?id=1808429
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726

--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -15,7 +15,6 @@ versions:
 # 4.2.21 edge into stable-4.3 pending further review
 - 4.3.0
 - 4.3.1
-# Upgrade edges disabled for 4.3.2 and 4.3.3 because of bugs https://bugzilla.redhat.com/show_bug.cgi?id=1802248
 - 4.3.2
 - 4.3.3
 # No 4.3.4 because of https://bugzilla.redhat.com/show_bug.cgi?id=1805726


### PR DESCRIPTION
Expanding on the links from b1465b73da (#87).

Port bug:

* 4.4.0: [rhbz#1801300](https://bugzilla.redhat.com/show_bug.cgi?id=1801300), openshift/cluster-version-operator#322 which made it into 4.4.0-rc.0:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.4.0-rc.0-x86_64 | grep cluster-version
      cluster-version-operator                       https://github.com/openshift/cluster-version-operator                       23856901003b95b559087b8e83bffdee82872b2b
    $ git --no-pager log --oneline --first-parent -6 origin/release-4.4
    2385690 (origin/release-4.4) Merge pull request #332 from openshift-cherrypick-robot/cherry-pick-328-to-release-4.4
    ...
    2df3d56 Merge pull request #322 from vrutkovs/remove-outdated-ports
    ```

* 4.3.z: [rbhz#1802710](https://bugzilla.redhat.com/show_bug.cgi?id=1802710) openshift/cluster-version-operator#323 which made it into 4.3.3:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.3-x86_64 | grep cluster-version
      cluster-version-operator                      https://github.com/openshift/cluster-version-operator                      210b4b1e6b1b7f53b5dc0d935de9c5d27058280c
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.2-x86_64 | grep cluster-version
      cluster-version-operator                      https://github.com/openshift/cluster-version-operator                      beee410fc8780e5613c09fc2690716b711747041
    $ git --no-pager log --oneline --first-parent -5 origin/release-4.3
    210b4b1 (origin/release-4.3) Merge pull request #321 from openshift-cherrypick-robot/cherry-pick-319-to-release-4.3
    5057680 Merge pull request #323 from vrutkovs/4.3-container-ports
    ...
    beee410 Merge pull request #290 from wking/no-ephemeral-storage-in-4.2-so-4.3-cannot-rely-on-it
    ```

* 4.2.z: [rhbz#1802248](https://bugzilla.redhat.com/show_bug.cgi?id=1802248) openshift/cluster-version-operator#325 which made it into 4.2.21:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.2.21-x86_64 | grep cluster-version
      cluster-version-operator                      https://github.com/openshift/cluster-version-operator                      ccbed39b6faab201a1bafc49a7f519194d5dd548
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.2.20-x86_64 | grep cluster-version
      cluster-version-operator                      https://github.com/openshift/cluster-version-operator                      9f4f04e736a0bbc61323593fbb62874570f07762
    $ git --no-pager log --oneline --first-parent -4 origin/release-4.2
    4b39863 (origin/release-4.2) Merge pull request #314 from wking/resource-merge-index-mutating-existing-4.2
    ccbed39 Merge pull request #300 from openshift-cherrypick-robot/cherry-pick-298-to-release-4.2
    a8ed501 Merge pull request #325 from vrutkovs/4.2-container-ports
    9f4f04e Merge pull request #288 from wking/no-ephemeral-storage-in-4.2
    ```

* autoscaler and machine-API operator both [removed their metrics port in 4.2 -> 4.3][1].  So 4.2 clusters which update to 4.3 < 4.3.5 will hit this.

* ingress operator [removed its metrics port in 4.1 -> 4.2][2], so 4.1 clusters which update to 4.2 < 4.2.21 will hit this.

Multus bug:

* 4.5.0: [rhbz#1805987](https://bugzilla.redhat.com/show_bug.cgi?id=1805987)

* 4.4.0: [rhbz#1805774](https://bugzilla.redhat.com/show_bug.cgi?id=1805774) openshift/cluster-network-operator#507 openshift/multus-cni#49 which made it into 4.4.0-rc.0:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.4.0-rc.0-x86_64 | grep 'network-operator\|multus-cni'
      cluster-network-operator                       https://github.com/openshift/cluster-network-operator                       983f31b7c4a207542bb71b8221addf82a954c6e0
      multus-cni                                     https://github.com/openshift/multus-cni                                     384bc19c84d2da109f9a5e30367c86bf32ad4e51
    cluster-network-operator$ git --no-pager log --oneline --first-parent -5 origin/release-4.4
    c4ee5bbd (origin/release-4.4) Merge pull request #518 from openshift-cherrypick-robot/cherry-pick-516-to-release-4.4
    983f31b7 Merge pull request #514 from pecameron/cp500.4.4
    ...
    53afa956 Merge pull request #507 from danwinship/add-readiness-indicator-4.4
    multus-cni$ git --no-pager log --oneline --first-parent -1 origin/release-4.4
    384bc19c (origin/release-4.4) Merge pull request #53 from dougbtv/no-config-invalidation-44
    ```

* 4.3.z: https://bugzilla.redhat.com/show_bug.cgi?id=1805444 openshift/cluster-network-operator#485 openshift/multus-cni#48 which made it into 4.3.5 (4.3.4 doesn't exist):

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.5-x86_64 | grep 'network-operator\|multus-cni'
      cluster-network-operator                      https://github.com/openshift/cluster-network-operator                      93c9431b9f5160cc620bba93a6f59e2525a54e2c
      multus-cni                                    https://github.com/openshift/multus-cni                                    50acccef844042b0bc3ffe5f243cb2e13647d07d
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.3-x86_64 | grep 'network-operator\|multus-cni'
      cluster-network-operator                      https://github.com/openshift/cluster-network-operator                      3e76a1ef1dccac9b44bdbd00ff145b2a1abe611a
      multus-cni                                    https://github.com/openshift/multus-cni                                    1cb7d0f9c0a336ba7f33a0e2800c12205f10878c
    cluster-network-operator$ git --no-pager log --oneline --first-parent -9 origin/release-4.3
    3af6eeb4 (origin/release-4.3) Merge pull request #526 from dougbtv/reintroduce-whereabouts-routeoverride-43
    ...
    93c9431b Merge pull request #504 from juanluisvaladas/fix-noproxy-43
    7ae0b7e8 Merge pull request #485 from dougbtv/add-readiness-indicator-43
    ...
    3e76a1ef Merge pull request #470 from alexanderConstantinescu/bugfix/fix_ovn_controller_rbac
    multus-cni$ git --no-pager log --oneline --first-parent -3 origin/release-4.3
    9e85cb1b (origin/release-4.3) Merge pull request #52 from dougbtv/no-config-invalidation-43
    50acccef Merge pull request #48 from dougbtv/readiness-indicator-poll-43
    1cb7d0f9 Merge pull request #40 from dougbtv/rhel8-set-commit
    ```

* Not backported to 4.2.z.  It's not clear to me what the situation on 4.2 is.  Also not clear to me what sort of updates would trigger this issue; whether it is all *-> into broken releases?  Just 4.2 -> broken 4.3?  Broken 4.2 -> any 4.3?  For now I'll just assume that 4.2 is not affected and * -> broken 4.3 is the only vulnerable case.

Memory leak:

* 4.5.0: MCO [rhbz#1800319](https://bugzilla.redhat.com/show_bug.cgi?id=1800319) openshift/machine-config-operator#1450 openshift/machine-config-operator#1476 origin [rhbz#1802687](https://bugzilla.redhat.com/show_bug.cgi?id=1802687) openshift/origin#24568

* 4.4.0: origin [rhbz#1806786](https://bugzilla.redhat.com/show_bug.cgi?id=1806786) openshift/origin#24596 .  The 4.5 MCO changes were not backported to 4.4.  The origin change made it into 4.4.0-rc.0:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.4.0-rc.0-x86_64 | grep hyperkube
      hyperkube                                      https://github.com/openshift/ose                                            261a15f4558887a0e53b4d5ad3e4e82f6d37b59f
    $ git --no-pager log -50 --format='%h %b' origin/enterprise-4.4 | grep -n '261a15f455\|1806786'
    5:261a15f455
    42:2850b41468 [release-4.4] Bug 1806786: UPSTREAM: 88251: Partially fix incorrect configuration of kubepods.slice unit by kubelet
    ```

* 4.3.z: origin [rhbz#1808429](https://bugzilla.redhat.com/show_bug.cgi?id=1808429) openshift/origin#24611 [rhbz#1801824](https://bugzilla.redhat.com/show_bug.cgi?id=1801824) ASSIGNED (I'm not sure what this one is; possibly a dup of 1808429).  The origin change did not make it into 4.3.5:

    ```console
    $ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.3.5-x86_64 | grep hyperkube
      hyperkube                                     https://github.com/openshift/ose                                           b3bfb5a8f782055fe16140fc3a670dd9d27271a7
    $ git --no-pager log --format='%h %b' origin/enterprise-4.3 | grep -n 'b3bfb5a8f7\|1808429'
    14:ec856fba4d [release-4.3] Bug 1808429: UPSTREAM: 88251: Partially fix incorrect configuration of kubepods.slice unit by kubelet
    16:b3bfb5a8f7 Created by command:
    ```

* 4.2.z: [rhbz#1801826](https://bugzilla.redhat.com/show_bug.cgi?id=1801826) Closed WONTFIX. [rhbz#1810136](https://bugzilla.redhat.com/show_bug.cgi?id=1810136) s380x NEW.  Not sure if that's "does not affect 4.2.z" or "not important enough to fix on 4.2.z".

* It's not clear to me that this is a regression.  Does this actually affect update edges at all?

Also, no need to talk about these in the channel YAML files, since we aren't tombstoning the releases (we discovered the bug after marking the releases supported by tagging them into fast channels).

Also block * -> 4.3 for 4.3 before 4.3.5, now that we have the Multus bug to worry about.  4.2 -> 4.3.1 had been blocked before, although that block was lifted in c641bbdc47 (#60).  This isolates the two 4.3 RCs, but we don't commit to providing updates out of candidate releases anway.  If we get pushback on that (unlikely now that 4.3 has been GA for so long), we can add rc -> 4.3.6 update edges or some such.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1801300#c29
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1802248#c3