### PR TITLE
blocked-edges/4.3: Block all 4.2->4.3 on PodIP vs. PodIPs, bug 1816302

### DIFF
--- a/blocked-edges/4.3.0.yaml
+++ b/blocked-edges/4.3.0.yaml
@@ -1,5 +1,6 @@
 to: 4.3.0
 from: .*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
 # 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.2 -> 4.3 updates occasionally hit RequiredPoolsFailed, fixed in 4.2.18 and rc.0, but not in 4.2.16: https://bugzilla.redhat.com/show_bug.cgi?id=1782152 https://bugzilla.redhat.com/show_bug.cgi?id=1782149
 # 4.2 -> 4.3 updates on GCP occasionally have unreachable workloads: https://bugzilla.redhat.com/show_bug.cgi?id=1793635

--- a/blocked-edges/4.3.2.yaml
+++ b/blocked-edges/4.3.2.yaml
@@ -1,4 +1,5 @@
 to: 4.3.2
 from: .*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
 # 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.3.yaml
+++ b/blocked-edges/4.3.3.yaml
@@ -1,4 +1,5 @@
 to: 4.3.3
 from: .*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
 # 4.2 -> 4.3 updates hit TargetDown for cluster-autoscaler-operator, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1801300
 # 4.3 -> 4.3 updates on GCP occasionally have kube-apiserver-operator panics, fixed in 4.3.5, https://bugzilla.redhat.com/show_bug.cgi?id=1809296

--- a/blocked-edges/4.3.5.yaml
+++ b/blocked-edges/4.3.5.yaml
@@ -8,3 +8,4 @@
 # Also includes broken OAuth service cert rotation: https://bugzilla.redhat.com/show_bug.cgi?id=1801573
 to: 4.3.5
 from: .*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302

--- a/blocked-edges/4.3.8.yaml
+++ b/blocked-edges/4.3.8.yaml
@@ -1,0 +1,3 @@
+to: 4.3.8
+from: 4\.2\..*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302


### PR DESCRIPTION
Seems like a low-probability flake (we've had many successful 4.2->4.3 before seeing this), but we don't have a recovery procedure yet, so pull the edges while we get more details.

https://bugzilla.redhat.com/show_bug.cgi?id=1816302