### PR TITLE
channels/fast-4.8: Backfill 4.7.z

### DIFF
--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -3,4 +3,14 @@ feeder:
   name: candidate-4.8
   delay: P1W
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
-versions: []
+versions:
+- 4.7.9
+- 4.7.8
+- 4.7.7
+- 4.7.6
+- 4.7.5
+- 4.7.4
+- 4.7.3
+- 4.7.2
+- 4.7.1
+- 4.7.0

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -2,4 +2,5 @@ name: stable-4.8
 feeder:
   name: fast-4.8
   delay: PT48H
+  filter: 4\.8\.[0-9]+(.*hotfix.*)?
 versions: []


### PR DESCRIPTION
These are in candidate-4.8, and also have public errata, so they should be in fast-4.8:

```console
$ hack/stabilization-changes.py
...
INFO: considering promotions from candidate-4.8 to fast-4.8 after P1W
INFO:   recommended: 4.7.0 (7 days, 20:34:17.149479)
DEBUG:     channels/fast-4.8: Promote 4.7.0 to fast-4.8
DEBUG:     It was promoted the feeder candidate-4.8 by 8a206158ff (Merge pull request #761 from wking/backfill-4.8-into-candidate-4.8, 2021-04-20).
...
```

I've added a filter to keep them out of stable-4.8, because with our current lack of phased rollouts, that's our mechanism for delaying the 4.7 -> 4.8 stable update recommendations.