### PR TITLE
Block upgrades from 4.4.12- to 4.5.6

### DIFF
--- a/blocked-edges/4.5.6.yaml
+++ b/blocked-edges/4.5.6.yaml
@@ -1,0 +1,4 @@
+to: 4.5.6
+from: 4\.4\.1[12]
+# Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd https://bugzilla.redhat.com/show_bug.cgi?id=1861017
+


### PR DESCRIPTION
Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd https://bugzilla.redhat.com/show_bug.cgi?id=1861017
This makes 4.5.6 match 4.5.5 minimum 4.4.z versions
```
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.5.6-x86_64  | grep Upgrade
  Upgrades: 4.4.11, 4.4.12, 4.4.13, 4.4.14, 4.4.15, 4.4.16, 4.4.17, 4.5.1, 4.5.2, 4.5.3, 4.5.4, 4.5.5
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.5.5-x86_64  | grep Upgrade
  Upgrades: 4.4.13, 4.4.14, 4.4.15, 4.4.16, 4.5.1, 4.5.2, 4.5.3, 4.5.4
```