### PR TITLE
graph-data.rs/Dockerfile: use rhel8/rust-toolset:1.47

### DIFF
--- a/graph-data.rs/Dockerfile
+++ b/graph-data.rs/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.access.redhat.com/devtools/rust-toolset-rhel7:1.43.1 as builder
+FROM registry.redhat.io/rhel8/rust-toolset:1.47.0 as builder
 
 WORKDIR /opt/app-root/src/
 COPY . .
 USER 0
 RUN bash -c "source /opt/app-root/etc/scl_enable && cargo install --path graph-data.rs"
 
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 


### PR DESCRIPTION
RHEL8-based Rust 1.47 as a builder and minimal UBI 8 as a base image. UBI minimal already inlcudes openssl-libs so `openssl` is no longer required.

TODO:
* [x] Add necessary pull secrets from registry.redhat.io in CI configuration
      https://github.com/openshift/release/pull/13484 would make CI use cached image