### PR TITLE
errata-webhook: add initial unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nodes
 graph-data.rs/target
+hack/__pycache__

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,1 +1,2 @@
 PyGithub==1.52
+pytest==6.2.2

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,2 +1,1 @@
 PyGithub==1.52
-pytest==6.2.2

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -91,9 +91,9 @@ def test_poll_params_of_url(urlopen_mock, json_load_mock):
     parsed_url = urllib.parse.urlparse(url)
     params = urllib.parse.parse_qs(parsed_url.query)
 
-    # Assert if parametres complies with datagrepper reference
+    # Assert if parameters complies with datagrepper reference
     assert int(params["page"][0]) > 0               # Page must be greater than 0
-    assert int(params["rows_per_page"][0]) <= 100   # Must be les than or equal to 100
+    assert int(params["rows_per_page"][0]) <= 100   # Must be less than or equal to 100
     assert params["category"][0] == "errata"        # Should only look for errata category
     assert params["contains"][0] == "RHOSE"         # Only messages containing RHOSE
 
@@ -117,7 +117,7 @@ def test_poll_params_of_url(urlopen_mock, json_load_mock):
 #         "pages": 1
 #     }
     
-#     # Retrive messages from errata.poll without specifying parametres
+#     # Retrive messages from errata.poll without specifying parameters
 #     polled_messages = []
 #     for message in errata.poll():
 #         polled_messages.append(message)
@@ -208,7 +208,7 @@ def test_poll_multiple_messages(urlopen_mock, json_load_mock):
     urlopen_mock.return_value = MagicMock()
     raw_messages = [
         {
-            "additional_necessary_info": "shouldn't be proccesed",
+            "additional_necessary_info": "shouldn't be processed",
             "msg": {
                 "errata_id": 1,
                 "product": "RHOSE",
@@ -216,7 +216,7 @@ def test_poll_multiple_messages(urlopen_mock, json_load_mock):
             }
         },
         {
-            "additional_necessary_info": "shouldn't be proccesed",
+            "additional_necessary_info": "shouldn't be processed",
             "msg": {
                 "errata_id": 2,
                 "product": "RHOSE",
@@ -224,7 +224,7 @@ def test_poll_multiple_messages(urlopen_mock, json_load_mock):
             }
         },
         {
-            "additional_necessary_info": "shouldn't be proccesed",
+            "additional_necessary_info": "shouldn't be processed",
             "msg": {
                 "errata_id": 3,
                 "product": "RHEL",
@@ -232,7 +232,7 @@ def test_poll_multiple_messages(urlopen_mock, json_load_mock):
             }
         },
         {
-            "additional_necessary_info": "shouldn't be proccesed",
+            "additional_necessary_info": "shouldn't be processed",
             "msg": {
                 "errata_id": 4,
                 "product": "RHEL",
@@ -240,7 +240,7 @@ def test_poll_multiple_messages(urlopen_mock, json_load_mock):
             }
         },
         {
-            "additional_necessary_info": "shouldn't be proccesed",
+            "additional_necessary_info": "shouldn't be processed",
             "msg": {
                 "errata_id": 5,
                 "product": "RHOSE",

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -98,35 +98,6 @@ def test_poll_params_of_url(urlopen_mock, json_load_mock):
     assert params["contains"][0] == "RHOSE"         # Only messages containing RHOSE
 
 
-# Possible minor bug, calling errata.poll() without passing arguments
-# @patch("json.load")
-# @patch("urllib.request.urlopen")
-# def test_poll_default_params(urlopen_mock, json_load_mock):
-#     urlopen_mock.return_value = MagicMock()
-#     # Mocked response from API
-#     raw_messages = [
-#         {
-#             "msg": {
-#                 "product": "RHOSE",
-#                 "to": "SHIPPED_LIVE",
-#             }
-#         }
-#     ]
-#     json_load_mock.return_value = {
-#         "raw_messages": raw_messages,
-#         "pages": 1
-#     }
-    
-#     # Retrive messages from errata.poll without specifying parameters
-#     polled_messages = []
-#     for message in errata.poll():
-#         polled_messages.append(message)
-
-#     # Test if data was polled correctly
-#     expected_messages = [x['msg'] for x in raw_messages]
-#     assert expected_messages == polled_messages
-
-
 @patch("json.load")
 @patch("urllib.request.urlopen")
 def test_poll_number_of_returned_pages_is_zero(urlopen_mock, json_load_mock):

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -1,0 +1,598 @@
+import datetime
+import errata
+import github
+import http
+import json
+import os
+import re
+import tempfile
+import unittest
+import urllib
+from collections import namedtuple
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+def test_extract_errata_number_from_body_valid_url():
+    body = "errata is https://errata.devel.redhat.com/advisory/12345"
+    assert errata.extract_errata_number_from_body(body) == 12345
+
+    body = "errata is https://errata.devel.redhat.com/advisory/9999"
+    assert errata.extract_errata_number_from_body(body) == 9999
+
+    body = "errata is https://errata.devel.redhat.com/advisory/"
+    assert errata.extract_errata_number_from_body(body) == None
+
+    body = "errata is https://errata.devel.redhat.com/advisory/invalid"
+    assert errata.extract_errata_number_from_body(body) == None
+
+
+def test_extract_errata_number_from_body_invalid_url():
+    # Possible invalid body
+    # body = "errata is https://errata.devel.redhat.com/advisory/advisory/12345"
+    # assert errata.extract_errata_number_from_body(body) == None
+
+    body = "errata is https://errata.devel.redhat.com/"
+    assert errata.extract_errata_number_from_body(body) == None
+
+
+def test_load():
+    with tempfile.TemporaryDirectory() as tempdir:
+        cachepath = os.path.join(tempdir, "cache.json")
+        cache = {"foo": "bar"}
+
+        with open(cachepath, 'w') as file:
+            json.dump(cache, file)
+
+        loaded_cache = errata.load(cachepath)
+        assert loaded_cache == cache
+
+
+def test_load_nonexisting_file():
+    with tempfile.TemporaryDirectory() as tempdir:
+        return_val = errata.load(os.path.join(
+            tempdir, "non_existing_file.txt"))
+        assert return_val == {}
+
+
+def test_save():
+    with tempfile.TemporaryDirectory() as tempdir:
+        cache = {"foo": "bar"}
+        cachepath = os.path.join(tempdir, "cache.json")
+        errata.save(cachepath, cache)
+        assert os.path.isfile(cachepath)
+
+        with open(cachepath, "r") as file:
+            loaded_cache = json.load(file)
+            assert cache == loaded_cache
+
+
+@patch("json.load")
+@patch("urllib.request.urlopen")
+def test_poll_params_of_url(urlopen_mock, json_load_mock):
+    urlopen_mock.return_value = MagicMock()
+    
+    # Mocked response from API
+    raw_messages = []
+    json_load_mock.return_value = {
+        "raw_messages": raw_messages,
+        "pages": 1
+    }
+    
+    # Call errata.poll function
+    polled_messages = []
+    poll_period = datetime.timedelta(seconds=3600)
+    for message in errata.poll(period=poll_period):
+        polled_messages.append(message)
+
+    #Get arguments of urlib.request.urlopen call inside errata.poll
+    urlopen_called_with_args = urlopen_mock.call_args
+    # Get params of the url
+    url = re.search(r"call\(\'(.*)\'\)", str(urlopen_called_with_args)).group(1)
+    parsed_url = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed_url.query)
+
+    # Assert if parametres complies with datagrepper reference
+    assert int(params["page"][0]) > 0               # Page must be greater than 0
+    assert int(params["rows_per_page"][0]) <= 100   # Must be les than or equal to 100
+    assert params["category"][0] == "errata"        # Should only look for errata category
+    assert params["contains"][0] == "RHOSE"         # Only messages containing RHOSE
+
+
+# Possible minor bug, calling errata.poll() without passing arguments
+# @patch("json.load")
+# @patch("urllib.request.urlopen")
+# def test_poll_default_params(urlopen_mock, json_load_mock):
+#     urlopen_mock.return_value = MagicMock()
+#     # Mocked response from API
+#     raw_messages = [
+#         {
+#             "msg": {
+#                 "product": "RHOSE",
+#                 "to": "SHIPPED_LIVE",
+#             }
+#         }
+#     ]
+#     json_load_mock.return_value = {
+#         "raw_messages": raw_messages,
+#         "pages": 1
+#     }
+    
+#     # Retrive messages from errata.poll without specifying parametres
+#     polled_messages = []
+#     for message in errata.poll():
+#         polled_messages.append(message)
+
+#     # Test if data was polled correctly
+#     expected_messages = [x['msg'] for x in raw_messages]
+#     assert expected_messages == polled_messages
+
+
+@patch("json.load")
+@patch("urllib.request.urlopen")
+def test_poll_number_of_returned_pages_is_zero(urlopen_mock, json_load_mock):
+    urlopen_mock.return_value = MagicMock()
+
+    raw_messages = []
+    json_load_mock.return_value = {
+        "raw_messages": raw_messages,
+        "pages": 0
+    }
+
+    polled_messages = []
+    poll_period = datetime.timedelta(seconds=3600)
+    for message in errata.poll(period=poll_period):
+        polled_messages.append(message)
+
+    # Test if data was polled correctly
+    assert polled_messages == []
+
+
+@patch("json.load")
+@patch("urllib.request.urlopen")
+def test_poll_no_results(urlopen_mock, json_load_mock):
+    urlopen_mock.return_value = MagicMock()
+
+    raw_messages = []
+    json_load_mock.return_value = {
+        "raw_messages": raw_messages,
+        "pages": 1
+    }
+
+    polled_messages = []
+    poll_period = datetime.timedelta(seconds=3600)
+    for message in errata.poll(period=poll_period):
+        polled_messages.append(message)
+    
+    # Test if data was polled correctly
+    assert polled_messages == []
+
+
+@patch("json.load")
+@patch("time.sleep")
+@patch("urllib.request.urlopen")
+def test_poll_unresponsive_url_becomes_responsive(urlopen_mock, sleep_mock, json_load_mock):
+    # First time calling request.urlopen returns Exception, 
+    # second time returns mocked HTTPResponse
+    urlopen_mock.side_effect = [
+    Exception("Unresponsive, request.urlopen has failed"), MagicMock()]
+    raw_messages = [
+        {
+            "msg": {
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            }
+        }
+    ]
+    json_load_mock.return_value = {
+        "raw_messages": raw_messages,
+        "pages": 1
+    }
+    
+    # Retrive messages from errata.poll
+    poll_period = datetime.timedelta(seconds=3600)
+    polled_messages = []
+    for message in errata.poll(period=poll_period):
+        polled_messages.append(message)
+
+    # Test if data was polled correctly
+    expected_messages = [x['msg'] for x in raw_messages]
+    assert expected_messages == polled_messages
+
+    # URL wasn't responsive only once, so sleep should be called only once
+    sleep_mock.assert_called_once()
+
+
+@patch("json.load")
+@patch("urllib.request.urlopen")
+def test_poll_multiple_messages(urlopen_mock, json_load_mock):
+    urlopen_mock.return_value = MagicMock()
+    raw_messages = [
+        {
+            "additional_necessary_info": "shouldn't be proccesed",
+            "msg": {
+                "errata_id": 1,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            }
+        },
+        {
+            "additional_necessary_info": "shouldn't be proccesed",
+            "msg": {
+                "errata_id": 2,
+                "product": "RHOSE",
+                "to": "QE",
+            }
+        },
+        {
+            "additional_necessary_info": "shouldn't be proccesed",
+            "msg": {
+                "errata_id": 3,
+                "product": "RHEL",
+                "to": "SHIPPED_LIVE",
+            }
+        },
+        {
+            "additional_necessary_info": "shouldn't be proccesed",
+            "msg": {
+                "errata_id": 4,
+                "product": "RHEL",
+                "to": "QE",
+            }
+        },
+        {
+            "additional_necessary_info": "shouldn't be proccesed",
+            "msg": {
+                "errata_id": 5,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            }
+        }
+    ]
+    expected_messages = [
+       {
+            "errata_id": 1,
+            "product": "RHOSE",
+            "to": "SHIPPED_LIVE",
+        },
+        {
+            "errata_id": 5,
+            "product": "RHOSE",
+            "to": "SHIPPED_LIVE",
+        }
+    ]
+    json_load_mock.return_value = {
+        "raw_messages": raw_messages,
+        "pages": 1
+    }
+    # Retrive messages from errata.poll
+    poll_period = datetime.timedelta(seconds=3600)
+    polled_messages = []
+    for message in errata.poll(period=poll_period):
+        polled_messages.append(message)
+    # Test if data was polled correctly
+    assert expected_messages == polled_messages
+
+
+@patch("builtins.print")
+@patch("urllib.request.urlopen")
+def test_notify_no_webhook(urlopen_mock, print_mock):
+    input_msgs = [
+        {
+            "errata_id": 1,
+            "product": "RHOSE",
+            "to": "SHIPPED_LIVE",
+        },
+        {
+            "errata_id": 5,
+            "product": "RHOSE",
+            "to": "SHIPPED_LIVE",
+        }
+    ]
+    errata.notify(message=input_msgs)
+    assert print_mock.call_args == (unittest.mock.call(input_msgs))
+
+    input_msgs = [
+        {
+            "errata_id": 3,
+            "product": "RHEL",
+            "to": "SHIPPED_LIVE",
+        },
+    ]
+    errata.notify(message=input_msgs)
+    assert print_mock.call_args == (unittest.mock.call(input_msgs))
+
+    input_msgs = [
+        {
+            "errata_id": 4,
+            "product": "RHEL",
+            "to": "QE",
+        },
+    ]
+    errata.notify(message=input_msgs)
+    assert print_mock.call_args == (unittest.mock.call(input_msgs))
+
+
+@patch("urllib.request.urlopen")
+def test_notify_format_of_message_pr_not_approved(urlopen_mock):
+    message = {
+        "fulladvisory": "RHEL",
+        "when": "today",
+        "synopsis": "OpenShift Container Platform X.X.X",
+        "uri": "example_uri"
+    }
+
+    errata.notify(message, True)
+
+    msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
+    expected_data = urllib.parse.urlencode({
+        'payload': {
+            'text': msg_text,
+        },
+    }).encode('utf-8')
+    assert urlopen_mock.call_args[1]["data"] == expected_data
+
+
+@patch("urllib.request.urlopen")
+def test_notify_format_of_message_pr_approved(urlopen_mock):
+    message = {
+        "fulladvisory": "RHEL",
+        "when": "today",
+        "synopsis": "OpenShift Container Platform X.X.X",
+        "uri": "example_uri",
+        "approved_pr": "example_approved"
+    }
+
+    errata.notify(message, True)
+
+    msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
+    msg_text += "\nPR {approved_pr} has been approved".format(**message)
+    
+    expected_data = urllib.parse.urlencode({
+        'payload': {
+            'text': msg_text,
+        },
+    }).encode('utf-8')
+    assert urlopen_mock.call_args[1]["data"] == expected_data
+
+
+# Mocking classes of PyGithub
+GitUser = namedtuple("GitUser", "login")
+GitLabel = namedtuple("GitLabel", "name")
+
+class GithubRepoPrMock:
+    def __init__(self, user, title, labels=[], number=0, body="", url="", html_url=""):
+        self.user = user
+        self.title = title
+        self.labels = labels
+        self.number = number
+        self.body = body
+        self.url = url
+        self.html_url = html_url
+        self.create_issue_comment = MagicMock()
+
+    def __eq__(self, other):
+        if not isinstance(other, GithubRepoPrMock):
+            return False
+        return      self.user == other.user     \
+                and self.title == other.title   \
+                and self.labels == other.labels \
+                and self.number == other.number \
+                and self.body == other.body     \
+                and self.url == other.url       \
+                and self.html_url == other.html_url
+
+
+def test_get_open_prs_to_fast_labels_not_lgtmed():
+    # Create multiple groups of label(s)
+    labels_empty = []
+    labels_bug = [GitLabel("bug")]
+    labels_duplicate = [GitLabel("duplicate")]
+    labels_enhancement = [GitLabel("enhancement")]
+    labels_multiple = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("documentation")]
+
+    # Mock Pullrequests in a repository
+    prs = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_bug, 2))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_duplicate, 3))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_enhancement, 4))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_multiple, 5))
+
+    # Mock repo.get_pulls used in errata.get_open_prs_to_fast
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    assert get_prs == prs
+
+
+def test_get_open_prs_to_fast_labels_lgtmed():
+    # Create multiple groups of label(s) including 'lgtm' at different indexes
+    labels_only_lgtm = [GitLabel("lgtm")]
+    labels_lgtm_index_0 = [GitLabel("lgtm"), GitLabel("bug")]
+    labels_lgtm_index_1 = [GitLabel("duplicate"), GitLabel("lgtm")]
+    labels_lgtm_index_2 = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("lgtm"), GitLabel("documentation")]
+    labels_lgtm_index_last = [GitLabel("enhancement"), GitLabel("bug"), GitLabel("fix"), GitLabel("lgtm")]
+
+    prs = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_only_lgtm, 1))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channels", labels_lgtm_index_0, 2))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channels", labels_lgtm_index_1, 3))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channels", labels_lgtm_index_2, 4))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channels", labels_lgtm_index_last, 5))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    assert get_prs == []
+
+
+def test_get_open_prs_to_fast_user_login():
+    labels_empty = []
+    prs = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1))
+    prs.append(GithubRepoPrMock(GitUser("openshift-user"), "Enable DEF in fast channels", labels_empty, 2))
+    prs.append(GithubRepoPrMock(GitUser("user1234"), "Enable GHI in fast channels", labels_empty, 3))
+    prs.append(GithubRepoPrMock(GitUser("abcdefgh"), "Enable JKL in fast channels", labels_empty, 4))
+    prs.append(GithubRepoPrMock(GitUser("bot-openshift"), "Enable MNO in fast channels", labels_empty, 5))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1)]
+
+
+def test_get_open_prs_to_fast_channel():
+    labels_empty = []
+    prs = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in stable channel(s)", labels_empty, 1))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in candidate channel(s)", labels_empty, 2))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in candidate channel(s)", labels_empty, 3))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in stable channel(s)", labels_empty, 5))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4)]
+
+
+def test_get_open_prs_to_fast_title():
+    labels_empty = []
+    prs = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable ABC in fast channel(s)", labels_empty, 1))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Fix GHI in fast channel(s)", labels_empty, 2))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable DEF in fast channel(s)", labels_empty, 4))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Add features in fast channel(s)", labels_empty, 5))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3)]
+
+
+def test_get_open_prs_to_fast_query_params():
+    prs = []
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    get_prs = []
+    for pr in errata.get_open_prs_to_fast(repo):
+        get_prs.append(pr)
+
+    query_params_expected = {
+        'state': 'open',
+        'base': 'master',
+        'sort': 'created',
+    }
+    assert repo.get_pulls.call_args == (unittest.mock.call(**query_params_expected))
+
+
+@patch("github.Github")
+def test_lgtm_fast_pr_for_errata_test_return_value(Github_mock):
+    prs = []
+    labels_empty = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    github_object_mock = MagicMock()
+    github_object_mock.get_repo.return_value = repo
+    Github_mock.return_value = github_object_mock
+
+    githubrepo = MagicMock()
+    githubtoken = MagicMock()
+    message = {
+        "errata_id" : 5678,
+    }
+
+    html = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+    assert html == "pr_html_url_5678"
+
+
+@patch("github.Github")
+def test_lgtm_fast_pr_for_errata_test_creating_issue(Github_mock):
+    # Mock Pullrequests in a repository
+    prs = []
+    labels_empty = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    github_object_mock = MagicMock()
+    github_object_mock.get_repo.return_value = repo
+    Github_mock.return_value = github_object_mock
+
+    githubrepo = MagicMock()
+    githubtoken = MagicMock()
+    message = {
+        "errata_id" : 5678,
+    }
+    
+    errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+    prs[0].create_issue_comment.assert_not_called()
+    prs[1].create_issue_comment.assert_not_called()
+    prs[2].create_issue_comment.assert_not_called()
+    prs[3].create_issue_comment.assert_not_called()
+    prs[4].create_issue_comment.assert_called_once()
+
+
+@patch("github.Github")
+def test_lgtm_fast_pr_for_errata_test_issue_format(Github_mock):
+    # Mock Pullrequests in a repository
+    prs = []
+    labels_empty = []
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+    repo = MagicMock()
+    repo.get_pulls = MagicMock(return_value=prs)
+
+    github_object_mock = MagicMock()
+    github_object_mock.get_repo.return_value = repo
+    Github_mock.return_value = github_object_mock
+
+    githubrepo = MagicMock()
+    githubtoken = MagicMock()
+    message = {
+        "errata_id" : 5678,
+    }
+
+    errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+
+    msg = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
+    assert  prs[4].create_issue_comment.call_args == (unittest.mock.call(msg))

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -37,31 +37,72 @@ class GithubRepoPrMock:
                 and self.url == other.url       \
                 and self.html_url == other.html_url
 
-class TestErrata(unittest.TestCase):
-
-    def test_extract_errata_number_from_body_valid_url(self):
-        body = "errata is https://errata.devel.redhat.com/advisory/12345"
-        self.assertEqual(errata.extract_errata_number_from_body(body), 12345)
-
-        body = "errata is https://errata.devel.redhat.com/advisory/9999"
-        self.assertEqual(errata.extract_errata_number_from_body(body), 9999)
-
-        body = "errata is https://errata.devel.redhat.com/advisory/"
-        self.assertEqual(errata.extract_errata_number_from_body(body), None)
-
-        body = "errata is https://errata.devel.redhat.com/advisory/invalid"
-        self.assertEqual(errata.extract_errata_number_from_body(body), None)
-
-
-    def test_extract_errata_number_from_body_invalid_url(self):
-        # Possible invalid body
-        # body = "errata is https://errata.devel.redhat.com/advisory/advisory/12345"
-        # assert errata.extract_errata_number_from_body(body) == None
-
-        body = "errata is https://errata.devel.redhat.com/"
-        self.assertEqual(errata.extract_errata_number_from_body(body), None)
+class ExtractErrataNumberFromBodyTest(unittest.TestCase):
+    def test_valid_url(self):
+        """
+        Test errata number extraction from valid URLs.
+        """
+        param_list = [
+            ('https://errata.devel.redhat.com/advisory/12345', 12345),
+            ('https://errata.devel.redhat.com/advisory/67890', 67890),
+            ('https://errata.devel.redhat.com/advisory/13579', 13579),
+            ('https://errata.devel.redhat.com/advisory/24680', 24680),
+            ('https://errata.devel.redhat.com/advisory/', None),
+            ('https://errata.devel.redhat.com/advisory/invalid', None)
+        ]
+        for (url, expected) in param_list:
+            with self.subTest():
+                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
 
 
+    def test_invalid_url(self):
+        """
+        Test errata number extraction from invalid URLs.
+        """
+        param_list = [
+            ('http://errata.devel.redhat.com/advisory/12345', None),
+            ('https://errrata.devel.redhat.com/advisory/12345', None),
+            ('https://errata.dvel.reddhat.com/advisori/12345', None),
+            ('https://errata.devel.redhat.com/12345', None),
+            ('https://errata.devel.com/advisory/12345', None),
+            ('https://errata.redhat.com/advisory/12345', None),
+            ('https://devel.redhat.com/advisory/12345', None),
+            ('https://redhat.com/advisory/12345', None),
+            ('https://errata.com/advisory/12345', None)
+        ]
+        for (url, expected) in param_list:
+            with self.subTest():
+                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
+
+
+    def test_missing_url(self):
+        """
+        Test errata number extraction from missing URLs.
+        """
+        param_list = [
+            ('errata', None),
+            ('12345', None),
+            ('errata is 12345', None)
+        ]
+        for (url, expected) in param_list:
+            with self.subTest():
+                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
+
+
+    def test_url_is_not_on_the_first_line(self):
+        """
+        Test errata number extraction from valid URLs which are not located on the first line.
+        """
+        param_list = [
+            ('\nhttps://errata.devel.redhat.com/advisory/12345', None),
+            ('\n\nhttps://errata.devel.redhat.com/advisory/12345', None),
+        ]
+        for (url, expected) in param_list:
+            with self.subTest():
+                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
+
+
+class ErrataTest(unittest.TestCase):
     def test_load(self):
         with tempfile.TemporaryDirectory() as tempdir:
             cachepath = os.path.join(tempdir, "cache.json")

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -12,10 +12,10 @@ from collections import namedtuple
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-# Mocking classes of PyGithub
-GitUser = namedtuple("GitUser", "login")
-GitLabel = namedtuple("GitLabel", "name")
-class GithubRepoPrMock:
+
+GithubUserMock = namedtuple("GithubUserMock", "login")
+GithubLabelMock = namedtuple("GithubLabelMock", "name")
+class GithubPRMock:
     def __init__(self, user, title, labels=[], number=0, body="", url="", html_url=""):
         self.user = user
         self.title = title
@@ -27,7 +27,7 @@ class GithubRepoPrMock:
         self.create_issue_comment = MagicMock()
         
     def __eq__(self, other):
-        if not isinstance(other, GithubRepoPrMock):
+        if not isinstance(other, GithubPRMock):
             return False
         return      self.user == other.user     \
                 and self.title == other.title   \
@@ -36,6 +36,7 @@ class GithubRepoPrMock:
                 and self.body == other.body     \
                 and self.url == other.url       \
                 and self.html_url == other.html_url
+
 
 class ExtractErrataNumberFromBodyTest(unittest.TestCase):
     def test_valid_url(self):
@@ -132,30 +133,87 @@ class SaveAndLoadTest(unittest.TestCase):
                     self.assertCountEqual(errata.load(cachepath), cache)
 
 
-class ErrataTest(unittest.TestCase):
+class PollTest(unittest.TestCase):
+    def setUp(self):
+        self.raw_messages_containing_msg_expected_to_be_polled = [
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 11,
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                }
+            },
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 12,
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                }
+            }
+        ]
+        self.raw_messages_containing_msg_expected_not_to_be_polled = [
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 21,
+                    "product": "RHOSE",
+                    "to": "QE",
+                }
+            },
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 22,
+                    "product": "RHEL",
+                    "to": "SHIPPED_LIVE",
+                }
+            },
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 23,
+                    "product": "RHEL",
+                    "to": "QE",
+                }
+            },
+            {
+                "additional_unnecessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 24,
+                    "product": "SHIPPED_LIVE",
+                    "to": "RHOSE",
+                }
+            }
+        ]
+        self.multiple_raw_messages =                                    \
+        self.raw_messages_containing_msg_expected_to_be_polled +        \
+        self.raw_messages_containing_msg_expected_not_to_be_polled
+
+        self.multiple_msg_expected_to_be_polled = [
+            raw_message['msg'] for raw_message
+            in self.raw_messages_containing_msg_expected_to_be_polled]
+
+
     @patch("json.load")
     @patch("urllib.request.urlopen")
-    def test_poll_params_of_url(self, urlopen_mock, json_load_mock):
+    def test_params_of_urlopen_call(self, urlopen_mock, json_load_mock):
+        """
+        Test parameters used in the data_grepper's url which is used for getting raw messages.
+        """
         urlopen_mock.return_value = MagicMock()
-
-        # Mocked response from API
-        raw_messages = []
         json_load_mock.return_value = {
-            "raw_messages": raw_messages,
+            "raw_messages": [],
             "pages": 1
         }
 
-        # Call errata.poll function
         polled_messages = []
-        poll_period = datetime.timedelta(seconds=3600)
-        for message in errata.poll(period=poll_period):
+        for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
 
-        #Get arguments of urlib.request.urlopen call inside errata.poll
-        urlopen_called_with_args = urlopen_mock.call_args
-        # Get params of the url
-        url = re.search(r"call\(\'(.*)\'\)", str(urlopen_called_with_args)).group(1)
-        parsed_url = urllib.parse.urlparse(url)
+        # Get params of the url used in urlopen in errata.poll
+        parsed_url = urllib.parse.urlparse(urlopen_mock.call_args[0][0])
         params = urllib.parse.parse_qs(parsed_url.query)
 
         # Assert if parameters complies with datagrepper reference
@@ -167,41 +225,37 @@ class ErrataTest(unittest.TestCase):
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
-    def test_poll_number_of_returned_pages_is_zero(self, urlopen_mock, json_load_mock):
+    def test_number_of_returned_pages_is_zero(self, urlopen_mock, json_load_mock):
+        """
+        Test poll's functionality if returned data contains number of pages equal to zero.
+        """
         urlopen_mock.return_value = MagicMock()
-
-        raw_messages = []
         json_load_mock.return_value = {
-            "raw_messages": raw_messages,
+            "raw_messages": [],
             "pages": 0
         }
 
         polled_messages = []
-        poll_period = datetime.timedelta(seconds=3600)
-        for message in errata.poll(period=poll_period):
+        for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
-
-        # Test if data was polled correctly
         self.assertEqual(polled_messages, [])
 
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
-    def test_poll_no_results(self, urlopen_mock, json_load_mock):
+    def test_poll_no_raw_messages(self, urlopen_mock, json_load_mock):
+        """
+        Test polling messages if data doesn't contain any raw messages.
+        """
         urlopen_mock.return_value = MagicMock()
-
-        raw_messages = []
         json_load_mock.return_value = {
-            "raw_messages": raw_messages,
+            "raw_messages": [],
             "pages": 1
         }
 
         polled_messages = []
-        poll_period = datetime.timedelta(seconds=3600)
-        for message in errata.poll(period=poll_period):
+        for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
-
-        # Test if data was polled correctly
         self.assertEqual(polled_messages, [])
 
 
@@ -209,401 +263,476 @@ class ErrataTest(unittest.TestCase):
     @patch("time.sleep")
     @patch("urllib.request.urlopen")
     def test_poll_unresponsive_url_becomes_responsive(self, urlopen_mock, sleep_mock, json_load_mock):
-        # First time calling request.urlopen returns Exception, 
-        # second time returns mocked HTTPResponse
+        """
+        Test polling messages if request.urlopen throws exception on a first try.
+        """
         urlopen_mock.side_effect = [
         Exception("Unresponsive, request.urlopen has failed"), MagicMock()]
-        raw_messages = [
-            {
-                "msg": {
-                    "product": "RHOSE",
-                    "to": "SHIPPED_LIVE",
-                }
-            }
-        ]
         json_load_mock.return_value = {
-            "raw_messages": raw_messages,
+            "raw_messages": self.multiple_raw_messages,
             "pages": 1
         }
 
-        # Retrive messages from errata.poll
-        poll_period = datetime.timedelta(seconds=3600)
         polled_messages = []
-        for message in errata.poll(period=poll_period):
+        for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
 
-        # Test if data was polled correctly
-        expected_messages = [x['msg'] for x in raw_messages]
-        self.assertEqual(expected_messages, polled_messages)
-
-        # URL wasn't responsive only once, so sleep should be called only once
-        sleep_mock.assert_called_once()
+        sleep_mock.assert_called_once() # URL wasn't responsive only once, so time.sleep should have been called only once
+        self.assertEqual(polled_messages, self.multiple_msg_expected_to_be_polled)
 
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
     def test_poll_multiple_messages(self, urlopen_mock, json_load_mock):
+        """
+        Test polling messages from raw messages that include wanted and unwanted messages.
+        """
         urlopen_mock.return_value = MagicMock()
-        raw_messages = [
-            {
-                "additional_necessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 1,
-                    "product": "RHOSE",
-                    "to": "SHIPPED_LIVE",
-                }
-            },
-            {
-                "additional_necessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 2,
-                    "product": "RHOSE",
-                    "to": "QE",
-                }
-            },
-            {
-                "additional_necessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 3,
-                    "product": "RHEL",
-                    "to": "SHIPPED_LIVE",
-                }
-            },
-            {
-                "additional_necessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 4,
-                    "product": "RHEL",
-                    "to": "QE",
-                }
-            },
-            {
-                "additional_necessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 5,
-                    "product": "RHOSE",
-                    "to": "SHIPPED_LIVE",
-                }
-            }
-        ]
-        expected_messages = [
-           {
-                "errata_id": 1,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            },
-            {
-                "errata_id": 5,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            }
-        ]
         json_load_mock.return_value = {
-            "raw_messages": raw_messages,
+            "raw_messages": self.multiple_raw_messages,
             "pages": 1
         }
-        # Retrive messages from errata.poll
-        poll_period = datetime.timedelta(seconds=3600)
+
         polled_messages = []
-        for message in errata.poll(period=poll_period):
+        for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
-        # Test if data was polled correctly
-        self.assertEqual(expected_messages, polled_messages)
+        self.assertEqual(polled_messages, self.multiple_msg_expected_to_be_polled)
+
+
+class NotifyTest(unittest.TestCase):
+    def setUp(self):
+        self.messages_including_approved_pr = [
+            (
+                {
+                    "errata_id": 11,
+                    "fulladvisory": "RHSA-2020:0000-00",
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                    "synopsis": "OpenShift Container Platform 4.6 GA Images",
+                    "when": "2021-01-01 12:00:00 UTC",
+                    "uri": "Public_Errata_URI_11",
+                    "approved_pr": "PR_HTML_URL_11"
+                },
+                '<!subteam^STE7S7ZU2>: '\
+                'RHSA-2020:0000-00 shipped '\
+                '2021-01-01 12:00:00 UTC: '\
+                'OpenShift Container Platform 4.6 GA Images '\
+                'Public_Errata_URI_11'\
+                '\nPR PR_HTML_URL_11 has been approved'
+            ),
+            (
+                {
+                    "errata_id": 12,
+                    "fulladvisory": "RHSA-2020:2000-20",
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                    "synopsis": "Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update",
+                    "when": "2021-01-02 13:00:00 UTC",
+                    "uri": "Public_Errata_URI_12",
+                    "approved_pr": "PR_HTML_URL_12"
+                },
+                '<!subteam^STE7S7ZU2>: '\
+                'RHSA-2020:2000-20 shipped '\
+                '2021-01-02 13:00:00 UTC: '\
+                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '\
+                'Public_Errata_URI_12'\
+                '\nPR PR_HTML_URL_12 has been approved'
+            )
+        ]
+        self.messages_not_including_approved_pr = [
+            (
+                {
+                    "errata_id": 21,
+                    "fulladvisory": "RHSA-2020:0000-00",
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                    "synopsis": "OpenShift Container Platform 4.6 GA Images",
+                    "when": "2021-01-01 12:00:00 UTC",
+                    "uri": "Public_Errata_URI_21",
+                },
+                '<!subteam^STE7S7ZU2>: '\
+                'RHSA-2020:0000-00 shipped '\
+                '2021-01-01 12:00:00 UTC: '\
+                'OpenShift Container Platform 4.6 GA Images '\
+                'Public_Errata_URI_21'\
+            ),
+            (
+                {
+                    "errata_id": 22,
+                    "fulladvisory": "RHSA-2020:2000-20",
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                    "synopsis": "Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update",
+                    "when": "2021-01-02 13:00:00 UTC",
+                    "uri": "Public_Errata_URI_22",
+                },
+                '<!subteam^STE7S7ZU2>: '\
+                'RHSA-2020:2000-20 shipped '\
+                '2021-01-02 13:00:00 UTC: '\
+                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '\
+                'Public_Errata_URI_22'
+            )
+        ]
+        self.messages_multiple =    self.messages_including_approved_pr +   \
+                                    self.messages_not_including_approved_pr
 
 
     @patch("builtins.print")
     @patch("urllib.request.urlopen")
-    def test_notify_no_webhook(self, urlopen_mock, print_mock):
-        input_msgs = [
-            {
-                "errata_id": 1,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            },
-            {
-                "errata_id": 5,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            }
-        ]
-        errata.notify(message=input_msgs)
-        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
-
-        input_msgs = [
-            {
-                "errata_id": 3,
-                "product": "RHEL",
-                "to": "SHIPPED_LIVE",
-            },
-        ]
-        errata.notify(message=input_msgs)
-        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
-
-        input_msgs = [
-            {
-                "errata_id": 4,
-                "product": "RHEL",
-                "to": "QE",
-            },
-        ]
-        errata.notify(message=input_msgs)
-        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
+    def test_no_webhook(self, urlopen_mock, print_mock):
+        """
+        Test functionality of notify if parameter webhook is set to its default value. 
+        """
+        for message in self.messages_multiple:
+            with self.subTest():
+                    errata.notify(message[0])
+                    expected_message = message[0]
+                    self.assertEqual(print_mock.call_args, unittest.mock.call(expected_message))
 
 
     @patch("urllib.request.urlopen")
-    def test_notify_format_of_message_pr_not_approved(self, urlopen_mock):
-        message = {
-            "fulladvisory": "RHEL",
-            "when": "today",
-            "synopsis": "OpenShift Container Platform X.X.X",
-            "uri": "example_uri"
-        }
-
-        errata.notify(message, True)
-
-        msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
-        expected_data = urllib.parse.urlencode({
-            'payload': {
-                'text': msg_text,
-            },
-        }).encode('utf-8')
-        self.assertEqual(urlopen_mock.call_args[1]["data"], expected_data)
+    def test_format_of_message_not_including_approved_pr(self, urlopen_mock):
+        """
+        Test format of data passed as argument to request.urlopen in errata.get_open_prs_to_fast.
+        This tests encoded format of the message in data as well.
+        Only testing messages including approved_pr key.
+        """
+        for (message, expected_message_in_data_to_be_uploaded) in self.messages_not_including_approved_pr:
+            with self.subTest():
+                    expected_data_to_be_uploaded = urllib.parse.urlencode({
+                        'payload' : {
+                            'text' : expected_message_in_data_to_be_uploaded
+                        }
+                    }).encode('utf-8')
+                    
+                    errata.notify(message, MagicMock())
+                    uploaded_data = urlopen_mock.call_args[1]['data']
+                    self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
 
 
     @patch("urllib.request.urlopen")
-    def test_notify_format_of_message_pr_approved(self, urlopen_mock):
-        message = {
-            "fulladvisory": "RHEL",
-            "when": "today",
-            "synopsis": "OpenShift Container Platform X.X.X",
-            "uri": "example_uri",
-            "approved_pr": "example_approved"
-        }
+    def test_format_of_message_including_approved_pr(self, urlopen_mock):
+        """
+        Test format of data passed as argument to request.urlopen in errata.get_open_prs_to_fast.
+        This tests encoded format of the message in data as well.
+        Only testing messages that do not include approved_pr key.
+        """
+        for (message, expected_message_in_data_to_be_uploaded) in self.messages_including_approved_pr:
+            with self.subTest():
+                    expected_data_to_be_uploaded = urllib.parse.urlencode({
+                        'payload' : {
+                            'text' : expected_message_in_data_to_be_uploaded
+                        }
+                    }).encode('utf-8')
 
-        errata.notify(message, True)
-
-        msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
-        msg_text += "\nPR {approved_pr} has been approved".format(**message)
-
-        expected_data = urllib.parse.urlencode({
-            'payload': {
-                'text': msg_text,
-            },
-        }).encode('utf-8')
-        self.assertEqual(urlopen_mock.call_args[1]["data"], expected_data)
+                    errata.notify(message, MagicMock())
+                    uploaded_data = urlopen_mock.call_args[1]['data']
+                    self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
 
 
-    def test_get_open_prs_to_fast_labels_not_lgtmed(self):
-        # Create multiple groups of label(s)
-        labels_empty = []
-        labels_bug = [GitLabel("bug")]
-        labels_duplicate = [GitLabel("duplicate")]
-        labels_enhancement = [GitLabel("enhancement")]
-        labels_multiple = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("documentation")]
-
-        # Mock Pullrequests in a repository
-        prs = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_bug, 2))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_duplicate, 3))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_enhancement, 4))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_multiple, 5))
-
-        # Mock repo.get_pulls used in errata.get_open_prs_to_fast
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
-
-        self.assertEqual(get_prs, prs)
-
-
-    def test_get_open_prs_to_fast_labels_lgtmed(self):
-        # Create multiple groups of label(s) including 'lgtm' at different indexes
-        labels_only_lgtm = [GitLabel("lgtm")]
-        labels_lgtm_index_0 = [GitLabel("lgtm"), GitLabel("bug")]
-        labels_lgtm_index_1 = [GitLabel("duplicate"), GitLabel("lgtm")]
-        labels_lgtm_index_2 = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("lgtm"), GitLabel("documentation")]
-        labels_lgtm_index_last = [GitLabel("enhancement"), GitLabel("bug"), GitLabel("fix"), GitLabel("lgtm")]
-
-        prs = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_only_lgtm, 1))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channels", labels_lgtm_index_0, 2))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channels", labels_lgtm_index_1, 3))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channels", labels_lgtm_index_2, 4))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channels", labels_lgtm_index_last, 5))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
-
-        self.assertEqual(get_prs, [])
-
-
-    def test_get_open_prs_to_fast_user_login(self):
-        labels_empty = []
-        prs = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1))
-        prs.append(GithubRepoPrMock(GitUser("openshift-user"), "Enable DEF in fast channels", labels_empty, 2))
-        prs.append(GithubRepoPrMock(GitUser("user1234"), "Enable GHI in fast channels", labels_empty, 3))
-        prs.append(GithubRepoPrMock(GitUser("abcdefgh"), "Enable JKL in fast channels", labels_empty, 4))
-        prs.append(GithubRepoPrMock(GitUser("bot-openshift"), "Enable MNO in fast channels", labels_empty, 5))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
-
-        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1)])
-
-
-    def test_get_open_prs_to_fast_channel(self):
-        labels_empty = []
-        prs = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in stable channel(s)", labels_empty, 1))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in candidate channel(s)", labels_empty, 2))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in candidate channel(s)", labels_empty, 3))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in stable channel(s)", labels_empty, 5))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
-
-        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4)])
+class GetOpenPRsToFastTest(unittest.TestCase):
+    def setUp(self):
+        self.repo = MagicMock()
+        self.labels_multiple_including_lgtm = [
+            [
+                GithubLabelMock('lgtm')
+            ],
+            [
+                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('documentation'), GithubLabelMock('invalid')
+            ],
+            [
+                GithubLabelMock('wontfix'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('question'), GithubLabelMock('invalid')
+            ],
+            [
+                GithubLabelMock('help wanted'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('good first issue'), GithubLabelMock('bug')
+            ]
+        ]
+        self.labels_multiple_not_including_lgtm = [
+            [
+            ],
+            [
+                GithubLabelMock('wontfix'), GithubLabelMock('bug'), 
+                GithubLabelMock('question'), GithubLabelMock('invalid')
+            ],
+            [
+                GithubLabelMock('help wanted'), GithubLabelMock('invalid'), 
+                GithubLabelMock('good first issue'), GithubLabelMock('duplicate')
+            ],
+            [
+                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('invalid'), 
+                GithubLabelMock('documentation'), GithubLabelMock('enhancement')
+            ]
+        ]
+        self.prs_correct_and_expected_to_be_yielded = [
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.6.0 in fast channel(s)"), 
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[0]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[1]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[2]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[3]),
+        ]
+        self.prs_including_the_lgtm_label = [
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_including_lgtm[0]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_including_lgtm[1]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_including_lgtm[2]),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_including_lgtm[3])
+        ]
+        self.prs_author_is_not_openshift_bot = [
+            GithubPRMock(GithubUserMock("user1234"), "Enable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("bot-openshift"), "Enable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("Openshift-Bot"), "Enable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("GitHubUser1234"), "Enable 4.0.0 in fast channel(s)")
+        ]
+        self.prs_title_not_starting_with_Enable = [
+            GithubPRMock(GithubUserMock("openshift-bot"), ""),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Fix component"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Add features in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "enable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Disable 4.0.0 in fast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enablee 4.0.0 in fast channel(s)")
+        ]
+        self.prs_do_not_target_fast = [
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable "),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in FAST channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in faast channel(s)"),
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in stable channel(s)"), 
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in candidate channel(s)")
+        ]
 
 
-    def test_get_open_prs_to_fast_title(self):
-        labels_empty = []
-        prs = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable ABC in fast channel(s)", labels_empty, 1))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Fix GHI in fast channel(s)", labels_empty, 2))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable DEF in fast channel(s)", labels_empty, 4))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Add features in fast channel(s)", labels_empty, 5))
+    def test_prs_including_the_lgtm_label(self):
+        """
+        Test retrieving PRs which include the LGTM label. These PRs should be skipped.
+        """
+        self.repo.get_pulls = MagicMock(return_value=self.prs_including_the_lgtm_label)
 
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
 
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
-
-        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3)])
+        expected_prs = []
+        self.assertEqual(open_prs_to_fast, expected_prs)
 
 
-    def test_get_open_prs_to_fast_query_params(self):
-        prs = []
+    def test_prs_author_is_not_openshift_bot(self):
+        """
+        Test getting PRs whose author is not openshift-bot. These PRs should be skipped.
+        """
+        self.repo.get_pulls = MagicMock(return_value=self.prs_author_is_not_openshift_bot)
 
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
 
-        get_prs = []
-        for pr in errata.get_open_prs_to_fast(repo):
-            get_prs.append(pr)
+        expected_prs = []
+        self.assertEqual(open_prs_to_fast, expected_prs)
 
-        query_params_expected = {
+
+    def test_unknown_prs_should_be_skipped(self):
+        """
+        Test getting unknown PRs. These PRs should be skipped.
+        """
+        self.repo.get_pulls = MagicMock(return_value=self.prs_title_not_starting_with_Enable)
+
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
+
+        expected_prs = []
+        self.assertEqual(open_prs_to_fast, expected_prs)
+
+
+    def test_ignore_prs_which_dont_target_fast(self):
+        """
+        Test getting PRs which don't target fast. These PRs should be skipped.
+        """
+        self.repo.get_pulls = MagicMock(return_value=self.prs_do_not_target_fast)
+
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
+
+        expected_prs = []
+        self.assertEqual(open_prs_to_fast, expected_prs)
+
+
+    def test_correct_prs_should_be_yielded(self):
+        """
+        Test getting PRs which are correct and should be yielded back.
+        """
+        self.repo.get_pulls = MagicMock(return_value=self.prs_correct_and_expected_to_be_yielded)
+
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
+
+        expected_prs = self.prs_correct_and_expected_to_be_yielded
+        self.assertEqual(open_prs_to_fast, expected_prs)
+
+
+    def test_get_pulls_query_params(self):
+        """
+        Test query params used for getting the initial PRs from the repository.
+        """
+        self.repo.get_pulls = MagicMock(return_value=[])
+
+        open_prs_to_fast = []
+        for pr in errata.get_open_prs_to_fast(self.repo):
+            open_prs_to_fast.append(pr)
+
+        expected_params = {
             'state': 'open',
             'base': 'master',
             'sort': 'created',
         }
-        self.assertEqual(repo.get_pulls.call_args, (unittest.mock.call(**query_params_expected)))
+        self.assertEqual(self.repo.get_pulls.call_args, (unittest.mock.call(**expected_params)))
+
+
+class LgtmFastPrForErrata(unittest.TestCase):
+    def setUp(self):
+        self.repo = MagicMock()
+        self.github_object_mock = MagicMock()
+        self.github_object_mock.get_repo.return_value = self.repo
+        self.prs_with_html_url_of_expected_pr = [
+            (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 1, "https://errata.devel.redhat.com/advisory/1111", "PR_URL1", "PR_HTML_URL1"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 2, "https://errata.devel.redhat.com/advisory/1234", "PR_URL2", "PR_HTML_URL2"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 3, "https://errata.devel.redhat.com/advisory/5678", "PR_URL3", "PR_HTML_URL3"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4, "https://errata.devel.redhat.com/advisory/1357", "PR_URL4", "PR_HTML_URL4")
+                ],
+                {
+                    "errata_id" : 1357
+                },
+                "PR_HTML_URL4"  # HTML url of a PR which body has the wanted errata id.
+            ),
+           (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 12345, "https://errata.devel.redhat.com/advisory/41", "PR_URL12345", "PR_HTML_URL12345"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 12354, "https://errata.devel.redhat.com/advisory/42", "PR_URL12354", "PR_HTML_URL12354"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 12340, "https://errata.devel.redhat.com/advisory/43", "PR_URL12340", "PR_HTML_URL12340"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 43215, "https://errata.devel.redhat.com/advisory/44", "PR_URL43215", "PR_HTML_URL43215")
+                ],
+                {
+                    "errata_id" : 41
+                },
+                "PR_HTML_URL12345"
+            ),
+            (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 1111, "https://errata.devel.redhat.com/advisory/51", "PR_URL1111", "PR_HTML_URL1111"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 2222, "https://errata.devel.redhat.com/advisory/62", "PR_URL2222", "PR_HTML_URL2222"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 3333, "https://errata.devel.redhat.com/advisory/73", "PR_URL3333", "PR_HTML_URL3333"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4444, "https://errata.devel.redhat.com/advisory/84", "PR_URL4444", "PR_HTML_URL4444")
+                ],
+                {
+                    "errata_id" : 73
+                },
+                "PR_HTML_URL3333"
+            )
+        ]
+        self.prs_with_index_of_expected_pr = [
+            (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 1, "https://errata.devel.redhat.com/advisory/1111", "PR_URL1", "PR_HTML_URL1"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 2, "https://errata.devel.redhat.com/advisory/1234", "PR_URL2", "PR_HTML_URL2"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 3, "https://errata.devel.redhat.com/advisory/5678", "PR_URL3", "PR_HTML_URL3"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4, "https://errata.devel.redhat.com/advisory/1357", "PR_URL4", "PR_HTML_URL4")
+                ],
+                {
+                    "errata_id" : 1357
+                },
+                3   # Index of the PR which has the wanted errata id.
+            ),
+            (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 12345, "https://errata.devel.redhat.com/advisory/41", "PR_URL12345", "PR_HTML_URL12345"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 12354, "https://errata.devel.redhat.com/advisory/42", "PR_URL12354", "PR_HTML_URL12354"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 12340, "https://errata.devel.redhat.com/advisory/43", "PR_URL12340", "PR_HTML_URL12340"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 43215, "https://errata.devel.redhat.com/advisory/44", "PR_URL43215", "PR_HTML_URL43215")
+                ],
+                {
+                    "errata_id" : 41
+                },
+                0
+            ),
+            (
+                [
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 1111, "https://errata.devel.redhat.com/advisory/51", "PR_URL1111", "PR_HTML_URL1111"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 2222, "https://errata.devel.redhat.com/advisory/62", "PR_URL2222", "PR_HTML_URL2222"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)", [], 3333, "https://errata.devel.redhat.com/advisory/73", "PR_URL3333", "PR_HTML_URL3333"),
+                    GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4444, "https://errata.devel.redhat.com/advisory/84", "PR_URL4444", "PR_HTML_URL4444")
+                ],
+                {
+                    "errata_id" : 73
+                },
+                2
+            )
+        ]
 
 
     @patch("github.Github")
-    def test_lgtm_fast_pr_for_errata_test_return_value(self, Github_mock):
-        prs = []
-        labels_empty = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        github_object_mock = MagicMock()
-        github_object_mock.get_repo.return_value = repo
-        Github_mock.return_value = github_object_mock
-
+    def test_return_value_is_correct_for_specific_pr(self, Github_mock):
+        """
+        Test retrieving the HTML url of a PR which is related to a specific errata id.
+        """
         githubrepo = MagicMock()
         githubtoken = MagicMock()
-        message = {
-            "errata_id" : 5678,
-        }
+        Github_mock.return_value = self.github_object_mock
+        param_list = self.prs_with_html_url_of_expected_pr
 
-        html = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
-        self.assertEqual(html, "pr_html_url_5678")
+        for (prs, message, expected_pr_html_url) in param_list:
+            with self.subTest():
+                self.repo.get_pulls = MagicMock(return_value=prs)
+
+                pr_html_url = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+                self.assertEqual(pr_html_url, expected_pr_html_url)
 
 
     @patch("github.Github")
-    def test_lgtm_fast_pr_for_errata_test_creating_issue(self, Github_mock):
-        # Mock Pullrequests in a repository
-        prs = []
-        labels_empty = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        github_object_mock = MagicMock()
-        github_object_mock.get_repo.return_value = repo
-        Github_mock.return_value = github_object_mock
-
+    def test_only_create_issue_on_the_expected_pr(self, Github_mock):
+        """
+        Test creating an issue comment only on the PR which is related to the specific errata id.
+        """
         githubrepo = MagicMock()
         githubtoken = MagicMock()
-        message = {
-            "errata_id" : 5678,
-        }
+        Github_mock.return_value = self.github_object_mock
+        param_list = self.prs_with_index_of_expected_pr
 
-        errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
-        prs[0].create_issue_comment.assert_not_called()
-        prs[1].create_issue_comment.assert_not_called()
-        prs[2].create_issue_comment.assert_not_called()
-        prs[3].create_issue_comment.assert_not_called()
-        prs[4].create_issue_comment.assert_called_once()
+        for (prs, message, expected_index_of_pr_to_create_issue) in param_list:
+            self.repo.get_pulls = MagicMock(return_value=prs)
+            errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+
+            for index, pr in enumerate(prs):
+                with self.subTest():
+                    if index == expected_index_of_pr_to_create_issue:
+                        pr.create_issue_comment.assert_called_once()
+                    else:
+                        pr.create_issue_comment.assert_not_called()
 
 
     @patch("github.Github")
-    def test_lgtm_fast_pr_for_errata_test_issue_format(self, Github_mock):
-        # Mock Pullrequests in a repository
-        prs = []
-        labels_empty = []
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
-
-        repo = MagicMock()
-        repo.get_pulls = MagicMock(return_value=prs)
-
-        github_object_mock = MagicMock()
-        github_object_mock.get_repo.return_value = repo
-        Github_mock.return_value = github_object_mock
-
+    def test_issue_comment_format(self, Github_mock):
+        """
+        Test the format of the created issue comment on the PR which is related to the specific errata id.
+        """
         githubrepo = MagicMock()
         githubtoken = MagicMock()
-        message = {
-            "errata_id" : 5678,
-        }
+        Github_mock.return_value = self.github_object_mock
+        param_list = self.prs_with_index_of_expected_pr
 
-        errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+        for (prs, message, expected_index_of_pr_to_create_issue) in param_list:
+            with self.subTest():
+                self.repo.get_pulls = MagicMock(return_value=prs)
+                errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
 
-        msg = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
-        self.assertEqual(prs[4].create_issue_comment.call_args, (unittest.mock.call(msg)))
+                issue_comment = prs[expected_index_of_pr_to_create_issue].create_issue_comment.call_args
+                expected_issue_comment = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
+                self.assertEqual(issue_comment, (unittest.mock.call(expected_issue_comment)))

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -12,324 +12,9 @@ from collections import namedtuple
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-def test_extract_errata_number_from_body_valid_url():
-    body = "errata is https://errata.devel.redhat.com/advisory/12345"
-    assert errata.extract_errata_number_from_body(body) == 12345
-
-    body = "errata is https://errata.devel.redhat.com/advisory/9999"
-    assert errata.extract_errata_number_from_body(body) == 9999
-
-    body = "errata is https://errata.devel.redhat.com/advisory/"
-    assert errata.extract_errata_number_from_body(body) == None
-
-    body = "errata is https://errata.devel.redhat.com/advisory/invalid"
-    assert errata.extract_errata_number_from_body(body) == None
-
-
-def test_extract_errata_number_from_body_invalid_url():
-    # Possible invalid body
-    # body = "errata is https://errata.devel.redhat.com/advisory/advisory/12345"
-    # assert errata.extract_errata_number_from_body(body) == None
-
-    body = "errata is https://errata.devel.redhat.com/"
-    assert errata.extract_errata_number_from_body(body) == None
-
-
-def test_load():
-    with tempfile.TemporaryDirectory() as tempdir:
-        cachepath = os.path.join(tempdir, "cache.json")
-        cache = {"foo": "bar"}
-
-        with open(cachepath, 'w') as file:
-            json.dump(cache, file)
-
-        loaded_cache = errata.load(cachepath)
-        assert loaded_cache == cache
-
-
-def test_load_nonexisting_file():
-    with tempfile.TemporaryDirectory() as tempdir:
-        return_val = errata.load(os.path.join(
-            tempdir, "non_existing_file.txt"))
-        assert return_val == {}
-
-
-def test_save():
-    with tempfile.TemporaryDirectory() as tempdir:
-        cache = {"foo": "bar"}
-        cachepath = os.path.join(tempdir, "cache.json")
-        errata.save(cachepath, cache)
-        assert os.path.isfile(cachepath)
-
-        with open(cachepath, "r") as file:
-            loaded_cache = json.load(file)
-            assert cache == loaded_cache
-
-
-@patch("json.load")
-@patch("urllib.request.urlopen")
-def test_poll_params_of_url(urlopen_mock, json_load_mock):
-    urlopen_mock.return_value = MagicMock()
-    
-    # Mocked response from API
-    raw_messages = []
-    json_load_mock.return_value = {
-        "raw_messages": raw_messages,
-        "pages": 1
-    }
-    
-    # Call errata.poll function
-    polled_messages = []
-    poll_period = datetime.timedelta(seconds=3600)
-    for message in errata.poll(period=poll_period):
-        polled_messages.append(message)
-
-    #Get arguments of urlib.request.urlopen call inside errata.poll
-    urlopen_called_with_args = urlopen_mock.call_args
-    # Get params of the url
-    url = re.search(r"call\(\'(.*)\'\)", str(urlopen_called_with_args)).group(1)
-    parsed_url = urllib.parse.urlparse(url)
-    params = urllib.parse.parse_qs(parsed_url.query)
-
-    # Assert if parameters complies with datagrepper reference
-    assert int(params["page"][0]) > 0               # Page must be greater than 0
-    assert int(params["rows_per_page"][0]) <= 100   # Must be less than or equal to 100
-    assert params["category"][0] == "errata"        # Should only look for errata category
-    assert params["contains"][0] == "RHOSE"         # Only messages containing RHOSE
-
-
-@patch("json.load")
-@patch("urllib.request.urlopen")
-def test_poll_number_of_returned_pages_is_zero(urlopen_mock, json_load_mock):
-    urlopen_mock.return_value = MagicMock()
-
-    raw_messages = []
-    json_load_mock.return_value = {
-        "raw_messages": raw_messages,
-        "pages": 0
-    }
-
-    polled_messages = []
-    poll_period = datetime.timedelta(seconds=3600)
-    for message in errata.poll(period=poll_period):
-        polled_messages.append(message)
-
-    # Test if data was polled correctly
-    assert polled_messages == []
-
-
-@patch("json.load")
-@patch("urllib.request.urlopen")
-def test_poll_no_results(urlopen_mock, json_load_mock):
-    urlopen_mock.return_value = MagicMock()
-
-    raw_messages = []
-    json_load_mock.return_value = {
-        "raw_messages": raw_messages,
-        "pages": 1
-    }
-
-    polled_messages = []
-    poll_period = datetime.timedelta(seconds=3600)
-    for message in errata.poll(period=poll_period):
-        polled_messages.append(message)
-    
-    # Test if data was polled correctly
-    assert polled_messages == []
-
-
-@patch("json.load")
-@patch("time.sleep")
-@patch("urllib.request.urlopen")
-def test_poll_unresponsive_url_becomes_responsive(urlopen_mock, sleep_mock, json_load_mock):
-    # First time calling request.urlopen returns Exception, 
-    # second time returns mocked HTTPResponse
-    urlopen_mock.side_effect = [
-    Exception("Unresponsive, request.urlopen has failed"), MagicMock()]
-    raw_messages = [
-        {
-            "msg": {
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            }
-        }
-    ]
-    json_load_mock.return_value = {
-        "raw_messages": raw_messages,
-        "pages": 1
-    }
-    
-    # Retrive messages from errata.poll
-    poll_period = datetime.timedelta(seconds=3600)
-    polled_messages = []
-    for message in errata.poll(period=poll_period):
-        polled_messages.append(message)
-
-    # Test if data was polled correctly
-    expected_messages = [x['msg'] for x in raw_messages]
-    assert expected_messages == polled_messages
-
-    # URL wasn't responsive only once, so sleep should be called only once
-    sleep_mock.assert_called_once()
-
-
-@patch("json.load")
-@patch("urllib.request.urlopen")
-def test_poll_multiple_messages(urlopen_mock, json_load_mock):
-    urlopen_mock.return_value = MagicMock()
-    raw_messages = [
-        {
-            "additional_necessary_info": "shouldn't be processed",
-            "msg": {
-                "errata_id": 1,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            }
-        },
-        {
-            "additional_necessary_info": "shouldn't be processed",
-            "msg": {
-                "errata_id": 2,
-                "product": "RHOSE",
-                "to": "QE",
-            }
-        },
-        {
-            "additional_necessary_info": "shouldn't be processed",
-            "msg": {
-                "errata_id": 3,
-                "product": "RHEL",
-                "to": "SHIPPED_LIVE",
-            }
-        },
-        {
-            "additional_necessary_info": "shouldn't be processed",
-            "msg": {
-                "errata_id": 4,
-                "product": "RHEL",
-                "to": "QE",
-            }
-        },
-        {
-            "additional_necessary_info": "shouldn't be processed",
-            "msg": {
-                "errata_id": 5,
-                "product": "RHOSE",
-                "to": "SHIPPED_LIVE",
-            }
-        }
-    ]
-    expected_messages = [
-       {
-            "errata_id": 1,
-            "product": "RHOSE",
-            "to": "SHIPPED_LIVE",
-        },
-        {
-            "errata_id": 5,
-            "product": "RHOSE",
-            "to": "SHIPPED_LIVE",
-        }
-    ]
-    json_load_mock.return_value = {
-        "raw_messages": raw_messages,
-        "pages": 1
-    }
-    # Retrive messages from errata.poll
-    poll_period = datetime.timedelta(seconds=3600)
-    polled_messages = []
-    for message in errata.poll(period=poll_period):
-        polled_messages.append(message)
-    # Test if data was polled correctly
-    assert expected_messages == polled_messages
-
-
-@patch("builtins.print")
-@patch("urllib.request.urlopen")
-def test_notify_no_webhook(urlopen_mock, print_mock):
-    input_msgs = [
-        {
-            "errata_id": 1,
-            "product": "RHOSE",
-            "to": "SHIPPED_LIVE",
-        },
-        {
-            "errata_id": 5,
-            "product": "RHOSE",
-            "to": "SHIPPED_LIVE",
-        }
-    ]
-    errata.notify(message=input_msgs)
-    assert print_mock.call_args == (unittest.mock.call(input_msgs))
-
-    input_msgs = [
-        {
-            "errata_id": 3,
-            "product": "RHEL",
-            "to": "SHIPPED_LIVE",
-        },
-    ]
-    errata.notify(message=input_msgs)
-    assert print_mock.call_args == (unittest.mock.call(input_msgs))
-
-    input_msgs = [
-        {
-            "errata_id": 4,
-            "product": "RHEL",
-            "to": "QE",
-        },
-    ]
-    errata.notify(message=input_msgs)
-    assert print_mock.call_args == (unittest.mock.call(input_msgs))
-
-
-@patch("urllib.request.urlopen")
-def test_notify_format_of_message_pr_not_approved(urlopen_mock):
-    message = {
-        "fulladvisory": "RHEL",
-        "when": "today",
-        "synopsis": "OpenShift Container Platform X.X.X",
-        "uri": "example_uri"
-    }
-
-    errata.notify(message, True)
-
-    msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
-    expected_data = urllib.parse.urlencode({
-        'payload': {
-            'text': msg_text,
-        },
-    }).encode('utf-8')
-    assert urlopen_mock.call_args[1]["data"] == expected_data
-
-
-@patch("urllib.request.urlopen")
-def test_notify_format_of_message_pr_approved(urlopen_mock):
-    message = {
-        "fulladvisory": "RHEL",
-        "when": "today",
-        "synopsis": "OpenShift Container Platform X.X.X",
-        "uri": "example_uri",
-        "approved_pr": "example_approved"
-    }
-
-    errata.notify(message, True)
-
-    msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
-    msg_text += "\nPR {approved_pr} has been approved".format(**message)
-    
-    expected_data = urllib.parse.urlencode({
-        'payload': {
-            'text': msg_text,
-        },
-    }).encode('utf-8')
-    assert urlopen_mock.call_args[1]["data"] == expected_data
-
-
 # Mocking classes of PyGithub
 GitUser = namedtuple("GitUser", "login")
 GitLabel = namedtuple("GitLabel", "name")
-
 class GithubRepoPrMock:
     def __init__(self, user, title, labels=[], number=0, body="", url="", html_url=""):
         self.user = user
@@ -340,7 +25,7 @@ class GithubRepoPrMock:
         self.url = url
         self.html_url = html_url
         self.create_issue_comment = MagicMock()
-
+        
     def __eq__(self, other):
         if not isinstance(other, GithubRepoPrMock):
             return False
@@ -352,218 +37,532 @@ class GithubRepoPrMock:
                 and self.url == other.url       \
                 and self.html_url == other.html_url
 
+class TestErrata(unittest.TestCase):
 
-def test_get_open_prs_to_fast_labels_not_lgtmed():
-    # Create multiple groups of label(s)
-    labels_empty = []
-    labels_bug = [GitLabel("bug")]
-    labels_duplicate = [GitLabel("duplicate")]
-    labels_enhancement = [GitLabel("enhancement")]
-    labels_multiple = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("documentation")]
+    def test_extract_errata_number_from_body_valid_url(self):
+        body = "errata is https://errata.devel.redhat.com/advisory/12345"
+        self.assertEqual(errata.extract_errata_number_from_body(body), 12345)
 
-    # Mock Pullrequests in a repository
-    prs = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_bug, 2))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_duplicate, 3))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_enhancement, 4))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_multiple, 5))
+        body = "errata is https://errata.devel.redhat.com/advisory/9999"
+        self.assertEqual(errata.extract_errata_number_from_body(body), 9999)
 
-    # Mock repo.get_pulls used in errata.get_open_prs_to_fast
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
+        body = "errata is https://errata.devel.redhat.com/advisory/"
+        self.assertEqual(errata.extract_errata_number_from_body(body), None)
 
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
-
-    assert get_prs == prs
+        body = "errata is https://errata.devel.redhat.com/advisory/invalid"
+        self.assertEqual(errata.extract_errata_number_from_body(body), None)
 
 
-def test_get_open_prs_to_fast_labels_lgtmed():
-    # Create multiple groups of label(s) including 'lgtm' at different indexes
-    labels_only_lgtm = [GitLabel("lgtm")]
-    labels_lgtm_index_0 = [GitLabel("lgtm"), GitLabel("bug")]
-    labels_lgtm_index_1 = [GitLabel("duplicate"), GitLabel("lgtm")]
-    labels_lgtm_index_2 = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("lgtm"), GitLabel("documentation")]
-    labels_lgtm_index_last = [GitLabel("enhancement"), GitLabel("bug"), GitLabel("fix"), GitLabel("lgtm")]
+    def test_extract_errata_number_from_body_invalid_url(self):
+        # Possible invalid body
+        # body = "errata is https://errata.devel.redhat.com/advisory/advisory/12345"
+        # assert errata.extract_errata_number_from_body(body) == None
 
-    prs = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_only_lgtm, 1))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channels", labels_lgtm_index_0, 2))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channels", labels_lgtm_index_1, 3))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channels", labels_lgtm_index_2, 4))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channels", labels_lgtm_index_last, 5))
-
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
-
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
-
-    assert get_prs == []
+        body = "errata is https://errata.devel.redhat.com/"
+        self.assertEqual(errata.extract_errata_number_from_body(body), None)
 
 
-def test_get_open_prs_to_fast_user_login():
-    labels_empty = []
-    prs = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1))
-    prs.append(GithubRepoPrMock(GitUser("openshift-user"), "Enable DEF in fast channels", labels_empty, 2))
-    prs.append(GithubRepoPrMock(GitUser("user1234"), "Enable GHI in fast channels", labels_empty, 3))
-    prs.append(GithubRepoPrMock(GitUser("abcdefgh"), "Enable JKL in fast channels", labels_empty, 4))
-    prs.append(GithubRepoPrMock(GitUser("bot-openshift"), "Enable MNO in fast channels", labels_empty, 5))
+    def test_load(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            cachepath = os.path.join(tempdir, "cache.json")
+            cache = {"foo": "bar"}
 
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
+            with open(cachepath, 'w') as file:
+                json.dump(cache, file)
 
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
-
-    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1)]
+            loaded_cache = errata.load(cachepath)
+            self.assertEqual(loaded_cache, cache)
 
 
-def test_get_open_prs_to_fast_channel():
-    labels_empty = []
-    prs = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in stable channel(s)", labels_empty, 1))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in candidate channel(s)", labels_empty, 2))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in candidate channel(s)", labels_empty, 3))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in stable channel(s)", labels_empty, 5))
-
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
-
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
-
-    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4)]
+    def test_load_nonexisting_file(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            return_val = errata.load(os.path.join(tempdir, "non_existing_file.txt"))
+            self.assertEqual(return_val, {})
 
 
-def test_get_open_prs_to_fast_title():
-    labels_empty = []
-    prs = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable ABC in fast channel(s)", labels_empty, 1))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Fix GHI in fast channel(s)", labels_empty, 2))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable DEF in fast channel(s)", labels_empty, 4))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Add features in fast channel(s)", labels_empty, 5))
+    def test_save(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            cache = {"foo": "bar"}
+            cachepath = os.path.join(tempdir, "cache.json")
+            errata.save(cachepath, cache)
+            self.assertTrue(os.path.isfile(cachepath))
 
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
-
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
-
-    assert get_prs == [GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3)]
+            with open(cachepath, "r") as file:
+                loaded_cache = json.load(file)
+                self.assertEqual(cache, loaded_cache)
 
 
-def test_get_open_prs_to_fast_query_params():
-    prs = []
+    @patch("json.load")
+    @patch("urllib.request.urlopen")
+    def test_poll_params_of_url(self, urlopen_mock, json_load_mock):
+        urlopen_mock.return_value = MagicMock()
 
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
+        # Mocked response from API
+        raw_messages = []
+        json_load_mock.return_value = {
+            "raw_messages": raw_messages,
+            "pages": 1
+        }
 
-    get_prs = []
-    for pr in errata.get_open_prs_to_fast(repo):
-        get_prs.append(pr)
+        # Call errata.poll function
+        polled_messages = []
+        poll_period = datetime.timedelta(seconds=3600)
+        for message in errata.poll(period=poll_period):
+            polled_messages.append(message)
 
-    query_params_expected = {
-        'state': 'open',
-        'base': 'master',
-        'sort': 'created',
-    }
-    assert repo.get_pulls.call_args == (unittest.mock.call(**query_params_expected))
+        #Get arguments of urlib.request.urlopen call inside errata.poll
+        urlopen_called_with_args = urlopen_mock.call_args
+        # Get params of the url
+        url = re.search(r"call\(\'(.*)\'\)", str(urlopen_called_with_args)).group(1)
+        parsed_url = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed_url.query)
 
-
-@patch("github.Github")
-def test_lgtm_fast_pr_for_errata_test_return_value(Github_mock):
-    prs = []
-    labels_empty = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
-
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
-
-    github_object_mock = MagicMock()
-    github_object_mock.get_repo.return_value = repo
-    Github_mock.return_value = github_object_mock
-
-    githubrepo = MagicMock()
-    githubtoken = MagicMock()
-    message = {
-        "errata_id" : 5678,
-    }
-
-    html = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
-    assert html == "pr_html_url_5678"
+        # Assert if parameters complies with datagrepper reference
+        self.assertGreater(int(params["page"][0]), 0)               # Page must be greater than 0
+        self.assertLessEqual(int(params["rows_per_page"][0]), 100)  # Must be less than or equal to 100
+        self.assertEqual(params["category"][0], "errata")           # Should only look for errata category
+        self.assertEqual(params["contains"][0], "RHOSE")            # Only messages containing RHOSE
 
 
-@patch("github.Github")
-def test_lgtm_fast_pr_for_errata_test_creating_issue(Github_mock):
-    # Mock Pullrequests in a repository
-    prs = []
-    labels_empty = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+    @patch("json.load")
+    @patch("urllib.request.urlopen")
+    def test_poll_number_of_returned_pages_is_zero(self, urlopen_mock, json_load_mock):
+        urlopen_mock.return_value = MagicMock()
 
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
+        raw_messages = []
+        json_load_mock.return_value = {
+            "raw_messages": raw_messages,
+            "pages": 0
+        }
 
-    github_object_mock = MagicMock()
-    github_object_mock.get_repo.return_value = repo
-    Github_mock.return_value = github_object_mock
+        polled_messages = []
+        poll_period = datetime.timedelta(seconds=3600)
+        for message in errata.poll(period=poll_period):
+            polled_messages.append(message)
 
-    githubrepo = MagicMock()
-    githubtoken = MagicMock()
-    message = {
-        "errata_id" : 5678,
-    }
-    
-    errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
-    prs[0].create_issue_comment.assert_not_called()
-    prs[1].create_issue_comment.assert_not_called()
-    prs[2].create_issue_comment.assert_not_called()
-    prs[3].create_issue_comment.assert_not_called()
-    prs[4].create_issue_comment.assert_called_once()
+        # Test if data was polled correctly
+        self.assertEqual(polled_messages, [])
 
 
-@patch("github.Github")
-def test_lgtm_fast_pr_for_errata_test_issue_format(Github_mock):
-    # Mock Pullrequests in a repository
-    prs = []
-    labels_empty = []
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
-    prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+    @patch("json.load")
+    @patch("urllib.request.urlopen")
+    def test_poll_no_results(self, urlopen_mock, json_load_mock):
+        urlopen_mock.return_value = MagicMock()
 
-    repo = MagicMock()
-    repo.get_pulls = MagicMock(return_value=prs)
+        raw_messages = []
+        json_load_mock.return_value = {
+            "raw_messages": raw_messages,
+            "pages": 1
+        }
 
-    github_object_mock = MagicMock()
-    github_object_mock.get_repo.return_value = repo
-    Github_mock.return_value = github_object_mock
+        polled_messages = []
+        poll_period = datetime.timedelta(seconds=3600)
+        for message in errata.poll(period=poll_period):
+            polled_messages.append(message)
 
-    githubrepo = MagicMock()
-    githubtoken = MagicMock()
-    message = {
-        "errata_id" : 5678,
-    }
+        # Test if data was polled correctly
+        self.assertEqual(polled_messages, [])
 
-    errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
 
-    msg = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
-    assert  prs[4].create_issue_comment.call_args == (unittest.mock.call(msg))
+    @patch("json.load")
+    @patch("time.sleep")
+    @patch("urllib.request.urlopen")
+    def test_poll_unresponsive_url_becomes_responsive(self, urlopen_mock, sleep_mock, json_load_mock):
+        # First time calling request.urlopen returns Exception, 
+        # second time returns mocked HTTPResponse
+        urlopen_mock.side_effect = [
+        Exception("Unresponsive, request.urlopen has failed"), MagicMock()]
+        raw_messages = [
+            {
+                "msg": {
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                }
+            }
+        ]
+        json_load_mock.return_value = {
+            "raw_messages": raw_messages,
+            "pages": 1
+        }
+
+        # Retrive messages from errata.poll
+        poll_period = datetime.timedelta(seconds=3600)
+        polled_messages = []
+        for message in errata.poll(period=poll_period):
+            polled_messages.append(message)
+
+        # Test if data was polled correctly
+        expected_messages = [x['msg'] for x in raw_messages]
+        self.assertEqual(expected_messages, polled_messages)
+
+        # URL wasn't responsive only once, so sleep should be called only once
+        sleep_mock.assert_called_once()
+
+
+    @patch("json.load")
+    @patch("urllib.request.urlopen")
+    def test_poll_multiple_messages(self, urlopen_mock, json_load_mock):
+        urlopen_mock.return_value = MagicMock()
+        raw_messages = [
+            {
+                "additional_necessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 1,
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                }
+            },
+            {
+                "additional_necessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 2,
+                    "product": "RHOSE",
+                    "to": "QE",
+                }
+            },
+            {
+                "additional_necessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 3,
+                    "product": "RHEL",
+                    "to": "SHIPPED_LIVE",
+                }
+            },
+            {
+                "additional_necessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 4,
+                    "product": "RHEL",
+                    "to": "QE",
+                }
+            },
+            {
+                "additional_necessary_info": "shouldn't be processed",
+                "msg": {
+                    "errata_id": 5,
+                    "product": "RHOSE",
+                    "to": "SHIPPED_LIVE",
+                }
+            }
+        ]
+        expected_messages = [
+           {
+                "errata_id": 1,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            },
+            {
+                "errata_id": 5,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            }
+        ]
+        json_load_mock.return_value = {
+            "raw_messages": raw_messages,
+            "pages": 1
+        }
+        # Retrive messages from errata.poll
+        poll_period = datetime.timedelta(seconds=3600)
+        polled_messages = []
+        for message in errata.poll(period=poll_period):
+            polled_messages.append(message)
+        # Test if data was polled correctly
+        self.assertEqual(expected_messages, polled_messages)
+
+
+    @patch("builtins.print")
+    @patch("urllib.request.urlopen")
+    def test_notify_no_webhook(self, urlopen_mock, print_mock):
+        input_msgs = [
+            {
+                "errata_id": 1,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            },
+            {
+                "errata_id": 5,
+                "product": "RHOSE",
+                "to": "SHIPPED_LIVE",
+            }
+        ]
+        errata.notify(message=input_msgs)
+        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
+
+        input_msgs = [
+            {
+                "errata_id": 3,
+                "product": "RHEL",
+                "to": "SHIPPED_LIVE",
+            },
+        ]
+        errata.notify(message=input_msgs)
+        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
+
+        input_msgs = [
+            {
+                "errata_id": 4,
+                "product": "RHEL",
+                "to": "QE",
+            },
+        ]
+        errata.notify(message=input_msgs)
+        self.assertEqual(print_mock.call_args, (unittest.mock.call(input_msgs)))
+
+
+    @patch("urllib.request.urlopen")
+    def test_notify_format_of_message_pr_not_approved(self, urlopen_mock):
+        message = {
+            "fulladvisory": "RHEL",
+            "when": "today",
+            "synopsis": "OpenShift Container Platform X.X.X",
+            "uri": "example_uri"
+        }
+
+        errata.notify(message, True)
+
+        msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
+        expected_data = urllib.parse.urlencode({
+            'payload': {
+                'text': msg_text,
+            },
+        }).encode('utf-8')
+        self.assertEqual(urlopen_mock.call_args[1]["data"], expected_data)
+
+
+    @patch("urllib.request.urlopen")
+    def test_notify_format_of_message_pr_approved(self, urlopen_mock):
+        message = {
+            "fulladvisory": "RHEL",
+            "when": "today",
+            "synopsis": "OpenShift Container Platform X.X.X",
+            "uri": "example_uri",
+            "approved_pr": "example_approved"
+        }
+
+        errata.notify(message, True)
+
+        msg_text = '<!subteam^STE7S7ZU2>: {fulladvisory} shipped {when}: {synopsis} {uri}'.format(**message)
+        msg_text += "\nPR {approved_pr} has been approved".format(**message)
+
+        expected_data = urllib.parse.urlencode({
+            'payload': {
+                'text': msg_text,
+            },
+        }).encode('utf-8')
+        self.assertEqual(urlopen_mock.call_args[1]["data"], expected_data)
+
+
+    def test_get_open_prs_to_fast_labels_not_lgtmed(self):
+        # Create multiple groups of label(s)
+        labels_empty = []
+        labels_bug = [GitLabel("bug")]
+        labels_duplicate = [GitLabel("duplicate")]
+        labels_enhancement = [GitLabel("enhancement")]
+        labels_multiple = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("documentation")]
+
+        # Mock Pullrequests in a repository
+        prs = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_bug, 2))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_duplicate, 3))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_enhancement, 4))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_multiple, 5))
+
+        # Mock repo.get_pulls used in errata.get_open_prs_to_fast
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        self.assertEqual(get_prs, prs)
+
+
+    def test_get_open_prs_to_fast_labels_lgtmed(self):
+        # Create multiple groups of label(s) including 'lgtm' at different indexes
+        labels_only_lgtm = [GitLabel("lgtm")]
+        labels_lgtm_index_0 = [GitLabel("lgtm"), GitLabel("bug")]
+        labels_lgtm_index_1 = [GitLabel("duplicate"), GitLabel("lgtm")]
+        labels_lgtm_index_2 = [GitLabel("bug"), GitLabel("duplicate"), GitLabel("lgtm"), GitLabel("documentation")]
+        labels_lgtm_index_last = [GitLabel("enhancement"), GitLabel("bug"), GitLabel("fix"), GitLabel("lgtm")]
+
+        prs = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_only_lgtm, 1))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channels", labels_lgtm_index_0, 2))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channels", labels_lgtm_index_1, 3))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channels", labels_lgtm_index_2, 4))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channels", labels_lgtm_index_last, 5))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        self.assertEqual(get_prs, [])
+
+
+    def test_get_open_prs_to_fast_user_login(self):
+        labels_empty = []
+        prs = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1))
+        prs.append(GithubRepoPrMock(GitUser("openshift-user"), "Enable DEF in fast channels", labels_empty, 2))
+        prs.append(GithubRepoPrMock(GitUser("user1234"), "Enable GHI in fast channels", labels_empty, 3))
+        prs.append(GithubRepoPrMock(GitUser("abcdefgh"), "Enable JKL in fast channels", labels_empty, 4))
+        prs.append(GithubRepoPrMock(GitUser("bot-openshift"), "Enable MNO in fast channels", labels_empty, 5))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channels", labels_empty, 1)])
+
+
+    def test_get_open_prs_to_fast_channel(self):
+        labels_empty = []
+        prs = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in stable channel(s)", labels_empty, 1))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in candidate channel(s)", labels_empty, 2))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in candidate channel(s)", labels_empty, 3))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in stable channel(s)", labels_empty, 5))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4)])
+
+
+    def test_get_open_prs_to_fast_title(self):
+        labels_empty = []
+        prs = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable ABC in fast channel(s)", labels_empty, 1))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Fix GHI in fast channel(s)", labels_empty, 2))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Disable DEF in fast channel(s)", labels_empty, 4))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Add features in fast channel(s)", labels_empty, 5))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        self.assertEqual(get_prs, [GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3)])
+
+
+    def test_get_open_prs_to_fast_query_params(self):
+        prs = []
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        get_prs = []
+        for pr in errata.get_open_prs_to_fast(repo):
+            get_prs.append(pr)
+
+        query_params_expected = {
+            'state': 'open',
+            'base': 'master',
+            'sort': 'created',
+        }
+        self.assertEqual(repo.get_pulls.call_args, (unittest.mock.call(**query_params_expected)))
+
+
+    @patch("github.Github")
+    def test_lgtm_fast_pr_for_errata_test_return_value(self, Github_mock):
+        prs = []
+        labels_empty = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        github_object_mock = MagicMock()
+        github_object_mock.get_repo.return_value = repo
+        Github_mock.return_value = github_object_mock
+
+        githubrepo = MagicMock()
+        githubtoken = MagicMock()
+        message = {
+            "errata_id" : 5678,
+        }
+
+        html = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+        self.assertEqual(html, "pr_html_url_5678")
+
+
+    @patch("github.Github")
+    def test_lgtm_fast_pr_for_errata_test_creating_issue(self, Github_mock):
+        # Mock Pullrequests in a repository
+        prs = []
+        labels_empty = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        github_object_mock = MagicMock()
+        github_object_mock.get_repo.return_value = repo
+        Github_mock.return_value = github_object_mock
+
+        githubrepo = MagicMock()
+        githubtoken = MagicMock()
+        message = {
+            "errata_id" : 5678,
+        }
+
+        errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+        prs[0].create_issue_comment.assert_not_called()
+        prs[1].create_issue_comment.assert_not_called()
+        prs[2].create_issue_comment.assert_not_called()
+        prs[3].create_issue_comment.assert_not_called()
+        prs[4].create_issue_comment.assert_called_once()
+
+
+    @patch("github.Github")
+    def test_lgtm_fast_pr_for_errata_test_issue_format(self, Github_mock):
+        # Mock Pullrequests in a repository
+        prs = []
+        labels_empty = []
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable ABC in fast channel(s)", labels_empty, 1, "https://errata.devel.redhat.com/advisory/1234", "pr_url_1234", "pr_html_url_1234"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable GHI in fast channel(s)", labels_empty, 2, "https://errata.devel.redhat.com/advisory/2345", "pr_url_2345", "pr_html_url_2345"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable JKL in fast channel(s)", labels_empty, 3, "https://errata.devel.redhat.com/advisory/3456", "pr_url_3456", "pr_html_url_3456"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable DEF in fast channel(s)", labels_empty, 4, "https://errata.devel.redhat.com/advisory/4567", "pr_url_4567", "pr_html_url_4567"))
+        prs.append(GithubRepoPrMock(GitUser("openshift-bot"), "Enable MNO in fast channel(s)", labels_empty, 5, "https://errata.devel.redhat.com/advisory/5678", "pr_url_5678", "pr_html_url_5678"))
+
+        repo = MagicMock()
+        repo.get_pulls = MagicMock(return_value=prs)
+
+        github_object_mock = MagicMock()
+        github_object_mock.get_repo.return_value = repo
+        Github_mock.return_value = github_object_mock
+
+        githubrepo = MagicMock()
+        githubtoken = MagicMock()
+        message = {
+            "errata_id" : 5678,
+        }
+
+        errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
+
+        msg = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
+        self.assertEqual(prs[4].create_issue_comment.call_args, (unittest.mock.call(msg)))

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -102,37 +102,37 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
                 self.assertEqual(errata.extract_errata_number_from_body(url), expected)
 
 
-class ErrataTest(unittest.TestCase):
-    def test_load(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            cachepath = os.path.join(tempdir, "cache.json")
-            cache = {"foo": "bar"}
-
-            with open(cachepath, 'w') as file:
-                json.dump(cache, file)
-
-            loaded_cache = errata.load(cachepath)
-            self.assertEqual(loaded_cache, cache)
-
-
+class SaveAndLoadTest(unittest.TestCase):
     def test_load_nonexisting_file(self):
+        """
+        Test loading a nonexisting file.
+        """
         with tempfile.TemporaryDirectory() as tempdir:
-            return_val = errata.load(os.path.join(tempdir, "non_existing_file.txt"))
-            self.assertEqual(return_val, {})
-
-
-    def test_save(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            cache = {"foo": "bar"}
             cachepath = os.path.join(tempdir, "cache.json")
-            errata.save(cachepath, cache)
-            self.assertTrue(os.path.isfile(cachepath))
-
-            with open(cachepath, "r") as file:
-                loaded_cache = json.load(file)
-                self.assertEqual(cache, loaded_cache)
+            self.assertCountEqual(errata.load(cachepath), {})
 
 
+    def test_save_and_load_as_a_pair(self):
+        """
+        Test using errata.save and errata.load as a pair to confirm their functionality.
+        """
+        param_list = [
+            (),
+            ({"foo": "bar"}),
+            ({"value": "1234"}),
+            ({"company": "Red Hat"}),
+            ({"foo": "bar"}, {"value": "1234"}, {"errata": "1234"}),
+            ({"value": "1234"}, {"foo": "bar"}, {"errata": "1234"})
+        ]
+        for cache in param_list:
+            with self.subTest():
+                with tempfile.TemporaryDirectory() as tempdir:
+                    cachepath = os.path.join(tempdir, "cache.json")
+                    errata.save(cachepath, cache)
+                    self.assertCountEqual(errata.load(cachepath), cache)
+
+
+class ErrataTest(unittest.TestCase):
     @patch("json.load")
     @patch("urllib.request.urlopen")
     def test_poll_params_of_url(self, urlopen_mock, json_load_mock):


### PR DESCRIPTION
Initial unit tests for the errata-webhook.

Pull request related to https://issues.redhat.com/browse/OTA-356.