### PR TITLE
build-suggestions/4.7: Raise *_min to 4.y.9999

### DIFF
--- a/build-suggestions/4.7.yaml
+++ b/build-suggestions/4.7.yaml
@@ -2,10 +2,10 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.6.15
+  minor_min: 4.6.9999
   minor_max: 4.6.9999
   minor_block_list: []
-  z_min: 4.7.0
+  z_min: 4.7.9999
   z_max: 4.7.9999
   z_block_list: []
 # s390x:


### PR DESCRIPTION
[rhbz#1943143][1], child of [4.8's rhbz#1942207][2], didn't make it into 4.7.5, so we want to block all edges into 4.7.5 (like we did for 4.7.4 in 26b44c6efe, #731).  Raising the suggestion floors into the distant future will get 4.7.5 built without update suggestions, which will avoid a confusing message about update sources in the generated errata message.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1943143
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1942207