### PR TITLE
graph-data.rs: ensure signatures are present for all scraped images

### DIFF
--- a/graph-data.rs/Cargo.lock
+++ b/graph-data.rs/Cargo.lock
@@ -581,14 +581,18 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cincinnati",
+ "futures 0.3.6",
+ "lazy_static",
  "protobuf",
  "protoc",
  "regex",
+ "reqwest",
  "semver",
  "serde",
  "serde_yaml",
  "tokio",
  "toml",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/graph-data.rs/Cargo.toml
+++ b/graph-data.rs/Cargo.toml
@@ -15,3 +15,7 @@ semver = { version = "^0.9.0", features = [ "serde" ] }
 toml = "^0.4.10"
 protoc = "=2.8.0"
 protobuf = "=2.8.0"
+lazy_static = "^1.2.0"
+url = "^2.1.0"
+reqwest = { version = "^0.10", features = ["gzip"] }
+futures = "0.3"

--- a/graph-data.rs/src/check_releases.rs
+++ b/graph-data.rs/src/check_releases.rs
@@ -1,19 +1,21 @@
 use cincinnati::plugins::internal::release_scrape_dockerv2::plugin;
 use cincinnati::plugins::internal::release_scrape_dockerv2::registry;
+use cincinnati::Release;
 
 use anyhow::Context;
 use anyhow::Result as Fallible;
 use semver::Version;
 use std::collections::HashSet;
+use std::str::FromStr;
 
-pub async fn run(found_versions: &HashSet<Version>) -> Fallible<()> {
+pub async fn run(found_versions: &HashSet<Version>) -> Fallible<Vec<Release>> {
     let settings = plugin::ReleaseScrapeDockerv2Settings::default();
     let cache = registry::cache::new();
     let registry = registry::Registry::try_from_str(&settings.registry)
         .context(format!("Parsing {} as Registry", &settings.registry))?;
 
     println!("Scraping Quay registry");
-    let released_versions: HashSet<Version> = registry::fetch_releases(
+    let released_metadata: Vec<Release> = registry::fetch_releases(
         &registry,
         &settings.repository,
         settings.username.as_ref().map(String::as_ref),
@@ -25,14 +27,20 @@ pub async fn run(found_versions: &HashSet<Version>) -> Fallible<()> {
     .await
     .context("failed to fetch all release metadata")?
     .into_iter()
-    .map(|r| r.metadata.version)
+    .map(|r| r.into())
     .collect();
+
+    let released_versions: HashSet<Version> = released_metadata
+        .clone()
+        .into_iter()
+        .map(|m| Version::from_str(m.version()).unwrap())
+        .collect();
 
     println!("Verifying all releases are uploaded");
     let missing_versions: HashSet<&Version> =
         found_versions.difference(&released_versions).collect();
     if missing_versions.is_empty() {
-        Ok(())
+        Ok(released_metadata.clone())
     } else {
         Err(anyhow::anyhow!(
             "Missing the following versions in scraped images: {:?}",

--- a/graph-data.rs/src/check_signatures.rs
+++ b/graph-data.rs/src/check_signatures.rs
@@ -1,0 +1,127 @@
+use anyhow::Result as Fallible;
+use anyhow::{format_err, Context};
+use futures::stream::{FuturesOrdered, StreamExt};
+use lazy_static::lazy_static;
+use reqwest::{Client, ClientBuilder};
+use semver::Version;
+use std::collections::HashSet;
+use std::ops::Range;
+use std::str::FromStr;
+use std::time::Duration;
+use url::Url;
+
+use cincinnati::plugins::prelude_plugin_impl::TryFutureExt;
+use cincinnati::Release;
+// base url for signature storage - see https://github.com/openshift/cluster-update-keys/blob/master/stores/store-openshift-official-release-mirror
+lazy_static! {
+  static ref BASE_URL: Url =
+    Url::parse("https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/")
+      .expect("could not parse url");
+}
+
+static DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+// CVO has maxSignatureSearch = 10 in pkg/verify/verify.go
+static MAX_SIGNATURES: u64 = 10;
+
+fn payload_from_release(release: &Release) -> Fallible<String> {
+  match release {
+    Release::Concrete(c) => Ok(c.payload.clone()),
+    _ => Err(format_err!("not a concrete release")),
+  }
+}
+
+async fn fetch_url(client: &Client, sha: &str, i: u64) -> Fallible<()> {
+  let url = BASE_URL
+    .join(format!("{}/", sha.replace(":", "=")).as_str())?
+    .join(format!("signature-{}", i).as_str())?;
+  let res = client
+    .get(url.clone())
+    .send()
+    .map_err(|e| anyhow::anyhow!(e.to_string()))
+    .await?;
+
+  let url_s = url.to_string();
+  let status = res.status();
+  match status.is_success() {
+    true => Ok(()),
+    false => Err(format_err!("Error fetching {} - {}", url_s, status)),
+  }
+}
+
+async fn find_signatures_for_version(client: &Client, release: &Release) -> Fallible<()> {
+  let mut errors = vec![];
+  let payload = payload_from_release(release)?;
+  let digest = payload
+    .split("@")
+    .last()
+    .ok_or_else(|| format_err!("could not parse payload '{:?}'", payload))?;
+
+  let mut attempts = Range {
+    start: 1,
+    end: MAX_SIGNATURES,
+  };
+  loop {
+    if let Some(i) = attempts.next() {
+      match fetch_url(client, digest, i).await {
+        Ok(_) => return Ok(()),
+        Err(e) => errors.push(e),
+      }
+    } else {
+      return Err(format_err!(
+        "Failed to find signatures for {} - {}: {:#?}",
+        release.version(),
+        payload,
+        errors
+      ));
+    }
+  }
+}
+
+fn is_release_in_versions(versions: &HashSet<Version>, release: &Release) -> bool {
+  // Strip arch identifier
+  let stripped_version = release
+    .version()
+    .split("+")
+    .next()
+    .ok_or(release.version())
+    .unwrap();
+  let version = Version::from_str(stripped_version).unwrap();
+  versions.contains(&version)
+}
+
+pub async fn run(
+  releases: &Vec<Release>,
+  found_versions: &HashSet<semver::Version>,
+) -> Fallible<()> {
+  println!("Checking release signatures");
+
+  let client: Client = ClientBuilder::new()
+    .gzip(true)
+    .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+    .build()
+    .context("Building reqwest client")?;
+
+  // Filter scraped images - skip CI images
+  let tracked_versions: Vec<&cincinnati::Release> = releases
+    .into_iter()
+    .filter(|ref r| is_release_in_versions(found_versions, &r))
+    .collect::<Vec<&cincinnati::Release>>();
+
+  let results: Vec<Fallible<()>> = tracked_versions
+    //Attempt to find signatures for filtered releases
+    .into_iter()
+    .map(|ref r| find_signatures_for_version(&client, r))
+    .collect::<FuturesOrdered<_>>()
+    .collect::<Vec<Fallible<()>>>()
+    .await
+    // Filter to keep errors only
+    .into_iter()
+    .filter(|e| e.is_err())
+    .collect();
+  if results.is_empty() {
+    Ok(())
+  } else {
+    Err(format_err!("Signature check errors: {:#?}", results))
+  }
+}

--- a/graph-data.rs/src/main.rs
+++ b/graph-data.rs/src/main.rs
@@ -9,6 +9,7 @@ use cincinnati::Release;
 async fn run_all_tests() -> Fallible<()> {
     let found_versions = verify_yaml::run().await?;
     let releases: Vec<Release> = check_releases::run(&found_versions).await?;
+    check_signatures::run(&releases, &found_versions).await?;
     Ok(())
 }
 

--- a/graph-data.rs/src/main.rs
+++ b/graph-data.rs/src/main.rs
@@ -1,10 +1,14 @@
 mod check_releases;
+mod check_signatures;
 mod verify_yaml;
+
 use anyhow::Result as Fallible;
+
+use cincinnati::Release;
 
 async fn run_all_tests() -> Fallible<()> {
     let found_versions = verify_yaml::run().await?;
-    check_releases::run(&found_versions).await?;
+    let releases: Vec<Release> = check_releases::run(&found_versions).await?;
     Ok(())
 }
 

--- a/graph-data.rs/src/verify_yaml.rs
+++ b/graph-data.rs/src/verify_yaml.rs
@@ -8,10 +8,7 @@ use anyhow::Result as Fallible;
 
 pub async fn run() -> Fallible<HashSet<Version>> {
     let data_dir = PathBuf::from(".");
-    println!(
-        "Looking for metadata in {:?}",
-        data_dir.canonicalize()?
-    );
+    println!("Looking for metadata in {:?}", data_dir.canonicalize()?);
     let all_files_regex = Regex::new(".*")?;
     let disallowed_errors: HashSet<plugin::DeserializeDirectoryFilesErrorDiscriminants> = [
         plugin::DeserializeDirectoryFilesErrorDiscriminants::File,


### PR DESCRIPTION
This uses several constants from CVO to verify that all images have a
signature file present. This doesn't verify the that the signature is
valid though.

TODO:
* [x] Ask ART to [have a look](https://issues.redhat.com/browse/ART-2397) at current failures - these seem valid and need fixing

Ref: https://issues.redhat.com/browse/OTA-153