### PR TITLE
blocked-edges/4.4.*: Block 4.3.12 and 4.3.13 -> 4.4

### DIFF
--- a/blocked-edges/4.4.3.yaml
+++ b/blocked-edges/4.4.3.yaml
@@ -1,3 +1,4 @@
 to: 4.4.3
 from: 4\.3\..*
 # 4.3 -> 4.4 updates occasionally stick on etcd NodeInstaller_InstallerPodFailed, https://bugzilla.redhat.com/show_bug.cgi?id=1830510
+# 4.3 -> 4.4 updates can stick on mutated SCCs, until 4.3.18 https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.5/master) https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.3)

--- a/blocked-edges/4.4.5.yaml
+++ b/blocked-edges/4.4.5.yaml
@@ -1,3 +1,3 @@
-to: 4.4.4
+to: 4.4.5
 from: 4\.3\.1[23]
 # 4.3 -> 4.4 updates can stick on mutated SCCs, until 4.3.18 https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.5/master) https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.3)

--- a/blocked-edges/4.4.6.yaml
+++ b/blocked-edges/4.4.6.yaml
@@ -1,3 +1,3 @@
-to: 4.4.4
+to: 4.4.6
 from: 4\.3\.1[23]
 # 4.3 -> 4.4 updates can stick on mutated SCCs, until 4.3.18 https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.5/master) https://bugzilla.redhat.com/show_bug.cgi?id=1827335 (4.3)


### PR DESCRIPTION
Extending 0a65fffd68 (#253) to subsequent releases which included the older 4.3 in their baked-in update sources.

Also consolidate the inline comment to be a one-liner for easier
grepping, and drop the unnecessary pipe from [23] character class.