### PR TITLE
blocked-edges/4.3.9: Block 4.2 -> 4.3.9 on PodIP vs. PodIPs, bug 1816302

### DIFF
--- a/blocked-edges/4.3.9.yaml
+++ b/blocked-edges/4.3.9.yaml
@@ -1,0 +1,3 @@
+to: 4.3.9
+from: 4\.2\..*
+# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302


### PR DESCRIPTION
Still not fixed in 4.3.z, [rhbz#1817040][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1817040