### PR TITLE
hack/graph-util: Drop --token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ The [contributing documentation](CONTRIBUTING.md) covers licencing and the usual
 1. Create a PR.
 1. Merge the PR to master.
 1. Update your local master branch.
-1. [Publish Quay labels](#publish-quay-labels) based on master.
 
-**Do Not Ever Update Quay Labels Based On Your Local Development Branch. Only from master!**
+[Cincinnati][] is configured to track the master branch, so it will automatically react to updates made to this repository.
 
 ### Release names
 
@@ -49,18 +48,6 @@ If you wish to block specific edges it might look like:
 to: 4.2.0-rc.5
 from: 4\.1\.(18|20)
 ```
-
-### Publish Quay Labels
-
-**DO NOT EVER PUSH YOUR LOCAL BRANCH TO QUAY! Only push AFTER changes have merged to master.**
-
-Push to Quay labels with:
-
-```console
-$ hack/graph-util.py push-to-quay --token="${YOUR_TOKEN}"
-```
-
-You can leave `--token` unset for a dry run (the actions the script would take are printed either way, but are only executed if you passed a token).
 
 [channel-semantics]: https://docs.openshift.com/container-platform/4.3/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
 [Cincinnati]: https://github.com/openshift/cincinnati/

--- a/hack/graph-util.py
+++ b/hack/graph-util.py
@@ -230,7 +230,7 @@ def normalize_node(node):
     return node
 
 
-def push(directory, token, push_versions):
+def push(directory, push_versions, token=None):
     _LOGGER.info('Getting all nodes we have pushed to ocp-release')
     nodes = load_nodes(directory=os.path.join(directory, '.nodes'), registry='quay.io', repository='openshift-release-dev/ocp-release')
     nodes = load_channels(directory=os.path.join(directory, 'channels'), nodes=nodes)
@@ -462,13 +462,6 @@ def get_release_metadata(node):
 
     raise ValueError('no release-metadata in {} layers ( {} )'.format(node['payload'], json.dumps(manifest)))
 
-def get_token(args):
-    if args.token:
-        return args.token
-    if args.token_file:
-        with open(args.token_file) as f:
-            return f.read().strip()
-    return None
 
 def set_log_level(args):
     _LOGGER.setLevel(logging.INFO)
@@ -490,14 +483,6 @@ if __name__ == '__main__':
         help='Push graph metadata to Quay.io labels.',
     )
     push_to_quay_parser.add_argument(
-        '-t', '--token',
-        help='Quay token ( https://docs.quay.io/api/#applications-and-tokens )',
-    )
-    push_to_quay_parser.add_argument(
-        '--token-file',
-        help='Path to file with Quay token',
-    )
-    push_to_quay_parser.add_argument(
         '--versions',
         help='Comma Seperated Versions to sync',
     )
@@ -506,7 +491,6 @@ if __name__ == '__main__':
     set_log_level(args)
 
     if args.command == 'push-to-quay':
-        token = get_token(args=args)
-        push(directory='.', token=token, push_versions=args.versions)
+        push(directory='.', push_versions=args.versions)
     else:
         parser.print_usage()


### PR DESCRIPTION
Now that Cincinnati is reading directly from the master branch, there is no need to manually publish to Quay labels.  Drop the `--token` argument to help make that clear.  We can't drop this script completely yet, because we need to slot in some Rust binary to cover pre-merge CI (e.g. "channels/whatever.yaml talks about 4.5.6.  Is there at least one release on quay.io with that version baked in?").