### PR TITLE
hack/errata: pygithub can't filter by author - skip PRs unless bot has created it

### DIFF
--- a/hack/errata.py
+++ b/hack/errata.py
@@ -109,11 +109,13 @@ def get_open_prs_to_fast(repo):
     query_params = {
         'state': 'open',
         'base': 'master',
-        'author': 'openshift-bot',
         'sort': 'created',
     }
     for pr in repo.get_pulls(**query_params):
         try:
+            # Check only bot PRs
+            if pr.user.login != "openshift-bot":
+                continue
             # Skip unknown PRs
             if not pr.title.startswith("Enable "):
                 continue


### PR DESCRIPTION
PyGithub can't filter by author in query params, so PRs need to be checked in the loop.

Fixes
```
DEBUG:root:looking for errata 59090 in open PRs for repo Repository(full_name="openshift/cincinnati-graph-data")
WARNING:root:Error looking up PRs: get_pulls() got an unexpected keyword argument 'author'
```

/cc @wking 