### PR TITLE
4.4.13 is the minimum version required to upgrade to 4.5

### DIFF
--- a/blocked-edges/4.4.12-to-4.5.7.yaml
+++ b/blocked-edges/4.4.12-to-4.5.7.yaml
@@ -1,0 +1,3 @@
+to: 4.5.7
+from: 4.4.12
+# Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd https://bugzilla.redhat.com/show_bug.cgi?id=1861017


### PR DESCRIPTION
Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd
https://bugzilla.redhat.com/show_bug.cgi?id=1861017