### PR TITLE
blocked-edges/4.5.9: Block 4.4.21 -> 4.5.9 to avoid kernel downgrades

### DIFF
--- a/blocked-edges/4.5.9.yaml
+++ b/blocked-edges/4.5.9.yaml
@@ -1,0 +1,3 @@
+to: 4.5.9
+from: 4\.4\.21
+# Kernel and other packages older in 4.5.9 than 4.4.21, https://bugzilla.redhat.com/show_bug.cgi?id=1879260


### PR DESCRIPTION
We're not clear on whether any of the regressions in kernel-0-4.18.0-193.19.1.el8_2-x86_64 -> kernel-0-4.18.0-193.14.3.el8_2-x86_64, etc. will have a meaningful impact on OpenShift clusters, but blocking the edge now before either release goes into stable avoids the risk that the regression is important.