### PR TITLE
channels/eus-4.6: Promote 4.6.35

### DIFF
--- a/channels/eus-4.6.yaml
+++ b/channels/eus-4.6.yaml
@@ -1,8 +1,8 @@
-name: eus-4.6
 feeder:
-  name: stable-4.6
   delay: PT0H
   filter: 4\.6\.[0-9]+(.*hotfix.*)?
+  name: stable-4.6
+name: eus-4.6
 versions:
 - 4.6.1
 - 4.6.3
@@ -29,5 +29,5 @@ versions:
 - 4.6.30
 - 4.6.31
 - 4.6.32
-
 - 4.6.34
+- 4.6.35


### PR DESCRIPTION
It was promoted to the feeder stable-4.6 by 566e20146c (Merge pull request #888 from openshift/promote-4.6.35-to-stable-4.6, 2021-06-24) 0:14:35.245033 ago.