### PR TITLE
hack/stabilization-changes: Check for public errata

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ For example, for [`channels/fast-4.2.yaml`](channels/fast-4.2.yaml):
 feeder:
   name: candidate-4.2
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*|\+amd64|-s390x)?
 ```
 
-which declares the intention that nodes and edges will be considered for promotion into `fast-4.2` after cooking for one week in `candidate-4.2`.
+which declares the intention that nodes and edges will be considered for promotion into `fast-4.2` after cooking for one week in `candidate-4.2` or the errata becomes public.
 The `delay` value is an [ISO 8601][rfc-3339-p13] [duration][iso-8601-durations].
+The optional `errata` property only accepts one value, `public`, and the feeder nodes are promoted when `delay` has elapsed or the release errata becomes public, whichever comes first.
 The `filter` value excludes `4.2.0-rc.5` and other releases, while allowing for `4.2.0-0.hotfix-2020-09-19-234758` and `4.2.10-s390x` and `4.2.14+amd64`.
 
 This is the expected delay, but it does not mean that promotion will happen at that moment.

--- a/README.md
+++ b/README.md
@@ -53,18 +53,26 @@ For example, for [`channels/fast-4.2.yaml`](channels/fast-4.2.yaml):
 ```yaml
 feeder:
   name: candidate-4.2
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*|\+amd64|-s390x)?
 ```
 
-which declares the intention that nodes and edges will be considered for promotion into `fast-4.2` after cooking for one week in `candidate-4.2` or the errata becomes public.
-The `delay` value is an [ISO 8601][rfc-3339-p13] [duration][iso-8601-durations].
-The optional `errata` property only accepts one value, `public`, and the feeder nodes are promoted when `delay` has elapsed or the release errata becomes public, whichever comes first.
+which declares the intention that nodes and edges will be considered for promotion from `candidate-4.2` into `fast-4.2` after the errata becomes public.
+The optional `errata` property only accepts one value, `public`, and marks a public errata as sufficient, but not necessary, for promoting a feeder node.
 The `filter` value excludes `4.2.0-rc.5` and other releases, while allowing for `4.2.0-0.hotfix-2020-09-19-234758` and `4.2.10-s390x` and `4.2.14+amd64`.
 
-This is the expected delay, but it does not mean that promotion will happen at that moment.
-For example, it is possible that release architects decide that there is insufficient data for a `fast-4.2` promotion, in which case the promotion can be delated until sufficient data accumulates.
+Another example is [`channels/stable-4.2.yaml`](channels/stable-4.2.yaml):
+
+```yaml
+feeder:
+  name: fast-4.2
+  delay: PT48H
+```
+
+which declares the intention that nodes and edges will be considered for promotion from `fast-4.2` into `stable-4.2` after a delay of 48 hours.
+The `delay` value is an [ISO 8601][rfc-3339-p13] [duration][iso-8601-durations], and spending sufficient time in the feeder channel is sufficient, but not necessary, for promoting the feeder node.
+
+If both `errata` and `delay` are set, the feeder nodes will be promoted when `delay` has elapsed or the release errata becomes public, whichever comes first.
 
 To see recommended feeder promotions, run:
 

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -2,6 +2,7 @@ name: fast-4.2
 feeder:
   name: candidate-4.2
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*|\+amd64|-s390x)?
 tombstones:
 - 4.2.10-s390x

--- a/channels/fast-4.2.yaml
+++ b/channels/fast-4.2.yaml
@@ -1,7 +1,6 @@
 name: fast-4.2
 feeder:
   name: candidate-4.2
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*|\+amd64|-s390x)?
 tombstones:

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -2,6 +2,7 @@ name: fast-4.3
 feeder:
   name: candidate-4.3
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:
 - 4.2.36

--- a/channels/fast-4.3.yaml
+++ b/channels/fast-4.3.yaml
@@ -1,7 +1,6 @@
 name: fast-4.3
 feeder:
   name: candidate-4.3
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:

--- a/channels/fast-4.4.yaml
+++ b/channels/fast-4.4.yaml
@@ -2,6 +2,7 @@ name: fast-4.4
 feeder:
   name: candidate-4.4
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:
 - 4.3.40

--- a/channels/fast-4.4.yaml
+++ b/channels/fast-4.4.yaml
@@ -1,7 +1,6 @@
 name: fast-4.4
 feeder:
   name: candidate-4.4
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:

--- a/channels/fast-4.5.yaml
+++ b/channels/fast-4.5.yaml
@@ -1,5 +1,6 @@
 feeder:
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.5
 name: fast-4.5

--- a/channels/fast-4.5.yaml
+++ b/channels/fast-4.5.yaml
@@ -1,5 +1,4 @@
 feeder:
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.5

--- a/channels/fast-4.6.yaml
+++ b/channels/fast-4.6.yaml
@@ -1,5 +1,4 @@
 feeder:
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.6

--- a/channels/fast-4.6.yaml
+++ b/channels/fast-4.6.yaml
@@ -1,5 +1,6 @@
 feeder:
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.6
 name: fast-4.6

--- a/channels/fast-4.7.yaml
+++ b/channels/fast-4.7.yaml
@@ -1,5 +1,6 @@
 feeder:
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.7
 name: fast-4.7

--- a/channels/fast-4.7.yaml
+++ b/channels/fast-4.7.yaml
@@ -1,5 +1,4 @@
 feeder:
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
   name: candidate-4.7

--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -2,5 +2,6 @@ name: fast-4.8
 feeder:
   name: candidate-4.8
   delay: P1W
+  errata: public
   filter: 4\.8\.[0-9]+(.*hotfix.*)?
 versions: []

--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -1,7 +1,6 @@
 name: fast-4.8
 feeder:
   name: candidate-4.8
-  delay: P1W
   errata: public
   filter: 4\.8\.[0-9]+(.*hotfix.*)?
 versions: []

--- a/channels/stable-4.1.yaml
+++ b/channels/stable-4.1.yaml
@@ -2,6 +2,7 @@ name: stable-4.1
 feeder:
   name: prerelease-4.1
   delay: P1W
+  errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:
 - 4.1.0

--- a/channels/stable-4.1.yaml
+++ b/channels/stable-4.1.yaml
@@ -1,7 +1,6 @@
 name: stable-4.1
 feeder:
   name: prerelease-4.1
-  delay: P1W
   errata: public
   filter: 4\.[0-9]+\.[0-9]+(.*hotfix.*)?
 versions:

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -1,21 +1,32 @@
 #!/usr/bin/env python
 
+import codecs
 import datetime
+import http
+import json
 import logging
 import os
 import re
 import subprocess
+import textwrap
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
+import github
 import yaml
 
 
 logging.basicConfig(format='%(levelname)s: %(message)s')
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
-_ISO_8601_DELAY_REGEXP = re.compile('^P((?P<weeks>\d+)W)?(T(?P<hours>\d+)H)?$')
-_GIT_BLAME_COMMIT_REGEXP = re.compile('^(?P<hash>[0-9a-f]{40}) .*')
-_GIT_BLAME_HEADER_REGEXP = re.compile('^(?P<key>[^ \t]+) (?P<value>.*)$')
-_GIT_BLAME_LINE_REGEXP = re.compile('^\t(?P<value>.*)$')
+_ADVISORY_TYPE_REGEXP = re.compile(r'RH[BS]A')
+_ISO_8601_DELAY_REGEXP = re.compile(r'^P((?P<weeks>\d+)W)?(T(?P<hours>\d+)H)?$')
+_GIT_BLAME_COMMIT_REGEXP = re.compile(r'^(?P<hash>[0-9a-f]{40}) .*')
+_GIT_BLAME_HEADER_REGEXP = re.compile(r'^(?P<key>[^ \t]+) (?P<value>.*)$')
+_GIT_BLAME_LINE_REGEXP = re.compile(r'^\t(?P<value>.*)$')
+_SEMANTIC_VERSION_DELIMITERS = re.compile('[.+-]')
 
 
 def parse_iso8601_delay(delay):
@@ -28,7 +39,98 @@ def parse_iso8601_delay(delay):
     return datetime.timedelta(days=7*weeks, hours=hours)
 
 
-def stabilization_changes(directory):
+def stabilization_changes(directory, webhook=None, **kwargs):
+    channels, channel_paths = load_channels(directory=directory)
+    cache = {}
+    notifications = []
+    for name, channel in sorted(channels.items()):
+        notifications.extend(stabilize_channel(name=name, channel=channel, channels=channels, channel_paths=channel_paths, cache=cache, **kwargs))
+    if notifications:
+        notify(message='* ' + ('\n* '.join(notifications)), webhook=webhook)
+
+
+def stabilize_channel(name, channel, channels, channel_paths, **kwargs):
+    if not channel.get('feeder'):
+        return
+    feeder = channel['feeder']['name']
+    delay_string = channel['feeder']['delay']
+    errata = channel['feeder'].get('errata')
+    if errata is not None and errata != 'public':
+        raise ValueError('invalid errata value for {}: {}', channel, errata)
+
+    delay = parse_iso8601_delay(delay=delay_string)
+    version_filter = re.compile('^{}$'.format(channel['feeder'].get('filter', '.*')))
+    feeder_data = channels[feeder]
+    unpromoted = set(feeder_data['versions']) - set(channel['versions']) - set(feeder_data.get('tombstones', {}))
+    candidates = set(v for v in unpromoted if version_filter.match(v))
+    if not candidates:
+        return
+    feeder_promotions = get_promotions(channel_paths[feeder])
+    suffix = ''
+    if errata:
+        suffix = ' or the errata is published'
+    _LOGGER.info('considering promotions from {} to {} after {}{}'.format(feeder, name, delay_string, suffix))
+    for version in sorted(candidates):
+        feeder_promotion = feeder_promotions[version]
+        yield from stabilize_release(
+            version=version,
+            channel_name=name,
+            channel_path=channel_paths[name],
+            delay=delay,
+            errata=errata,
+            feeder_name=feeder,
+            feeder_promotion=feeder_promotion,
+            **kwargs)
+
+
+def stabilize_release(version, channel_name, channel_path, delay, errata, feeder_name, feeder_promotion, cache, waiting_notifications=True, **kwargs):
+    now = datetime.datetime.now()
+    version_delay = now - feeder_promotion['committer-time']
+    errata_public = False
+    public_errata_message = ''
+    if errata:
+        errata_uri, errata_public = public_errata_uri(version=version, channel=feeder_name, cache=cache)
+        if errata_uri:
+            public_errata_message = ' {} is{} public.'.format(errata_uri, '' if errata_public else ' not')
+    if version_delay > delay or errata_public:
+        path_without_extension, _ = os.path.splitext(channel_path)
+        subject = '{}: Promote {}'.format(path_without_extension, version)
+        body = 'It was promoted to the feeder {} by {} ({}, {}) {} ago.{}'.format(
+                feeder_name,
+                feeder_promotion['hash'][:10],
+                feeder_promotion['summary'],
+                feeder_promotion['committer-time'].date().isoformat(),
+                version_delay,
+                public_errata_message,
+            )
+        try:
+            pull = promote(
+                version=version,
+                channel_name=channel_name,
+                channel_path=channel_path,
+                subject=subject,
+                body=body,
+                **kwargs)
+        except Exception as error:
+            _LOGGER.error('  failed to promote {} to {}: {}'.format(version, channel_name, error))
+            yield 'FAILED {}. {} {}'.format(subject, body, error)
+        else:
+            yield '{}. {} {}'.format(subject, body, pull.html_url)
+    else:
+        _LOGGER.info('  waiting: {} ({}){}'.format(version, version_delay, public_errata_message))
+        if waiting_notifications:
+            yield 'Recommend waiting to promote {} to {}; it was promoted the feeder {} by {} ({}, {}, {}){}'.format(
+                version,
+                channel_name,
+                feeder_name,
+                feeder_promotion['hash'][:10],
+                feeder_promotion['summary'],
+                feeder_promotion['committer-time'].date().isoformat(),
+                version_delay,
+                public_errata_message)
+
+
+def load_channels(directory):
     channels = {}
     paths = {}
     for root, _, files in os.walk(directory):
@@ -46,38 +148,15 @@ def stabilization_changes(directory):
                 raise ValueError('multiple definitions for {}: {} and {}'.format(channel, paths[channel], path))
             paths[channel] = path
             channels[channel] = data
-    for name, channel in sorted(channels.items()):
-        if not channel.get('feeder'):
-            continue
-        feeder = channel['feeder']['name']
-        delay_string = channel['feeder']['delay']
-        delay = parse_iso8601_delay(delay=delay_string)
-        version_filter = re.compile('^{}$'.format(channel['feeder'].get('filter', '.*')))
-        feeder_data = channels[feeder]
-        unpromoted = set(feeder_data['versions']) - set(channel['versions']) - set(feeder_data.get('tombstones', {}))
-        candidates = set(v for v in unpromoted if version_filter.match(v))
-        if not candidates:
-            continue
-        promotions = get_promotions(paths[feeder])
-        now = datetime.datetime.now()
-        _LOGGER.info('considering promotions from {} to {} after {}'.format(feeder, name, delay_string))
-        for version in sorted(candidates):
-            promotion = promotions[version]
-            version_delay = now - promotion['committer-time']
-            if version_delay > delay:
-                _LOGGER.info('  recommended: {} ({})'.format(version, version_delay))
-                _LOGGER.debug('    {}: Promote {} to {}'.format(paths[name].rsplit('.', 1)[0], version, name))
-                _LOGGER.debug('    It was promoted the feeder {} by {} ({}, {}).'.format(feeder, promotion['hash'][:10], promotion['summary'], promotion['committer-time'].date().isoformat()))
-            else:
-                _LOGGER.info('  waiting: {} ({})'.format(version, version_delay))
+    return channels, paths
 
 
 def get_promotions(path):
     # https://git-scm.com/docs/git-blame#_the_porcelain_format
-    output = subprocess.check_output(['git', 'blame', '--first-parent', '--porcelain', path]).decode('utf-8')
+    process = subprocess.run(['git', 'blame', '--first-parent', '--porcelain', path], check=True, capture_output=True)
     commits = {}
     lines = {}
-    for line in output.strip().split('\n'):
+    for line in process.stdout.decode('utf-8').strip().split('\n'):
         match = _GIT_BLAME_COMMIT_REGEXP.match(line)
         if match:
             commit = match.group('hash')
@@ -105,5 +184,207 @@ def get_promotions(path):
     return promotions
 
 
+def public_errata_uri(version, cache=None, **kwargs):
+    if cache and cache.get('versions', {}).get(version, -1) != -1:
+        cached = cache['versions'][version]
+        if not cached:
+            return None, None
+        return cached['uri'], cached['public']
+    cincinnati_uri, cincinnati_data = get_cincinnati_channel(cache=cache, **kwargs)
+    canonical_errata_uri = errata_uri_from_cincinnati(version=version, cincinnati_data=cincinnati_data, cincinnati_uri=cincinnati_uri)
+    if not canonical_errata_uri:
+        if cache is not None:
+            if 'versions' not in cache:
+                cache['versions'] = {}
+            cache['versions'][version] = None
+        return None, None
+    errata_uri, public = _public_errata_uri(uri=canonical_errata_uri)
+    if cache is not None:
+        if 'versions' not in cache:
+            cache['versions'] = {}
+        cache['versions'][version] = {
+            'uri': errata_uri,
+            'public': public,
+        }
+    return errata_uri, public
+
+
+def get_cincinnati_channel(arch='amd64', channel='', update_service='https://api.openshift.com/api/upgrades_info/v1/graph', cache=None):
+    params = {
+        'channel': channel,
+        'arch': arch,
+    }
+
+    headers = {
+        'Accept': 'application/json',
+    }
+
+    uri = '{}?{}'.format(update_service, urllib.parse.urlencode(params))
+
+    if cache and cache.get('channels', {}).get(channel, {}).get(arch):
+        return uri, cache['channels'][channel][arch]
+
+    request = urllib.request.Request(uri, headers=headers)
+    _LOGGER.debug('retrieve Cincinnati data from {}'.format(uri))
+    while True:
+        try:
+            with urllib.request.urlopen(request) as f:
+                data = json.load(codecs.getreader('utf-8')(f))  # hack: should actually respect Content-Type
+        except Exception as error:
+            _LOGGER.error('{}: {}'.format(uri, error))
+            time.sleep(10)
+            continue
+        break
+    if cache is not None:
+        if 'channels' not in cache:
+            cache['channels'] = {}
+        if channel not in cache['channels']:
+            cache['channels'][channel] = {}
+        cache['channels'][channel][arch] = data
+    return uri, data
+
+
+def errata_uri_from_cincinnati(version, cincinnati_data, cincinnati_uri='Cincinnati'):
+    versions = set()
+    errata_uri = None
+    for node in cincinnati_data['nodes']:
+        if node['version'] == version:
+            errata_uri = node.get('metadata', {}).get('url')
+            if not errata_uri:
+                _LOGGER.debug('{} found in {}, but does not declare metadata.url'.format(version, cincinnati_uri))
+                return None
+            break
+        versions.add(node['version'])
+    if not errata_uri:
+        _LOGGER.debug('{} not found in {} ({})'.format(version, cincinnati_uri, ', '.join(sorted(versions))))
+    return errata_uri
+
+
+def _public_errata_uri(uri):
+    for potential_errata_uri in advisory_phrasings(advisory=uri):
+        headers = {
+            'User-Agent': 'cincinnati-graph-data/0.1',  # for some reason, https://access.redhat.com/ 403s urllib/{version}
+        }
+        request = urllib.request.Request(potential_errata_uri, headers=headers)
+        while True:
+            try:
+                with urllib.request.urlopen(request):
+                    pass
+            except urllib.error.HTTPError as error:
+                if error.code == http.HTTPStatus.FORBIDDEN or error.code == http.HTTPStatus.NOT_FOUND:
+                    _LOGGER.debug('{}: {}'.format(potential_errata_uri, error))
+                    break
+                _LOGGER.error('{}: {}'.format(potential_errata_uri, error))
+                time.sleep(10)
+                continue
+            except Exception as error:
+                _LOGGER.error('{}: {}'.format(potential_errata_uri, error))
+                time.sleep(10)
+                continue
+            return potential_errata_uri, True
+    return uri, False
+
+
+def advisory_phrasings(advisory):
+    match = _ADVISORY_TYPE_REGEXP.search(advisory)
+    if not match:
+        _LOGGER.warning('advisory did not match the advisory type regular expression: {}'.format(advisory))
+        return
+    for phrasing in ['RHBA', 'RHSA']:
+        yield '{}{}{}'.format(advisory[:match.start()], phrasing, advisory[match.end():])
+
+
+def notify(message, webhook=None):
+    if not webhook:
+        print(message)
+        return
+
+    msg_text = '<!subteam^STE7S7ZU2>: Cincinnati stabilization:\n{}'.format(message)
+
+    urllib.request.urlopen(webhook, data=urllib.parse.urlencode({
+        'payload': {
+            'text': msg_text,
+        },
+    }).encode('utf-8'))
+
+
+def promote(version, channel_name, channel_path, subject, body, github_repo, github_token, upstream_remote='origin', upstream_branch='master'):
+    if not github_token:
+        raise ValueError('cannot promote without a configured GitHub token')
+    subprocess.run(['git', 'fetch', upstream_remote], check=True)
+    branch = 'promote-{}-to-{}'.format(version, channel_name)
+    subprocess.run(['git', 'checkout', '-b', branch, '{}/{}'.format(upstream_remote, upstream_branch)], check=True)
+    with open(channel_path) as f:
+        try:
+            data = yaml.load(f, Loader=yaml.SafeLoader)
+        except ValueError as error:
+            raise ValueError('failed to load YAML from {}: {}'.format(channel_path, error))
+    versions = set(data['versions'])
+    if version in versions:
+        raise ValueError('version {} has already been promoted to {} in {}/{}'.format(version, channel_name, upstream_remote, upstream_branch))
+    versions.add(version)
+    data['versions'] = list(sorted(versions, key=semver_sort_key))
+    with open(channel_path, 'w') as f:
+        yaml.safe_dump(data, f, default_flow_style=False)
+    message = '{}\n\n{}\n'.format(subject, textwrap.fill(body, width=76))
+    subprocess.run(['git', 'commit', '--file', '-', channel_path], check=True, encoding='utf-8', input=message)
+    subprocess.run(['git', 'push', '-u', upstream_remote, branch], check=True)
+
+    github_object = github.Github(github_token)
+    repo = github_object.get_repo(github_repo)
+    pull = repo.create_pull(title=subject, body=body, head=branch, base=upstream_branch)
+    pull.add_to_labels('lgtm', 'approved')
+    return pull
+
+
+def semver_sort_key(version):
+    # Precedence is defined in https://semver.org/spec/v2.0.0.html#spec-item-11
+    identifiers = _SEMANTIC_VERSION_DELIMITERS.sub(' ', version)
+    ids = []
+    for identifier in identifiers.split():
+        try:
+            i = int(identifier)
+        except ValueError:
+            ids.append(identifier)
+        else:
+            ids.append(i)
+    return tuple(ids)
+
+
 if __name__ == '__main__':
-    stabilization_changes(directory='channels')
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Check for stabilization changes as versions are promoted from feeder channels.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        '--github-repo',
+        dest='github_repo',
+        metavar='REPO',
+        help='Automatically create promotion pull requests in the GitHub repository (requires --github-token).',
+        default="openshift/cincinnati-graph-data",
+    )
+    parser.add_argument(
+        '--github-token',
+        dest='github_token',
+        metavar='TOKEN',
+        help='GitHub token for pull request creation ( https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token ). Defaults to the value of the GITHUB_TOKEN environment variable.',
+        default=os.environ.get('GITHUB_TOKEN', ''),
+    )
+    parser.add_argument(
+        '--webhook',
+        metavar='URI',
+        help='Set this to actually push notifications to Slack.  Defaults to the value of the WEBHOOK environment variable.',
+        default=os.environ.get('WEBHOOK', ''),
+    )
+
+    args = parser.parse_args()
+
+    stabilization_changes(
+        directory='channels',
+        github_repo=args.github_repo.strip(),
+        github_token=args.github_token.strip(),
+        webhook=args.webhook.strip(),
+        waiting_notifications=True,
+    )


### PR DESCRIPTION
We currently have hack/errata.py to look for errata notifications in data-grepper, but data-grepper requires VPN access and fiddly synopsis matching.  Teaching stabilization-changes.py about checking directly for public errata is a step towards making stabilization changes something we can run in an external cluster without VPN access.