### PR TITLE
graph-data.rs/Dockerfile: run cargo install as root

### DIFF
--- a/graph-data.rs/Dockerfile
+++ b/graph-data.rs/Dockerfile
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/devtools/rust-toolset-rhel7:1.43.1 as builder
 
 WORKDIR /opt/app-root/src/
 COPY . .
+USER 0
 RUN bash -c "source /opt/app-root/etc/scl_enable && cargo install --path graph-data.rs"
 
 FROM centos:7


### PR DESCRIPTION
In newer openshift versions builds must explicitly declare a user,
otherwise these would run as unprivileged user. However copied source
would be owned by root, so `target/release` cannot be created.