### PR TITLE
blocked-edges/4.7.0: Block edges from 4.6.19

### DIFF
--- a/blocked-edges/4.7.0.yaml
+++ b/blocked-edges/4.7.0.yaml
@@ -1,0 +1,3 @@
+to: 4.7.0
+from: 4\.6\.19
+# 4.6.19 doesn't exist yet, so block the edge to 4.7.0 until we know what it will contain


### PR DESCRIPTION
Baked in update sources:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64 | grep Upgrades
  Upgrades: 4.6.15, 4.6.16, 4.6.17, 4.6.18, 4.6.19, 4.7.0-fc.1, 4.7.0-fc.2, 4.7.0-fc.3, 4.7.0-fc.4, 4.7.0-fc.5, 4.7.0-rc.1, 4.7.0-rc.2, 4.7.0-rc.3
```

But 4.6.18 is the latest 4.6.z.  Block edges from 4.6.19 to 4.7.0 for now, so we aren't recommending an update that would regress (e.g. if 4.6.19 fixes a kernel CVE or whatever, and 4.7.0 was cut before that CVE was fixed).  If it turns out that 4.6.19 has no fixes that aren't included in 4.7.0, we can drop the block.