### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/hack"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "wking"
+      - "vrutkovs"
+      - "PratikMahajan"
+      - "LalatenduMohanty"


### PR DESCRIPTION
This would setup a bot to bump dependencies daily if update is available.

See https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically for more information.
Reference: https://issues.redhat.com/browse/OTA-336