### PR TITLE
Block upgrades to 4.3.5 and 4.2.22

### DIFF
--- a/blocked-edges/4.2.22.yaml
+++ b/blocked-edges/4.2.22.yaml
@@ -1,0 +1,8 @@
+# Upgrading any release to 4.2.22 will enable automated service ca
+# rotation without unique ca serial numbers. This will result in
+# condition reported in the linked bz, and only be recoverable by
+# manual service ca rotation.
+#
+# Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1810036
+to: 4.2.22
+from: .*

--- a/blocked-edges/4.3.5.yaml
+++ b/blocked-edges/4.3.5.yaml
@@ -1,0 +1,8 @@
+# Upgrading any release to 4.3.5 will enable automated service ca
+# rotation without unique ca serial numbers. This will result in
+# condition reported in the linked bz, and only be recoverable by
+# manual service ca rotation.
+#
+# Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1810036
+to: 4.3.5
+from: .*


### PR DESCRIPTION
These releases enable automated ca rotation without unique ca serial numbers which can break non-golang tls clients as per [1].

1: https://bugzilla.redhat.com/show_bug.cgi?id=1810036