### PR TITLE
Align minimum 4.7.z to latest at code freeze

### DIFF
--- a/build-suggestions/4.8.yaml
+++ b/build-suggestions/4.8.yaml
@@ -2,10 +2,10 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.7.7
+  minor_min: 4.7.16
   minor_max: 4.7.9999
   minor_block_list: []
-  z_min: 4.8.0-fc.5
+  z_min: 4.8.0-rc.0
   z_max: 4.8.9999
   z_block_list: []
 # s390x:


### PR DESCRIPTION
z_min will of course be updated at GA but minor_min will not be updated again unless we become aware of a specific identified issue affecting upgrade success