### PR TITLE
Add suggestions

### DIFF
--- a/build-suggestions/4.3.yaml
+++ b/build-suggestions/4.3.yaml
@@ -1,0 +1,18 @@
+# valid archs are amd64, s390x
+# If you specify an arch it must have the full set of values
+---
+default:
+  minor_min: 4.2.21
+  minor_block_list: []
+  minor_max: 4.2.9999
+  z_min: 4.3.0
+  z_block_list: []
+  z_max: 4.3.9999
+# s390x:
+#   minor_min: 4.2.21
+#   minor_max: 4.2.9999
+#   minor_block_list:
+#     - 4.2.999
+#   z_min: 4.3.0
+#   z_max: 4.3.9999
+#   z_block_list: []

--- a/build-suggestions/4.4.yaml
+++ b/build-suggestions/4.4.yaml
@@ -1,0 +1,18 @@
+# valid archs are amd64, s390x
+# If you specify an arch it must have the full set of values
+---
+default:
+  minor_min: 4.3.21
+  minor_block_list: []
+  minor_max: 4.3.9999
+  z_min: 4.4.4
+  z_block_list: []
+  z_max: 4.4.9999
+# s390x:
+#   minor_min: 4.3.21
+#   minor_max: 4.3.9999
+#   minor_block_list:
+#     - 4.3.999
+#   z_min: 4.4.4
+#   z_max: 4.4.9999
+#   z_block_list: []

--- a/build-suggestions/4.5.yaml
+++ b/build-suggestions/4.5.yaml
@@ -1,0 +1,18 @@
+# valid archs are amd64, s390x
+# If you specify an arch it must have the full set of values
+---
+default:
+  minor_min: 4.4.13
+  minor_max: 4.4.9999
+  minor_block_list: []
+  z_min: 4.5.3
+  z_max: 4.5.9999
+  z_block_list: []
+# s390x:
+#   minor_min: 4.4.13
+#   minor_max:
+#   minor_block_list:
+#     - 4.4.999
+#   z_min: 4.5.3
+#   z_max:
+#   z_block_list: []

--- a/build-suggestions/4.6.yaml
+++ b/build-suggestions/4.6.yaml
@@ -1,0 +1,18 @@
+# valid archs are amd64, ppc64le, s390x
+# If you specify an arch it must have the full set of values
+---
+default:
+  minor_min: 4.5.16
+  minor_max: 4.5.9999
+  minor_block_list: []
+  z_min: 4.6.1
+  z_max: 4.6.9999
+  z_block_list: []
+# s390x:
+#   minor_min: 4.5.12
+#   minor_max: 4.5.9999
+#   minor_block_list:
+#     - 4.5.11
+#   z_min: 4.6.0-fc.6
+#   z_max: 4.6.9999
+#   z_block_list: []

--- a/build-suggestions/4.7.yaml
+++ b/build-suggestions/4.7.yaml
@@ -1,0 +1,18 @@
+# valid archs are amd64, ppc64le, s390x
+# If you specify an arch it must have the full set of values
+---
+default:
+  minor_min: 4.6.1
+  minor_max: 4.6.9999
+  minor_block_list: []
+  z_min: 4.7.0-fc.0
+  z_max: 4.7.9999
+  z_block_list: []
+# s390x:
+#   minor_min: 4.6.12
+#   minor_max: 4.6.9999
+#   minor_block_list:
+#     - 4.6.11
+#   z_min: 4.7.0-fc.0
+#   z_max: 4.7.9999
+#   z_block_list: []


### PR DESCRIPTION
This adds minor_min, minor_block_list, minor_max, z_min, z_block_list,
and z_max which define the minimum, a list of blocked versions, and a
maximum version which can be used to filter upgrade edges. It's expected
that this is applied atop a list of versions already present in a
channel so the block_list may not see much use.

There's a default as well as arch specific definitions. If you define
arch specific data you are expected to define the entire structure.