### PR TITLE
channels/candidate-4.[78]: Tombstone 4.7.14 on hard anti-affinity vs. volume affinity

### DIFF
--- a/channels/candidate-4.7.yaml
+++ b/channels/candidate-4.7.yaml
@@ -6,6 +6,8 @@ tombstones:
 - 4.6.24
 # 4.7.10 installer segfaults on install-config serviceEndpoints https://bugzilla.redhat.com/show_bug.cgi?id=1958420
 - 4.7.10
+# 4.7.14 moved monitoring to hard-anti-affinity, and that can conflict with volume affinity https://bugzilla.redhat.com/show_bug.cgi?id=1967614
+- 4.7.14
 versions:
 - 4.6.32
 

--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -2,6 +2,8 @@ name: candidate-4.8
 tombstones:
 # 4.7.10 installer segfaults on install-config serviceEndpoints https://bugzilla.redhat.com/show_bug.cgi?id=1958420
 - 4.7.10
+# 4.7.14 moved monitoring to hard-anti-affinity, and that can conflict with volume affinity https://bugzilla.redhat.com/show_bug.cgi?id=1967614
+- 4.7.14
 versions:
 - 4.7.14
 


### PR DESCRIPTION
As described in [rhbz#1967614][1], this can wedge updates between releases where monitoring/Prometheus had soft-anti-affinity to releases where it had hard-anti-affinity, in some storage/monitoring/topology situations.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1967614