### PR TITLE
WIP: Block 4.2 -> 4.3.10 for Azure clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ And LEAVE COMMENTS if you skip a version.
 Create/edit an appropriate file in `blocked_edges/`.
 - `to` is the release which has the existing incoming edges.
 - `from` is a regex for the previous release versions.
+- `clusters` selects cluster flavors for which the edges will be blocked.
+    If it is unset, the edges will blocked for all clusters.
+    - `telemetry` is a PromQL expression.
+        Clusters will have edges blocked if their cluster ID shows up in `max by (_id) $EXPRESSION`.
+    - `insights` is evaluated against the cluster's most-recently pushed insights.
+        - `path` is the path extracted from the insights tarball.
+        - `jq` is a `jq` expression evaluated on the contents of the extracted `path`.
+        Clusters will have edges blocked if the `jq` output is `true`.
 
 For example: to block all incoming edges to a release create a file such as `blocked-edges/4.2.11.yaml` containing:
 ```yaml

--- a/blocked-edges/4.3.10.yaml
+++ b/blocked-edges/4.3.10.yaml
@@ -1,0 +1,10 @@
+to: 4.3.10
+from: 4\.2\..*
+clusters:
+  telemetry: cluster_infrastructure_provider{type="Azure"}
+  insights:
+    path: config/infrastructure
+    # FIXME: what if we need to consume multiple paths from the tarball?
+    jq: .status.platformStatus.type == "Azure" or .status.platform == "Azure"
+    # FIXME: probably something more standard with Rust support.  Maybe JSON Pointer: https://tools.ietf.org/html/rfc6901 ?  Some scripting shim?
+# 4.2 -> 4.3 updates on Azure exhaust nominal CPU capacity, https://bugzilla.redhat.com/show_bug.cgi?id=1820432


### PR DESCRIPTION
We don't know why we started seeing this in 4.3.10, and installer defaults for Azure CPU capacity haven't changed between 4.2 and 4.3, but I'm pushing this up as a mock up of what "block this edge for some types of clusters" might look like.