### PR TITLE
channels/candidate-4.4: Promote remaining 4.3.18 arches

### DIFF
--- a/channels/candidate-4.4.yaml
+++ b/channels/candidate-4.4.yaml
@@ -2,7 +2,7 @@ name: candidate-4.4
 versions:
 - 4.3.19
 
-- 4.3.18+amd64
+- 4.3.18
 
 - 4.3.17+amd64
 


### PR DESCRIPTION
We put all architectures into fast-4.4 in b8bef52e3c (#214).  Catch candidate back up with an arch-agnostic version.