### PR TITLE
Adding 4.4.10 and 4.4.11 to fast-4.5 channel

### DIFF
--- a/channels/fast-4.5.yaml
+++ b/channels/fast-4.5.yaml
@@ -1,2 +1,5 @@
 name: fast-4.5
-versions: []
+versions:
+- 4.4.10
+
+- 4.4.11


### PR DESCRIPTION
The versions of 4.4.z is the same versions present in the release image manifest for upgrades

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>