### PR TITLE
channels: Add fast-4.6 and stable-4.6

### DIFF
--- a/channels/fast-4.6.yaml
+++ b/channels/fast-4.6.yaml
@@ -1,0 +1,2 @@
+name: fast-4.6
+versions: []

--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,0 +1,2 @@
+name: stable-4.6
+versions: []


### PR DESCRIPTION
Like adde027889 (#113), but without candidate because we got that in 713f464bc4 (#376).  This sets us up to avoid `VersionNotFound` issues once [rhbz#1884760][1] lands.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1884760