### PR TITLE
hack/errata: Match the 4.7.13 errata message

### DIFF
--- a/hack/errata.py
+++ b/hack/errata.py
@@ -68,7 +68,7 @@ def run(poll_period=datetime.timedelta(seconds=3600),
                     githubtoken=githubtoken,
                 )
             except ValueError as error:
-                _LOGGER.warn(error)
+                _LOGGER.warning(error)
         next_time += poll_period
         _LOGGER.debug('sleep until {}'.format(next_time))
         time.sleep((next_time - datetime.datetime.now()).seconds)
@@ -89,15 +89,15 @@ def process_message(message, cache, excluded_cache, webhook, githubrepo, githubt
     channel = 'candidate-{major}.{minor}'.format(**synopsis_groups)
     message['uri'] = public_errata_uri(version=synopsis_groups['version'], advisory=advisory, channel=channel)
     if not message['uri']:
-        _LOGGER.warn('No known errata URI for {} in {}'.format(synopsis_groups['version'], channel))
+        _LOGGER.warning('No known errata URI for {} in {}'.format(synopsis_groups['version'], channel))
         return
     if not message['uri'].endswith(advisory):
-        _LOGGER.warn('Version {} errata {} does not match synopsis {} ({!r})'.format(synopsis_groups['version'], message['uri'], message['fulladvisory'], advisory))
+        _LOGGER.warning('Version {} errata {} does not match synopsis {} ({!r})'.format(synopsis_groups['version'], message['uri'], message['fulladvisory'], advisory))
         return
     try:
         message['approved_pr'] = lgtm_fast_pr_for_errata(githubrepo, githubtoken, message)
     except Exception as error:
-        _LOGGER.warn('Error looking up PRs: {}'.format(error))
+        _LOGGER.warning('Error looking up PRs: {}'.format(error))
     notify(message=message, webhook=webhook)
     if cache is not None:
         cache[message['fulladvisory']] = {
@@ -175,7 +175,7 @@ def get_open_prs_to_fast(repo):
                 continue
             yield pr
         except Exception as e:
-            _LOGGER.warn("Failed to parse {}: {}".format(pr.number, e))
+            _LOGGER.warning("Failed to parse {}: {}".format(pr.number, e))
 
 
 def extract_errata_number_from_body(body):
@@ -185,14 +185,14 @@ def extract_errata_number_from_body(body):
         x for x in first_line.split(' ') if x.startswith(ERRATA_MARKER)
     ]
     if len(links) == 0:
-        _LOGGER.warn("No links found in PR body: {}".format(body))
+        _LOGGER.warning("No links found in PR body: {}".format(body))
         return None
     errata_num = links[0].rsplit('/', 1)[-1]
 
     try:
         return int(errata_num)
     except ValueError:
-        _LOGGER.warn("Failed to convert PR number to int: {}".format(errata_num))
+        _LOGGER.warning("Failed to convert PR number to int: {}".format(errata_num))
         return None
 
 

--- a/hack/errata.py
+++ b/hack/errata.py
@@ -27,7 +27,7 @@ _SYNOPSIS_REGEXP = re.compile(r'''
     (?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
   )
   [ ](?P<type>
-    (?:(?:security[ ]and[ ])?bug[ ]fix(?:[ ]and[ ]golang[ ]security)?[ ]update)?
+    (?:(?:security[ ]and[ ])?bug[ ]fix(?:[ ]and(?:[ ]golang)?[ ]security)?[ ]update)?
     (?:GA[ ]Images)?
   )$
 ''',

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -319,6 +319,19 @@ class SynopsisMatchTest(unittest.TestCase):
         """
         for synopsis, expected in [
                 (
+                    'Moderate: OpenShift Container Platform 4.7.13 bug fix and security update',
+                    {
+                        'impact': 'Moderate',
+                        'version': '4.7.13',
+                        'major': '4',
+                        'minor': '7',
+                        'patch': '13',
+                        'prerelease': None,
+                        'build': None,
+                        'type': 'bug fix and security update',
+                    },
+                ),
+                (
                     'Moderate: OpenShift Container Platform 4.7.5 security and bug fix update',
                     {
                         'impact': 'Moderate',

--- a/hack/test_errata.py
+++ b/hack/test_errata.py
@@ -396,6 +396,34 @@ class SynopsisMatchTest(unittest.TestCase):
                     self.assertEqual(actual, expected)
 
 
+class AdvisoryPhrasingsTest(unittest.TestCase):
+    def test_phrasings(self):
+        """
+        Ensure we can construct synonym phrasins.
+        """
+        for advisory, expected in [
+                (
+                    'RHBA-123',
+                    ['RHBA-123', 'RHSA-123'],
+                ),
+                (
+                    'RHSA-123',
+                    ['RHBA-123', 'RHSA-123'],
+                ),
+                (
+                    'https://example.com/RHBA-123',
+                    ['https://example.com/RHBA-123', 'https://example.com/RHSA-123'],
+                ),
+                (
+                    'https://example.com/RHBA-123/abc',
+                    ['https://example.com/RHBA-123/abc', 'https://example.com/RHSA-123/abc'],
+                ),
+            ]:
+            with self.subTest(advisory=advisory):
+                actual = list(errata.advisory_phrasings(advisory=advisory))
+                self.assertEqual(actual, expected)
+
+
 class NotifyTest(unittest.TestCase):
     def setUp(self):
         self.messages_including_approved_pr = [


### PR DESCRIPTION
It has a slightly different bug/security phrasing than previous bug/security errata.  Also add a helper to treat RHBA and RHSA as synonyms, because ART sometimes guesses wrong when baking the URI into the release image (details in the commit messages).