### PR TITLE
Enable 4.7.0 in stable channel(s)

### DIFF
--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,0 +1,3 @@
+name: stable-4.7
+versions:
+- 4.7.0


### PR DESCRIPTION
No need to cook in fast, because there will be no stable-4.7 into or out of 4.7.0 for a while.