### PR TITLE
Block edges to 4.3.8 through 4.3.12 on DefaultSecurityContextConstraints_Mutated

### DIFF
--- a/blocked-edges/4.3.10.yaml
+++ b/blocked-edges/4.3.10.yaml
@@ -1,4 +1,3 @@
-to: 4.3.8
+to: 4.3.10
 from: .*
-# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
 # 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231

--- a/blocked-edges/4.3.11.yaml
+++ b/blocked-edges/4.3.11.yaml
@@ -4,3 +4,4 @@ from: .*
 # Hence the images are rebuilt as 4.3.12. However 4.3.12 release image does not have metadata to update from 4.3.11.
 # 4.3.11 is only released in candidate-4.3 so we should stop edges to it as there are no outgoing edges available for now.
 # BugZilla: https://bugzilla.redhat.com/show_bug.cgi?id=1823378
+# 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231

--- a/blocked-edges/4.3.12.yaml
+++ b/blocked-edges/4.3.12.yaml
@@ -1,4 +1,3 @@
-to: 4.3.8
+to: 4.3.12
 from: .*
-# 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
 # 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231

--- a/blocked-edges/4.3.9.yaml
+++ b/blocked-edges/4.3.9.yaml
@@ -1,3 +1,4 @@
 to: 4.3.9
-from: 4\.2\..*
+from: .*
 # 4.2 -> 4.3 updates occasionally hit PodIP vs. PodIPs, https://bugzilla.redhat.com/show_bug.cgi?id=1816302
+# 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231


### PR DESCRIPTION
4.3.8 introduced a change which blocks upgrades when the default SCCs are
mutated. That change was merged under the assumption that the CVO would not
block z-stream upgrades on that condition. However that change had not
merged yet and thus ~40% of clusters which have upgraded to 4.3.8-4.3.12
are now blocked from upgrading with out specifying the --force flag. 4.3.13
relaxes the Upgradeable=False such that you can now apply z-stream updates
when that condition is set. A future update, likely 4.3.14 will revert the change
which began setting that condition.

Because the slim majority of subscribed clusters had already upgraded into
this problem and because of the numerous previously blocked upgrades we
had decided to live with the problem until 4.3.13 ships. So once 4.3.13 is
promoted into stable-4.3 we should stop additional clusters from falling
into the problem.

Reference https://bugzilla.redhat.com/show_bug.cgi?id=1821905#c22