### PR TITLE
hack/graph-util: Stop dry-run syncing nodes in 'push'

### DIFF
--- a/hack/graph-util.py
+++ b/hack/graph-util.py
@@ -235,6 +235,7 @@ def push(directory, push_versions, token=None):
     nodes = load_nodes(directory=os.path.join(directory, '.nodes'), registry='quay.io', repository='openshift-release-dev/ocp-release')
     nodes = load_channels(directory=os.path.join(directory, 'channels'), nodes=nodes)
     nodes = block_edges(directory=os.path.join(directory, 'blocked-edges'), nodes=nodes)
+    return  # we don't actually care about syncing anymore, just loading to get the validating assertions
 
     _LOGGER.info('Syncing nodes, channels, and edges to Quay')
     sync_nodes = []


### PR DESCRIPTION
Lots of our publish runs die with errors [like][1]:

```
DEBUG: syncing node=4.4.0-rc.2+amd64 channels=candidate-4.4
Traceback (most recent call last):
  File "hack/graph-util.py", line 494, in <module>
    push(directory='.', push_versions=args.versions)
  File "hack/graph-util.py", line 247, in push
    pool.map(sync, sync_nodes)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 250, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 554, in get
    raise self._value
urllib2.HTTPError: HTTP Error 429: Too Many Requests
```

We're no longer actually publishing with this script, see 397129c0e6 (#149).  This commit short-circuits `push()` to only get the load-time validation.  Hopefully soon we'll get a Rust replacement and can drop the Python script entirely.

/assign @sdodson

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati-graph-data/316/pull-ci-openshift-cincinnati-graph-data-master-publish/1284116256667996160#1:build-log.txt%3A691