### PR TITLE
errata-webhook: add additional unit tests, refactor, and a fix

### DIFF
--- a/hack/errata.py
+++ b/hack/errata.py
@@ -79,7 +79,7 @@ def process_message(message, cache, excluded_cache, webhook, githubrepo, githubt
         if message['synopsis'] not in excluded_cache:
             _LOGGER.debug('{fulladvisory} shipped {when} does not match synopsis regular expression: {synopsis}'.format(**message))
             excluded_cache[message['synopsis']] = message['fulladvisory']
-            return
+        return
     if cache and message['fulladvisory'] in cache:
         return
     synopsis_groups = synopsis_match.groupdict()

--- a/hack/errata.py
+++ b/hack/errata.py
@@ -49,14 +49,12 @@ def save(path, cache):
 
 def run(poll_period=datetime.timedelta(seconds=3600),
         cache=None,
-        excluded_cache=None,
         webhook=None,
         githubrepo=None,
         githubtoken=None,
         **kwargs):
     next_time = datetime.datetime.now()
-    if excluded_cache is None:
-        excluded_cache = {}
+    excluded_cache = {}
     while True:
         _LOGGER.debug('poll for messages')
         for message in poll(period=2*poll_period, **kwargs):
@@ -287,11 +285,9 @@ if __name__ == '__main__':
 
     cache_path = '.errata.json'
     cache = load(path=cache_path)
-    excluded_cache = {}
     try:
         run(
             cache=cache,
-            excluded_cache=excluded_cache,
             webhook=args.webhook.strip(),
             githubrepo=args.githubrepo.strip(),
             githubtoken=args.githubtoken.strip(),

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -1,20 +1,24 @@
 import datetime
-import errata
-import github
-import http
-import json
 import os
-import re
 import tempfile
 import unittest
 import urllib
-from collections import namedtuple
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import errata
 
-GithubUserMock = namedtuple("GithubUserMock", "login")
-GithubLabelMock = namedtuple("GithubLabelMock", "name")
+
+class GithubUserMock():
+    def __init__(self, login):
+        self.login = login
+
+
+class GithubLabelMock():
+    def __init__(self, name):
+        self.name = name
+
+
 class GithubPRMock:
     def __init__(self, user, title, labels=[], number=0, body="", url="", html_url=""):
         self.user = user
@@ -25,23 +29,24 @@ class GithubPRMock:
         self.url = url
         self.html_url = html_url
         self.create_issue_comment = MagicMock()
-        
+
     def __eq__(self, other):
         if not isinstance(other, GithubPRMock):
             return False
-        return      self.user == other.user     \
-                and self.title == other.title   \
-                and self.labels == other.labels \
-                and self.number == other.number \
-                and self.body == other.body     \
-                and self.url == other.url       \
-                and self.html_url == other.html_url
+        return self.user == other.user          \
+            and self.title == other.title       \
+            and self.labels == other.labels     \
+            and self.number == other.number     \
+            and self.body == other.body         \
+            and self.url == other.url           \
+            and self.html_url == other.html_url
 
 
 class ExtractErrataNumberFromBodyTest(unittest.TestCase):
-    def test_valid_url(self):
+    def test_url_starting_with_valid_errata_marker(self):
         """
         Test errata number extraction from valid URLs.
+        URLs starting with corresponding ERRATA_MARKER in errata.py.
         """
         param_list = [
             ('https://errata.devel.redhat.com/advisory/12345', 12345),
@@ -55,52 +60,49 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
             with self.subTest():
                 self.assertEqual(errata.extract_errata_number_from_body(url), expected)
 
-
     def test_invalid_url(self):
         """
         Test errata number extraction from invalid URLs.
         """
         param_list = [
-            ('http://errata.devel.redhat.com/advisory/12345', None),
-            ('https://errrata.devel.redhat.com/advisory/12345', None),
-            ('https://errata.dvel.reddhat.com/advisori/12345', None),
-            ('https://errata.devel.redhat.com/12345', None),
-            ('https://errata.devel.com/advisory/12345', None),
-            ('https://errata.redhat.com/advisory/12345', None),
-            ('https://devel.redhat.com/advisory/12345', None),
-            ('https://redhat.com/advisory/12345', None),
-            ('https://errata.com/advisory/12345', None)
+            'http://errata.devel.redhat.com/advisory/12345',
+            'https://errrata.devel.redhat.com/advisory/12345',
+            'https://errata.dvel.reddhat.com/advisori/12345',
+            'https://errata.devel.redhat.com/12345',
+            'https://errata.devel.com/advisory/12345',
+            'https://errata.redhat.com/advisory/12345',
+            'https://devel.redhat.com/advisory/12345',
+            'https://redhat.com/advisory/12345',
+            'https://errata.com/advisory/12345'
         ]
-        for (url, expected) in param_list:
+        for url in param_list:
             with self.subTest():
-                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
-
+                self.assertEqual(errata.extract_errata_number_from_body(url), None)
 
     def test_missing_url(self):
         """
         Test errata number extraction from missing URLs.
         """
         param_list = [
-            ('errata', None),
-            ('12345', None),
-            ('errata is 12345', None)
+            'errata',
+            '12345',
+            'errata is 12345'
         ]
-        for (url, expected) in param_list:
+        for url in param_list:
             with self.subTest():
-                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
-
+                self.assertEqual(errata.extract_errata_number_from_body(url), None)
 
     def test_url_is_not_on_the_first_line(self):
         """
         Test errata number extraction from valid URLs which are not located on the first line.
         """
         param_list = [
-            ('\nhttps://errata.devel.redhat.com/advisory/12345', None),
-            ('\n\nhttps://errata.devel.redhat.com/advisory/12345', None),
+            '\nhttps://errata.devel.redhat.com/advisory/12345',
+            '\n\nhttps://errata.devel.redhat.com/advisory/12345'
         ]
-        for (url, expected) in param_list:
+        for url in param_list:
             with self.subTest():
-                self.assertEqual(errata.extract_errata_number_from_body(url), expected)
+                self.assertEqual(errata.extract_errata_number_from_body(url), None)
 
 
 class SaveAndLoadTest(unittest.TestCase):
@@ -111,7 +113,6 @@ class SaveAndLoadTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             cachepath = os.path.join(tempdir, "cache.json")
             self.assertCountEqual(errata.load(cachepath), {})
-
 
     def test_save_and_load_as_a_pair(self):
         """
@@ -135,66 +136,76 @@ class SaveAndLoadTest(unittest.TestCase):
 
 class PollTest(unittest.TestCase):
     def setUp(self):
-        self.raw_messages_containing_msg_expected_to_be_polled = [
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 11,
-                    "product": "RHOSE",
-                    "to": "SHIPPED_LIVE",
+        self.raw_messages = [
+            (
+                True,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 11,
+                        "product": "RHOSE",
+                        "to": "SHIPPED_LIVE",
+                    }
                 }
-            },
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 12,
-                    "product": "RHOSE",
-                    "to": "SHIPPED_LIVE",
+            ),
+            (
+                True,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 12,
+                        "product": "RHOSE",
+                        "to": "SHIPPED_LIVE",
+                    }
                 }
-            }
+            ),
+            (
+                False,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 21,
+                        "product": "RHOSE",
+                        "to": "QE",
+                    }
+                }
+            ),
+            (
+                False,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 22,
+                        "product": "RHEL",
+                        "to": "SHIPPED_LIVE",
+                    }
+                }
+            ),
+            (
+                False,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 23,
+                        "product": "RHEL",
+                        "to": "QE",
+                    }
+                }
+            ),
+            (
+                False,
+                {
+                    "additional_unnecessary_info": "shouldn't be processed",
+                    "msg": {
+                        "errata_id": 24,
+                        "product": "SHIPPED_LIVE",
+                        "to": "RHOSE",
+                    }
+                }
+            )
         ]
-        self.raw_messages_containing_msg_expected_not_to_be_polled = [
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 21,
-                    "product": "RHOSE",
-                    "to": "QE",
-                }
-            },
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 22,
-                    "product": "RHEL",
-                    "to": "SHIPPED_LIVE",
-                }
-            },
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 23,
-                    "product": "RHEL",
-                    "to": "QE",
-                }
-            },
-            {
-                "additional_unnecessary_info": "shouldn't be processed",
-                "msg": {
-                    "errata_id": 24,
-                    "product": "SHIPPED_LIVE",
-                    "to": "RHOSE",
-                }
-            }
-        ]
-        self.multiple_raw_messages =                                    \
-        self.raw_messages_containing_msg_expected_to_be_polled +        \
-        self.raw_messages_containing_msg_expected_not_to_be_polled
-
-        self.multiple_msg_expected_to_be_polled = [
-            raw_message['msg'] for raw_message
-            in self.raw_messages_containing_msg_expected_to_be_polled]
-
+        self.valid_messages = [x[1] for x in self.raw_messages if x[0]]
+        self.invalid_messages = [x[1] for x in self.raw_messages if not x[0]]
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
@@ -222,7 +233,6 @@ class PollTest(unittest.TestCase):
         self.assertEqual(params["category"][0], "errata")           # Should only look for errata category
         self.assertEqual(params["contains"][0], "RHOSE")            # Only messages containing RHOSE
 
-
     @patch("json.load")
     @patch("urllib.request.urlopen")
     def test_number_of_returned_pages_is_zero(self, urlopen_mock, json_load_mock):
@@ -239,7 +249,6 @@ class PollTest(unittest.TestCase):
         for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
         self.assertEqual(polled_messages, [])
-
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
@@ -258,7 +267,6 @@ class PollTest(unittest.TestCase):
             polled_messages.append(message)
         self.assertEqual(polled_messages, [])
 
-
     @patch("json.load")
     @patch("time.sleep")
     @patch("urllib.request.urlopen")
@@ -267,9 +275,11 @@ class PollTest(unittest.TestCase):
         Test polling messages if request.urlopen throws exception on a first try.
         """
         urlopen_mock.side_effect = [
-        Exception("Unresponsive, request.urlopen has failed"), MagicMock()]
+            Exception("Unresponsive, request.urlopen has failed"),
+            MagicMock()
+        ]
         json_load_mock.return_value = {
-            "raw_messages": self.multiple_raw_messages,
+            "raw_messages": self.valid_messages,
             "pages": 1
         }
 
@@ -277,9 +287,9 @@ class PollTest(unittest.TestCase):
         for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
 
-        sleep_mock.assert_called_once() # URL wasn't responsive only once, so time.sleep should have been called only once
-        self.assertEqual(polled_messages, self.multiple_msg_expected_to_be_polled)
-
+        sleep_mock.assert_called_once()  # URL wasn't responsive only once, so time.sleep should have been called only once
+        expected_msgs = [x['msg'] for x in self.valid_messages]
+        self.assertEqual(polled_messages, expected_msgs)
 
     @patch("json.load")
     @patch("urllib.request.urlopen")
@@ -288,15 +298,17 @@ class PollTest(unittest.TestCase):
         Test polling messages from raw messages that include wanted and unwanted messages.
         """
         urlopen_mock.return_value = MagicMock()
+        messages = self.valid_messages + self.invalid_messages
         json_load_mock.return_value = {
-            "raw_messages": self.multiple_raw_messages,
+            "raw_messages": messages,
             "pages": 1
         }
 
         polled_messages = []
         for message in errata.poll(period=datetime.timedelta(seconds=3600)):
             polled_messages.append(message)
-        self.assertEqual(polled_messages, self.multiple_msg_expected_to_be_polled)
+        expected_msgs = [x['msg'] for x in self.valid_messages]
+        self.assertEqual(polled_messages, expected_msgs)
 
 
 class NotifyTest(unittest.TestCase):
@@ -313,11 +325,11 @@ class NotifyTest(unittest.TestCase):
                     "uri": "Public_Errata_URI_11",
                     "approved_pr": "PR_HTML_URL_11"
                 },
-                '<!subteam^STE7S7ZU2>: '\
-                'RHSA-2020:0000-00 shipped '\
-                '2021-01-01 12:00:00 UTC: '\
-                'OpenShift Container Platform 4.6 GA Images '\
-                'Public_Errata_URI_11'\
+                '<!subteam^STE7S7ZU2>: '
+                'RHSA-2020:0000-00 shipped '
+                '2021-01-01 12:00:00 UTC: '
+                'OpenShift Container Platform 4.6 GA Images '
+                'Public_Errata_URI_11'
                 '\nPR PR_HTML_URL_11 has been approved'
             ),
             (
@@ -331,11 +343,11 @@ class NotifyTest(unittest.TestCase):
                     "uri": "Public_Errata_URI_12",
                     "approved_pr": "PR_HTML_URL_12"
                 },
-                '<!subteam^STE7S7ZU2>: '\
-                'RHSA-2020:2000-20 shipped '\
-                '2021-01-02 13:00:00 UTC: '\
-                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '\
-                'Public_Errata_URI_12'\
+                '<!subteam^STE7S7ZU2>: '
+                'RHSA-2020:2000-20 shipped '
+                '2021-01-02 13:00:00 UTC: '
+                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '
+                'Public_Errata_URI_12'
                 '\nPR PR_HTML_URL_12 has been approved'
             )
         ]
@@ -350,11 +362,11 @@ class NotifyTest(unittest.TestCase):
                     "when": "2021-01-01 12:00:00 UTC",
                     "uri": "Public_Errata_URI_21",
                 },
-                '<!subteam^STE7S7ZU2>: '\
-                'RHSA-2020:0000-00 shipped '\
-                '2021-01-01 12:00:00 UTC: '\
-                'OpenShift Container Platform 4.6 GA Images '\
-                'Public_Errata_URI_21'\
+                '<!subteam^STE7S7ZU2>: '
+                'RHSA-2020:0000-00 shipped '
+                '2021-01-01 12:00:00 UTC: '
+                'OpenShift Container Platform 4.6 GA Images '
+                'Public_Errata_URI_21'
             ),
             (
                 {
@@ -366,29 +378,28 @@ class NotifyTest(unittest.TestCase):
                     "when": "2021-01-02 13:00:00 UTC",
                     "uri": "Public_Errata_URI_22",
                 },
-                '<!subteam^STE7S7ZU2>: '\
-                'RHSA-2020:2000-20 shipped '\
-                '2021-01-02 13:00:00 UTC: '\
-                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '\
+                '<!subteam^STE7S7ZU2>: '
+                'RHSA-2020:2000-20 shipped '
+                '2021-01-02 13:00:00 UTC: '
+                'Moderate: OpenShift Container Platform 4.5.20 bug fix and golang security update '
                 'Public_Errata_URI_22'
             )
         ]
-        self.messages_multiple =    self.messages_including_approved_pr +   \
-                                    self.messages_not_including_approved_pr
-
+        self.messages =                                 \
+            self.messages_including_approved_pr +       \
+            self.messages_not_including_approved_pr
 
     @patch("builtins.print")
     @patch("urllib.request.urlopen")
     def test_no_webhook(self, urlopen_mock, print_mock):
         """
-        Test functionality of notify if parameter webhook is set to its default value. 
+        Test functionality of notify if parameter webhook is set to its default value.
         """
-        for message in self.messages_multiple:
+        for message in self.messages:
             with self.subTest():
-                    errata.notify(message[0])
-                    expected_message = message[0]
-                    self.assertEqual(print_mock.call_args, unittest.mock.call(expected_message))
-
+                errata.notify(message[0])
+                expected_message = message[0]
+                self.assertEqual(print_mock.call_args, unittest.mock.call(expected_message))
 
     @patch("urllib.request.urlopen")
     def test_format_of_message_not_including_approved_pr(self, urlopen_mock):
@@ -399,16 +410,15 @@ class NotifyTest(unittest.TestCase):
         """
         for (message, expected_message_in_data_to_be_uploaded) in self.messages_not_including_approved_pr:
             with self.subTest():
-                    expected_data_to_be_uploaded = urllib.parse.urlencode({
-                        'payload' : {
-                            'text' : expected_message_in_data_to_be_uploaded
-                        }
-                    }).encode('utf-8')
-                    
-                    errata.notify(message, MagicMock())
-                    uploaded_data = urlopen_mock.call_args[1]['data']
-                    self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
+                expected_data_to_be_uploaded = urllib.parse.urlencode({
+                    'payload': {
+                        'text': expected_message_in_data_to_be_uploaded
+                    }
+                }).encode('utf-8')
 
+                errata.notify(message, MagicMock())
+                uploaded_data = urlopen_mock.call_args[1]['data']
+                self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
 
     @patch("urllib.request.urlopen")
     def test_format_of_message_including_approved_pr(self, urlopen_mock):
@@ -419,15 +429,15 @@ class NotifyTest(unittest.TestCase):
         """
         for (message, expected_message_in_data_to_be_uploaded) in self.messages_including_approved_pr:
             with self.subTest():
-                    expected_data_to_be_uploaded = urllib.parse.urlencode({
-                        'payload' : {
-                            'text' : expected_message_in_data_to_be_uploaded
-                        }
-                    }).encode('utf-8')
+                expected_data_to_be_uploaded = urllib.parse.urlencode({
+                    'payload': {
+                        'text': expected_message_in_data_to_be_uploaded
+                    }
+                }).encode('utf-8')
 
-                    errata.notify(message, MagicMock())
-                    uploaded_data = urlopen_mock.call_args[1]['data']
-                    self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
+                errata.notify(message, MagicMock())
+                uploaded_data = urlopen_mock.call_args[1]['data']
+                self.assertEqual(uploaded_data, expected_data_to_be_uploaded)
 
 
 class GetOpenPRsToFastTest(unittest.TestCase):
@@ -438,15 +448,15 @@ class GetOpenPRsToFastTest(unittest.TestCase):
                 GithubLabelMock('lgtm')
             ],
             [
-                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('lgtm'),
                 GithubLabelMock('documentation'), GithubLabelMock('invalid')
             ],
             [
-                GithubLabelMock('wontfix'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('wontfix'), GithubLabelMock('lgtm'),
                 GithubLabelMock('question'), GithubLabelMock('invalid')
             ],
             [
-                GithubLabelMock('help wanted'), GithubLabelMock('lgtm'), 
+                GithubLabelMock('help wanted'), GithubLabelMock('lgtm'),
                 GithubLabelMock('good first issue'), GithubLabelMock('bug')
             ]
         ]
@@ -454,15 +464,15 @@ class GetOpenPRsToFastTest(unittest.TestCase):
             [
             ],
             [
-                GithubLabelMock('wontfix'), GithubLabelMock('bug'), 
+                GithubLabelMock('wontfix'), GithubLabelMock('bug'),
                 GithubLabelMock('question'), GithubLabelMock('invalid')
             ],
             [
-                GithubLabelMock('help wanted'), GithubLabelMock('invalid'), 
+                GithubLabelMock('help wanted'), GithubLabelMock('invalid'),
                 GithubLabelMock('good first issue'), GithubLabelMock('duplicate')
             ],
             [
-                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('invalid'), 
+                GithubLabelMock('bug'), GithubLabelMock('duplicate'), GithubLabelMock('invalid'),
                 GithubLabelMock('documentation'), GithubLabelMock('enhancement')
             ]
         ]
@@ -471,7 +481,7 @@ class GetOpenPRsToFastTest(unittest.TestCase):
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.1.2 in fast channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)"),
-            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.6.0 in fast channel(s)"), 
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.6.0 in fast channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[0]),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[1]),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", self.labels_multiple_not_including_lgtm[2]),
@@ -502,10 +512,9 @@ class GetOpenPRsToFastTest(unittest.TestCase):
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in FAST channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in faast channel(s)"),
-            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in stable channel(s)"), 
+            GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in stable channel(s)"),
             GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in candidate channel(s)")
         ]
-
 
     def test_prs_including_the_lgtm_label(self):
         """
@@ -520,7 +529,6 @@ class GetOpenPRsToFastTest(unittest.TestCase):
         expected_prs = []
         self.assertEqual(open_prs_to_fast, expected_prs)
 
-
     def test_prs_author_is_not_openshift_bot(self):
         """
         Test getting PRs whose author is not openshift-bot. These PRs should be skipped.
@@ -533,7 +541,6 @@ class GetOpenPRsToFastTest(unittest.TestCase):
 
         expected_prs = []
         self.assertEqual(open_prs_to_fast, expected_prs)
-
 
     def test_unknown_prs_should_be_skipped(self):
         """
@@ -548,7 +555,6 @@ class GetOpenPRsToFastTest(unittest.TestCase):
         expected_prs = []
         self.assertEqual(open_prs_to_fast, expected_prs)
 
-
     def test_ignore_prs_which_dont_target_fast(self):
         """
         Test getting PRs which don't target fast. These PRs should be skipped.
@@ -562,7 +568,6 @@ class GetOpenPRsToFastTest(unittest.TestCase):
         expected_prs = []
         self.assertEqual(open_prs_to_fast, expected_prs)
 
-
     def test_correct_prs_should_be_yielded(self):
         """
         Test getting PRs which are correct and should be yielded back.
@@ -575,7 +580,6 @@ class GetOpenPRsToFastTest(unittest.TestCase):
 
         expected_prs = self.prs_correct_and_expected_to_be_yielded
         self.assertEqual(open_prs_to_fast, expected_prs)
-
 
     def test_get_pulls_query_params(self):
         """
@@ -609,11 +613,11 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4, "https://errata.devel.redhat.com/advisory/1357", "PR_URL4", "PR_HTML_URL4")
                 ],
                 {
-                    "errata_id" : 1357
+                    "errata_id": 1357
                 },
                 "PR_HTML_URL4"  # HTML url of a PR which body has the wanted errata id.
             ),
-           (
+            (
                 [
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 3.0.0 in fast channel(s)", [], 12345, "https://errata.devel.redhat.com/advisory/41", "PR_URL12345", "PR_HTML_URL12345"),
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.0.0 in fast channel(s)", [], 12354, "https://errata.devel.redhat.com/advisory/42", "PR_URL12354", "PR_HTML_URL12354"),
@@ -621,7 +625,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 43215, "https://errata.devel.redhat.com/advisory/44", "PR_URL43215", "PR_HTML_URL43215")
                 ],
                 {
-                    "errata_id" : 41
+                    "errata_id": 41
                 },
                 "PR_HTML_URL12345"
             ),
@@ -633,7 +637,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4444, "https://errata.devel.redhat.com/advisory/84", "PR_URL4444", "PR_HTML_URL4444")
                 ],
                 {
-                    "errata_id" : 73
+                    "errata_id": 73
                 },
                 "PR_HTML_URL3333"
             )
@@ -647,7 +651,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4, "https://errata.devel.redhat.com/advisory/1357", "PR_URL4", "PR_HTML_URL4")
                 ],
                 {
-                    "errata_id" : 1357
+                    "errata_id": 1357
                 },
                 3   # Index of the PR which has the wanted errata id.
             ),
@@ -659,7 +663,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 43215, "https://errata.devel.redhat.com/advisory/44", "PR_URL43215", "PR_HTML_URL43215")
                 ],
                 {
-                    "errata_id" : 41
+                    "errata_id": 41
                 },
                 0
             ),
@@ -671,12 +675,11 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     GithubPRMock(GithubUserMock("openshift-bot"), "Enable 4.2.3 in fast channel(s)", [], 4444, "https://errata.devel.redhat.com/advisory/84", "PR_URL4444", "PR_HTML_URL4444")
                 ],
                 {
-                    "errata_id" : 73
+                    "errata_id": 73
                 },
                 2
             )
         ]
-
 
     @patch("github.Github")
     def test_return_value_is_correct_for_specific_pr(self, Github_mock):
@@ -694,7 +697,6 @@ class LgtmFastPrForErrata(unittest.TestCase):
 
                 pr_html_url = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
                 self.assertEqual(pr_html_url, expected_pr_html_url)
-
 
     @patch("github.Github")
     def test_only_create_issue_on_the_expected_pr(self, Github_mock):
@@ -717,7 +719,6 @@ class LgtmFastPrForErrata(unittest.TestCase):
                     else:
                         pr.create_issue_comment.assert_not_called()
 
-
     @patch("github.Github")
     def test_issue_comment_format(self, Github_mock):
         """
@@ -736,6 +737,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
                 issue_comment = prs[expected_index_of_pr_to_create_issue].create_issue_comment.call_args
                 expected_issue_comment = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
                 self.assertEqual(issue_comment, (unittest.mock.call(expected_issue_comment)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -736,3 +736,6 @@ class LgtmFastPrForErrata(unittest.TestCase):
                 issue_comment = prs[expected_index_of_pr_to_create_issue].create_issue_comment.call_args
                 expected_issue_comment = "Autoapproving PR to fast after the errata has shipped\n/lgtm"
                 self.assertEqual(issue_comment, (unittest.mock.call(expected_issue_comment)))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -938,6 +938,40 @@ class ProcessMessageTest(unittest.TestCase):
     @patch("errata.lgtm_fast_pr_for_errata")
     @patch("errata.public_errata_uri")
     @patch("errata.notify")
+    def test_should_raise_exception_when_new_invalid_synopsis_is_received(
+        self,
+        notify_mock,
+        public_errata_uri_mock,
+        lgtm_fast_pr_for_errata_mock
+    ):
+        """
+        Test processing an invalid synopsis which is not in the excluded cache.
+        Should raise the ValueError exception.
+        """
+        public_errata_uri_mock.return_value = "https://access.redhat.com/errata/RHBA-2020:0000"
+        invalid_synopsis = "Invalid Synopsis 0.0.0"
+
+        message = {
+            "synopsis": invalid_synopsis,
+            "fulladvisory": "RHBA-2020:0000-01",
+            "when": "2021-01-01 00:00:00 UTC",
+        }
+        cache = {}
+        excluded_cache = {}
+
+        with self.assertRaises(ValueError):
+            errata.process_message(
+                message=message,
+                cache=cache,
+                excluded_cache=excluded_cache,
+                webhook=None,
+                githubrepo=None,
+                githubtoken=None,
+            )
+
+    @patch("errata.lgtm_fast_pr_for_errata")
+    @patch("errata.public_errata_uri")
+    @patch("errata.notify")
     def test_content_of_cache_when_invalid_synopsis_is_received(
         self,
         notify_mock,

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -57,7 +57,7 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
             ('https://errata.devel.redhat.com/advisory/invalid', None)
         ]
         for (url, expected) in param_list:
-            with self.subTest():
+            with self.subTest(url=url):
                 self.assertEqual(errata.extract_errata_number_from_body(url), expected)
 
     def test_invalid_url(self):
@@ -76,7 +76,7 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
             'https://errata.com/advisory/12345'
         ]
         for url in param_list:
-            with self.subTest():
+            with self.subTest(url=url):
                 self.assertEqual(errata.extract_errata_number_from_body(url), None)
 
     def test_missing_url(self):
@@ -88,9 +88,9 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
             '12345',
             'errata is 12345'
         ]
-        for url in param_list:
-            with self.subTest():
-                self.assertEqual(errata.extract_errata_number_from_body(url), None)
+        for body in param_list:
+            with self.subTest(body=body):
+                self.assertEqual(errata.extract_errata_number_from_body(body), None)
 
     def test_url_is_not_on_the_first_line(self):
         """
@@ -100,9 +100,9 @@ class ExtractErrataNumberFromBodyTest(unittest.TestCase):
             '\nhttps://errata.devel.redhat.com/advisory/12345',
             '\n\nhttps://errata.devel.redhat.com/advisory/12345'
         ]
-        for url in param_list:
-            with self.subTest():
-                self.assertEqual(errata.extract_errata_number_from_body(url), None)
+        for body in param_list:
+            with self.subTest(body=body):
+                self.assertEqual(errata.extract_errata_number_from_body(body), None)
 
 
 class SaveAndLoadTest(unittest.TestCase):
@@ -396,7 +396,7 @@ class NotifyTest(unittest.TestCase):
         Test functionality of notify if parameter webhook is set to its default value.
         """
         for message in self.messages:
-            with self.subTest():
+            with self.subTest(message=message):
                 errata.notify(message[0])
                 expected_message = message[0]
                 self.assertEqual(print_mock.call_args, unittest.mock.call(expected_message))
@@ -409,7 +409,7 @@ class NotifyTest(unittest.TestCase):
         Only testing messages including approved_pr key.
         """
         for (message, expected_message_in_data_to_be_uploaded) in self.messages_not_including_approved_pr:
-            with self.subTest():
+            with self.subTest(message=message):
                 expected_data_to_be_uploaded = urllib.parse.urlencode({
                     'payload': {
                         'text': expected_message_in_data_to_be_uploaded
@@ -428,7 +428,7 @@ class NotifyTest(unittest.TestCase):
         Only testing messages that do not include approved_pr key.
         """
         for (message, expected_message_in_data_to_be_uploaded) in self.messages_including_approved_pr:
-            with self.subTest():
+            with self.subTest(message=message):
                 expected_data_to_be_uploaded = urllib.parse.urlencode({
                     'payload': {
                         'text': expected_message_in_data_to_be_uploaded
@@ -692,7 +692,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
         param_list = self.prs_with_html_url_of_expected_pr
 
         for (prs, message, expected_pr_html_url) in param_list:
-            with self.subTest():
+            with self.subTest(prs_body=[x.body for x in prs], message=message):
                 self.repo.get_pulls = MagicMock(return_value=prs)
 
                 pr_html_url = errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
@@ -713,7 +713,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
             errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
 
             for index, pr in enumerate(prs):
-                with self.subTest():
+                with self.subTest(prs_body=[x.body for x in prs], message=message):
                     if index == expected_index_of_pr_to_create_issue:
                         pr.create_issue_comment.assert_called_once()
                     else:
@@ -730,7 +730,7 @@ class LgtmFastPrForErrata(unittest.TestCase):
         param_list = self.prs_with_index_of_expected_pr
 
         for (prs, message, expected_index_of_pr_to_create_issue) in param_list:
-            with self.subTest():
+            with self.subTest(prs_body=[x.body for x in prs], message=message):
                 self.repo.get_pulls = MagicMock(return_value=prs)
                 errata.lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
 

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -965,14 +965,15 @@ class ProcessMessageTest(unittest.TestCase):
             "when": "2021-01-01 00:00:00 UTC",
         }
         excluded_cache = {}
-        errata.process_message(
-            message=message,
-            cache=cache,
-            excluded_cache=excluded_cache,
-            webhook=None,
-            githubrepo=None,
-            githubtoken=None,
-        )
+        with self.assertRaises(ValueError):
+            errata.process_message(
+                message=message,
+                cache=cache,
+                excluded_cache=excluded_cache,
+                webhook=None,
+                githubrepo=None,
+                githubtoken=None,
+            )
         self.assertDictEqual(cache, cache_copy)
 
     @patch("errata.lgtm_fast_pr_for_errata")
@@ -998,14 +999,16 @@ class ProcessMessageTest(unittest.TestCase):
         }
         cache = {}
         excluded_cache = {}
-        errata.process_message(
-            message=message,
-            cache=cache,
-            excluded_cache=excluded_cache,
-            webhook=None,
-            githubrepo=None,
-            githubtoken=None,
-        )
+
+        with self.assertRaises(ValueError):
+            errata.process_message(
+                message=message,
+                cache=cache,
+                excluded_cache=excluded_cache,
+                webhook=None,
+                githubrepo=None,
+                githubtoken=None,
+            )
         self.assertDictEqual(
             excluded_cache,
             {
@@ -1036,14 +1039,15 @@ class ProcessMessageTest(unittest.TestCase):
         }
         cache = {}
         excluded_cache = {}
-        errata.process_message(
-            message=message,
-            cache=cache,
-            excluded_cache=excluded_cache,
-            webhook=None,
-            githubrepo=None,
-            githubtoken=None,
-        )
+        with self.assertRaises(ValueError):
+            errata.process_message(
+                message=message,
+                cache=cache,
+                excluded_cache=excluded_cache,
+                webhook=None,
+                githubrepo=None,
+                githubtoken=None,
+            )
         lgtm_fast_pr_for_errata_mock.assert_not_called()
 
     @patch("errata.lgtm_fast_pr_for_errata")
@@ -1069,14 +1073,15 @@ class ProcessMessageTest(unittest.TestCase):
         }
         cache = {}
         excluded_cache = {}
-        errata.process_message(
-            message=message,
-            cache=cache,
-            excluded_cache=excluded_cache,
-            webhook=None,
-            githubrepo=None,
-            githubtoken=None,
-        )
+        with self.assertRaises(ValueError):
+            errata.process_message(
+                message=message,
+                cache=cache,
+                excluded_cache=excluded_cache,
+                webhook=None,
+                githubrepo=None,
+                githubtoken=None,
+            )
         notify_mock.assert_not_called()
 
     @patch("errata.lgtm_fast_pr_for_errata")


### PR DESCRIPTION
Additional unit tests for the errata-webhook.

- New unit tests mainly focused on the `public_errata_uri` and the `process_message` functions.
- Refactoring of the initial unit tests.
- Refactoring the `errata.py` to be more testable.
- Fixing a potential bug in the `errata.py`.

Pull request related to https://issues.redhat.com/browse/OTA-356.