### PR TITLE
Widen the block to 4.5.2 to include all releases

### DIFF
--- a/blocked-edges/4.5.2.yaml
+++ b/blocked-edges/4.5.2.yaml
@@ -1,3 +1,3 @@
 to: 4.5.2
-from: 4.4.*
+from: .*
 # Containers fails to launch when nodes hit this issue https://bugzilla.redhat.com/show_bug.cgi?id=1857224


### PR DESCRIPTION
Now that 4.5.3 has shipped 4.5.1 folks should go directly to 4.5.3
/cc @LalatenduMohanty 