### PR TITLE
blocked-edges/4.4.*: Block edges from 4.3 on vSphere waitForControllerConfigToBeCompleted

### DIFF
--- a/blocked-edges/4.4.4.yaml
+++ b/blocked-edges/4.4.4.yaml
@@ -1,5 +1,7 @@
 to: 4.4.4
-from: 4\.3\.1[2|3]
+from: 4\.3\..*
 # 4.3.12, 4.3.13 were added to stable-4.4 since those versions added
 # stable-4.4 channel but 4.3.18 is the minimum version with fixes for
 # https://bugzilla.redhat.com/show_bug.cgi?id=1827337
+#
+# 4.3 -> 4.4 breaks on vSphere with machine-config showing waitForControllerConfigToBeCompleted: https://bugzilla.redhat.com/show_bug.cgi?id=1834925

--- a/blocked-edges/4.4.5.yaml
+++ b/blocked-edges/4.4.5.yaml
@@ -1,4 +1,3 @@
-to: 4.4.3
+to: 4.4.5
 from: 4\.3\..*
-# 4.3 -> 4.4 updates occasionally stick on etcd NodeInstaller_InstallerPodFailed, https://bugzilla.redhat.com/show_bug.cgi?id=1830510
 # 4.3 -> 4.4 breaks on vSphere with machine-config showing waitForControllerConfigToBeCompleted: https://bugzilla.redhat.com/show_bug.cgi?id=1834925


### PR DESCRIPTION
The master-ward bug is [rhbz#1834925][1].  From [rhbz#1834194 comment 19][2], this seems to impact everyone taking vSphere clusters to 4.4, not just clusters born in 4.1.  Impact statement [here][3].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1834925
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1834194#c19
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1834194#c13