### PR TITLE
hack/errata: Mention @ota-monitor

### DIFF
--- a/hack/errata.py
+++ b/hack/errata.py
@@ -84,7 +84,7 @@ def notify(message, webhook=None):
 
     urllib.request.urlopen(webhook, data=urllib.parse.urlencode({
         'payload': {
-            'text': '{fulladvisory} shipped {when}: {synopsis}'.format(**message),
+            'text': '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis}'.format(**message),
         },
     }).encode('utf-8'))
 


### PR DESCRIPTION
Some day we will automatically promote to fast when the errata goes public, but, for now, mention the folks responsible for manually approving the pull request.

Syntax described [here][1].  `STE7S7ZU2` is `@ota-monitor`.

[1]: https://api.slack.com/reference/surfaces/formatting#mentioning-groups