### PR TITLE
build-suggestions/4.7: Bump z_min to 4.7.0

### DIFF
--- a/build-suggestions/4.7.yaml
+++ b/build-suggestions/4.7.yaml
@@ -5,7 +5,7 @@ default:
   minor_min: 4.6.15
   minor_max: 4.6.9999
   minor_block_list: []
-  z_min: 4.7.0-fc.1
+  z_min: 4.7.0
   z_max: 4.7.9999
   z_block_list: []
 # s390x:


### PR DESCRIPTION
We've had a few stable releases out in 4.7.z now, so anyone still running the FCs and RCs should be able to update to one of those (e.g. 4.7.2), and then update from there on to later 4.7.z.  Raising this floor makes life easier for ART, because they attempt to validate all the update edges we bake into release images.  Raising the floor means we no longer need to test FC and RC -> 4.7.z for new releases.