### PR TITLE
Block 4.3.12, 4.3.13 to 4.4.4

### DIFF
--- a/blocked-edges/4.4.4.yaml
+++ b/blocked-edges/4.4.4.yaml
@@ -1,0 +1,5 @@
+to: 4.4.4
+from: 4\.3\.1[2|3]
+# 4.3.12, 4.3.13 were added to stable-4.4 since those versions added
+# stable-4.4 channel but 4.3.18 is the minimum version with fixes for
+# https://bugzilla.redhat.com/show_bug.cgi?id=1827337


### PR DESCRIPTION
Need to have fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1827337
before upgrading to 4.4. We didn't run into this with 4.4.3 because it only included 4.3.18+