### PR TITLE
channels/candidate-4.[67]: Tombstone 4.6.33

### DIFF
--- a/channels/candidate-4.6.yaml
+++ b/channels/candidate-4.6.yaml
@@ -17,6 +17,8 @@ tombstones:
 - 4.6.10
 # 4.6.24 introduced a regression in registry ca-trust handling: https://bugzilla.redhat.com/show_bug.cgi?id=1949040#c4
 - 4.6.24
+# Shares an errata with a later release
+- 4.6.33
 versions:
 - 4.5.40
 

--- a/channels/candidate-4.7.yaml
+++ b/channels/candidate-4.7.yaml
@@ -4,6 +4,8 @@ tombstones:
 - 4.6.10
 # 4.6.24 introduced a regression in registry ca-trust handling: https://bugzilla.redhat.com/show_bug.cgi?id=1949040#c4
 - 4.6.24
+# Shares an errata with a later release
+- 4.6.33
 # 4.7.10 installer segfaults on install-config serviceEndpoints https://bugzilla.redhat.com/show_bug.cgi?id=1958420
 - 4.7.10
 # 4.7.14 moved monitoring to hard-anti-affinity, and that can conflict with volume affinity https://bugzilla.redhat.com/show_bug.cgi?id=1967614


### PR DESCRIPTION
It was renamed to 4.6.34 using the same errata:

```console
$ curl -sH accept:application/json 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.6' | jq -r '
>    .nodes as $n |
>     [$n[].metadata.url] | unique[] | . as $url |
>     ([$n[] | select(.metadata.url == $url).version]) as $versions |
>     select(($versions | length) > 1) | $url + " " + ($versions | join(" "))
>   ' | sort
...
https://access.redhat.com/errata/RHBA-2021:2267 4.6.33 4.6.34
...
```