### PR TITLE
Block 4.7.11 due to bug 1953518

### DIFF
--- a/blocked-edges/4.7.11.yaml
+++ b/blocked-edges/4.7.11.yaml
@@ -1,0 +1,3 @@
+to: 4.7.11
+from: .*
+# CMO goes degraded when user monitoring workflow is enabled due to DNS changes https://bugzilla.redhat.com/show_bug.cgi?id=1953518


### PR DESCRIPTION
CMO goes degraded when user monitoring workflow is enabled due to DNS changes https://bugzilla.redhat.com/show_bug.cgi?id=1953518