### PR TITLE
blocked-edges/4.7: Block all edges from 4.6

### DIFF
--- a/blocked-edges/4.7.1.yaml
+++ b/blocked-edges/4.7.1.yaml
@@ -1,4 +1,3 @@
-to: 4.7.0
+to: 4.7.1
 from: 4\.6\..*
-# 4.6.19 doesn't exist yet, so block the edge to 4.7.0 until we know what it will contain
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539

--- a/blocked-edges/4.7.2.yaml
+++ b/blocked-edges/4.7.2.yaml
@@ -1,4 +1,3 @@
-to: 4.7.0
+to: 4.7.2
 from: 4\.6\..*
-# 4.6.19 doesn't exist yet, so block the edge to 4.7.0 until we know what it will contain
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539

--- a/blocked-edges/4.7.3.yaml
+++ b/blocked-edges/4.7.3.yaml
@@ -1,4 +1,3 @@
-to: 4.7.0
+to: 4.7.3
 from: 4\.6\..*
-# 4.6.19 doesn't exist yet, so block the edge to 4.7.0 until we know what it will contain
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539


### PR DESCRIPTION
4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: [rhbz#1935539][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1935539