### PR TITLE
Graphdata rework dockerfile

### DIFF
--- a/graph-data.rs/Dockerfile
+++ b/graph-data.rs/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/devtools/rust-toolset-rhel7:1.43.1 as builder
 
 WORKDIR /opt/app-root/src/
 COPY . .
-RUN bash -c "source /opt/app-root/etc/scl_enable && cargo install --path ."
+RUN bash -c "source /opt/app-root/etc/scl_enable && cargo install --path graph-data.rs"
 
 FROM centos:7
 
@@ -12,6 +12,8 @@ RUN yum update -y && \
     yum install -y openssl && \
     yum clean all
 
+WORKDIR /code
+COPY . .
 COPY --from=builder /opt/app-root/src/.cargo/bin/cincinnati-graph-data /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/cincinnati-graph-data"]

--- a/graph-data.rs/src/verify_yaml.rs
+++ b/graph-data.rs/src/verify_yaml.rs
@@ -7,7 +7,11 @@ use std::path::PathBuf;
 use anyhow::Result as Fallible;
 
 pub async fn run() -> Fallible<HashSet<Version>> {
-    let data_dir = PathBuf::from("..");
+    let data_dir = PathBuf::from(".");
+    println!(
+        "Looking for metadata in {:?}",
+        data_dir.canonicalize()?
+    );
     let all_files_regex = Regex::new(".*")?;
     let disallowed_errors: HashSet<plugin::DeserializeDirectoryFilesErrorDiscriminants> = [
         plugin::DeserializeDirectoryFilesErrorDiscriminants::File,


### PR DESCRIPTION
Previously Rust CI tool was using `graph-data.rs` context, so that it would produce an image with just the binary. The plan was to promote it to `cincinnati-ci` namespace and avoid rebuilding it to save time.
However that didn't really work well:
* CI can't do optional builds atm, so there is no way to skip the build even if `graph-data.rs` is not touched
* There is no easy way to run the image with other src from the repo. CI provides a way to build `bin` container from `src`, but currently it would break existing python script, so implementation of that needs to be postponed.

This PR would rework graph-data Dockerfile so that it would include the whole repo and adjust the test to run from current directory (previously the binary was expected to run from the subfolder)

/cc @steveeJ 