### PR TITLE
channels/stable-4.1: Promote 4.1.38 to stable-4.1 and fast-4.2

### DIFF
--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -12,7 +12,10 @@ versions:
 # no 4.1.32 because we didn't cut a release in the week after 4.1.31
 # no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.1.34
-# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393
+# no 4.1.35 because we didn't cut a release in the week after 4.1.34
+# no 4.1.36 because we didn't cut a release in the week after 4.1.35
+# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393 (Jenkins webconsole 403 Forbidden)
+- 4.1.38
 - 4.2.0
 - 4.2.1
 - 4.2.2

--- a/channels/stable-4.1.yaml
+++ b/channels/stable-4.1.yaml
@@ -32,4 +32,7 @@ versions:
 # no 4.1.32 because we didn't cut a release in the week after 4.1.31
 # no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.1.34
-# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393
+# no 4.1.35 because we didn't cut a release in the week after 4.1.34
+# no 4.1.36 because we didn't cut a release in the week after 4.1.35
+# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393 (Jenkins webconsole 403 Forbidden)
+- 4.1.38

--- a/channels/stable-4.2.yaml
+++ b/channels/stable-4.2.yaml
@@ -10,7 +10,9 @@ versions:
 # no 4.1.32 because we didn't cut a release in the week after 4.1.31
 # no 4.1.33 because we didn't cut a release in the week after 4.1.32
 - 4.1.34
-# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393
+# no 4.1.35 because we didn't cut a release in the week after 4.1.34
+# no 4.1.36 because we didn't cut a release in the week after 4.1.35
+# no 4.1.37 because of https://bugzilla.redhat.com/show_bug.cgi?id=1810393 (Jenkins webconsole 403 Forbidden)
 - 4.2.0
 - 4.2.1
 - 4.2.2


### PR DESCRIPTION
It was promoted the feeder prerelease-4.1 and candidate-4.2 four days ago by fe9434117f (Merge pull request #110 from joepvd/4.1.38-candidate, 2020-03-12).

[The bug which killed 4.1.37][1] was [fixed in d9f0019][2], which landed after 4.1.37:

```console
$ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.1.37-x86_64 | grep ' jenkins '
  jenkins                                       https://github.com/openshift/jenkins                                       76904bc459f27f8ea823d5c45a64a2748e782e4d
$ git --no-pager log --oneline -3 origin/release-4.1
d9f0019 (origin/release-4.1) Merge pull request #1033 from akram/4.1-nss-wrapper-2.204.2-and-plugins-updates
1cd33d9 - Bump jenkins 2.204.2 and all plugins versions - Symlink to Dockerfile.localdev
76904bc Merge pull request #982 from akram/4.1-bz-1764466-cve-2019-10431
```

But 4.1.38 has the fix:

```console
$ oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.1.38-x86_64 | grep ' jenkins '
  jenkins                                       https://github.com/openshift/jenkins                                       d9f00196fcf9acd8bf5675767fbb165857efbc40
```

I'm not clear on exactly when 4.1 broke, or whether releases older than 4.1.37 are also affected.  However, there are no older 4.1 releases waiting for a prerelease -> fast promotion, so it's not critical to pin down the regression timing (if this even was a regression).

Not a lot of signal out of Telemetry/Insights, but the few updates we've seen involving 4.1.38 have all gone smoothly enough.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1810393
[2]: https://github.com/openshift/jenkins/pull/1033#event-3114787745