### PR TITLE
Partially revert "build-suggestions/4.7: Raise *_min to 4.y.9999"

### DIFF
--- a/build-suggestions/4.7.yaml
+++ b/build-suggestions/4.7.yaml
@@ -2,10 +2,10 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.6.9999
+  minor_min: 4.6.24
   minor_max: 4.6.9999
   minor_block_list: []
-  z_min: 4.7.9999
+  z_min: 4.7.0
   z_max: 4.7.9999
   z_block_list: []
 # s390x:


### PR DESCRIPTION
This partially reverts commit f190365bec2619b041a8c5035f92baf7429b6a94, #732.

The vSphere hostname thing is [verified fixed in 4.7][1].  And [the vSphere HW thing][2].  A new-in-4.7.3 OVN thing that we'd [been on the
fence about blocking on][3] should also [be fixed][4].

4.6.4 will fix [an issue][5] with non-control-plane UPI vSphere MachineConfigPools getting stuck if you update to 4.7 while they're churning a 4.6 udpate, so we're setting the 4.6 floor at 4.6.24.  Folks on older 4.6 will have to get to at least 4.6.24 to pick up that fix before they can go to 4.7.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1943143#c4
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1941246#c6
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1940498#c12
[4]: https://bugzilla.redhat.com/show_bug.cgi?id=1942702#c1
[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1940585#c18