### PR TITLE
hack/errata: strip newlines in argparse arguments

### DIFF
--- a/hack/errata.py
+++ b/hack/errata.py
@@ -204,9 +204,9 @@ if __name__ == '__main__':
     try:
         run(
             cache=cache,
-            webhook=args.webhook,
-            githubrepo=args.githubrepo,
-            githubtoken=args.githubtoken
+            webhook=args.webhook.strip(),
+            githubrepo=args.githubrepo.strip(),
+            githubtoken=args.githubtoken.strip(),
         )
     except:
         save(path=cache_path, cache=cache)


### PR DESCRIPTION
erratahoook deployment on datahub adds extra `\n` to the github token stored in the secret in the resulting queries. I checked the secret and it doesn't contain extra new line, so it must be python argparse doing that.

This would ensure received arguments are stripped.

/cc @wking 