### PR TITLE
blocked-edges: block updates to 4.3.25

### DIFF
--- a/blocked-edges/4.3.25.yaml
+++ b/blocked-edges/4.3.25.yaml
@@ -1,0 +1,3 @@
+to: 4.3.25
+from: .*
+# Blocked as expected rhcos image didn't get promoted


### PR DESCRIPTION
Expected RHCOS image didn't get promoted