### PR TITLE
blocked-edges/4.4.3: Block 4.3 -> 4.4.3 on etcd DNS SAN peer certs

### DIFF
--- a/blocked-edges/4.4.3.yaml
+++ b/blocked-edges/4.4.3.yaml
@@ -1,0 +1,3 @@
+to: 4.4.3
+from: 4\.3\..*
+# 4.3 -> 4.4 updates occasionally stick on etcd NodeInstaller_InstallerPodFailed, https://bugzilla.redhat.com/show_bug.cgi?id=1830510


### PR DESCRIPTION
There's [a reasonably easy workaround][1] for folks who do get stuck, so not worth pulling the edge immediately.  But we want to pull the edge once there's a 4.3 -> 4.4 route that is not exposed to the fix, so cluster admins don't have to discover the workaround.  Blocking on that 4.3 -> 4.4 route (e.g. via 4.4.4).

/hold

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1830409#c7