### PR TITLE
dependabot: fix directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/hack"
+    directory: "/graph-data.rs"
     schedule:
       interval: "daily"
     reviewers:


### PR DESCRIPTION
Cargo.toml is in `graph-data.rs`, not `hack`

Fixes issue in https://github.com/openshift/cincinnati-graph-data/network/updates/96914164