### PR TITLE
blocked-edges/4.6.6: Block * -> 4.6.(6|7) on born-in-4.1 ingress

### DIFF
--- a/blocked-edges/4.6.6.yaml
+++ b/blocked-edges/4.6.6.yaml
@@ -1,0 +1,3 @@
+to: 4.6.6
+from: .*
+# *.apps ingress breaks for born-in-4.1 clusters that incorrectly transition to internal DNS on 4.6.6 and later, https://bugzilla.redhat.com/show_bug.cgi?id=1904582

--- a/blocked-edges/4.6.7.yaml
+++ b/blocked-edges/4.6.7.yaml
@@ -1,0 +1,3 @@
+to: 4.6.7
+from: .*
+# *.apps ingress breaks for born-in-4.1 clusters that incorrectly transition to internal DNS on 4.6.6 and later, https://bugzilla.redhat.com/show_bug.cgi?id=1904582


### PR DESCRIPTION
There aren't all that many born-in-4.1 clusters within striking distance of 4.6.6+, so the number of vulnerable clusters is small. But `*.apps` breaking would be really bad, so block the edges to protect that small subset.  [rhbz#1904582](https://bugzilla.redhat.com/show_bug.cgi?id=1904582).

We could keep 4.6.6 -> 4.6.7 in place, but I didn't bother to figure out the regexp for "all versions that aren't 4.6.6".