### PR TITLE
channels/stable-4.3: Add 4.2.16 through 4.2.19 (amd64)

### DIFF
--- a/channels/stable-4.3.yaml
+++ b/channels/stable-4.3.yaml
@@ -1,9 +1,9 @@
 name: stable-4.3
 versions:
-# 4.2.16+amd64 - withheld as it's only valid into 4.3.0,4.3.1 people should go direct to 4.3.5
+- 4.2.16+amd64
 # not 4.2.17 because we had a long quiet time after 4.2.16 with no releases
-# 4.2.18+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
-# 4.2.19+amd64 - withheld as it's only valid into 4.3.1, people should go direct to 4.3.5
+- 4.2.18+amd64
+- 4.2.19+amd64
 - 4.2.20+amd64
 - 4.2.21+amd64
 - 4.2.22+amd64


### PR DESCRIPTION
It's been at least 24 days since the fast promotions landed, so finish the "phased rollout" and put them in stable.

* 4.2.16+amd64 was promoted to the feeder fast-4.3 by 7660e1d14c (#73, 2020-02-21).
* There was no 4.2.17 (no releases in the week after 4.2.16).
* 4.2.18+amd64 was promoted to the feeder fast-4.3 by fa66fd41b4 (#60, 2020-02-20).
* 4.2.19+amd64 was promoted to the feeder fast-4.3 by 04c5b057d2 (#64, 2020-02-24).

The previous comments about "only valid into" were from 505f7a64b1 (#109), and I'm not clear on the motivation.