### PR TITLE
channels/fast-4.8: Exclude 4.7.z releases

### DIFF
--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -2,5 +2,5 @@ name: fast-4.8
 feeder:
   name: candidate-4.8
   delay: P1W
-  filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
+  filter: 4\.8\.[0-9]+(.*hotfix.*)?
 versions: []


### PR DESCRIPTION
These are in candidate-4.8, and also have public errata, so the stabilizer wants them in fast-4.8:

```console
$ hack/stabilization-changes.py
...
INFO: considering promotions from candidate-4.8 to fast-4.8 after P1W
INFO:   recommended: 4.7.0 (7 days, 20:34:17.149479)
DEBUG:     channels/fast-4.8: Promote 4.7.0 to fast-4.8
DEBUG:     It was promoted the feeder candidate-4.8 by 8a206158ff (Merge pull request #761 from wking/backfill-4.8-into-candidate-4.8, 2021-04-20).
...
```

But we want to keep them out of stable-4.8, because with our current lack of phased rollouts, because that's our mechanism for delaying the 4.7 -> 4.8 stable update recommendations.  [Lala doesn't want them in fast-4.8 either][1], out of concern that their presence would confuse users before the 4.8 GA.

[1]: https://github.com/openshift/cincinnati-graph-data/pull/783#issuecomment-830032300