### PR TITLE
channels/*-4.5: Add 4.4.6 through 4.4.10 to fast-4.5 and stable-4.5

### DIFF
--- a/channels/fast-4.5.yaml
+++ b/channels/fast-4.5.yaml
@@ -1,2 +1,6 @@
 name: fast-4.5
-versions: []
+versions:
+- 4.4.10
+- 4.4.9
+- 4.4.8
+- 4.4.6

--- a/channels/stable-4.5.yaml
+++ b/channels/stable-4.5.yaml
@@ -1,2 +1,6 @@
 name: stable-4.5
-versions: []
+versions:
+- 4.4.10
+- 4.4.9
+- 4.4.8
+- 4.4.6


### PR DESCRIPTION
It has been in stable-4.4 since dc06ce1fe3 (#263) landed.  Promoting into fast/stable channels for 4.5 makes it clear that we support 4.4.6 regardless of whether a cluster is interested in 4.5 update recommendations or not.