### PR TITLE
blocked-edges/4.7: Soften auth connection-leak blocking

### DIFF
--- a/blocked-edges/4.7.0.yaml
+++ b/blocked-edges/4.7.0.yaml
@@ -2,3 +2,4 @@ to: 4.7.0
 from: 4\.6\..*
 # 4.6.19 doesn't exist yet, so block the edge to 4.7.0 until we know what it will contain
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.1.yaml
+++ b/blocked-edges/4.7.1.yaml
@@ -1,3 +1,4 @@
 to: 4.7.1
 from: 4\.6\..*
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.2.yaml
+++ b/blocked-edges/4.7.2.yaml
@@ -1,3 +1,4 @@
 to: 4.7.2
 from: 4\.6\..*
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.3.yaml
+++ b/blocked-edges/4.7.3.yaml
@@ -1,3 +1,4 @@
 to: 4.7.3
 from: 4\.6\..*
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.4.yaml
+++ b/blocked-edges/4.7.4.yaml
@@ -2,3 +2,4 @@ to: 4.7.4
 from: .*
 # 4.7.4 introduced a node-hostname clear on vSphere: https://bugzilla.redhat.com/show_bug.cgi?id=1942207
 # 4.7 has cross-node SDN issues on vSphere Virtual Hardware Version 14 and later: https://bugzilla.redhat.com/show_bug.cgi?id=1935539
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.5.yaml
+++ b/blocked-edges/4.7.5.yaml
@@ -1,3 +1,3 @@
 to: 4.7.5
-from: .*
-# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router : https://bugzilla.redhat.com/show_bug.cgi?id=1941840
+from: 4\.6\..*
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.6.yaml
+++ b/blocked-edges/4.7.6.yaml
@@ -1,3 +1,3 @@
 to: 4.7.6
-from: .*
-# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router : https://bugzilla.redhat.com/show_bug.cgi?id=1941840
+from: 4\.6\..*
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.7.yaml
+++ b/blocked-edges/4.7.7.yaml
@@ -1,3 +1,3 @@
 to: 4.7.7
-from: .*
-# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router : https://bugzilla.redhat.com/show_bug.cgi?id=1941840
+from: 4\.6\..*
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.8.yaml
+++ b/blocked-edges/4.7.8.yaml
@@ -1,3 +1,3 @@
 to: 4.7.8
-from: .*
-# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router : https://bugzilla.redhat.com/show_bug.cgi?id=1941840
+from: 4\.6\..*
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840

--- a/blocked-edges/4.7.9.yaml
+++ b/blocked-edges/4.7.9.yaml
@@ -1,3 +1,3 @@
 to: 4.7.9
-from: .*
-# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router: https://bugzilla.redhat.com/show_bug.cgi?id=1941840
+from: 4\.6\..*
+# Authentication operator's endpoints controller fails to close connections, causing intermittent apiserver and authentication cluster operator instability and high memory usage by the router.  A regression since 4.6, eventually fixed in 4.7.11 https://bugzilla.redhat.com/show_bug.cgi?id=1941840


### PR DESCRIPTION
1dd86a31bb (#891) was a bit too broad.  This commit makes two changes:

* The bug was an issue with all the early 4.7, up until the fix landed in 4.7.11.  So even though 4.7.4 and earlier already had incoming blocks for other bugs, I'd have added comments there too about their exposure to this bug.  That also helps set patterns for when we do have targeted edge blocking, so folks considering ignoring our recommendations and doing 4.6 -> 4.7.4, for example, would know they were exposed to all three of the blocker-worthy bugs that are known (so far) to affect that edge.

* The fact that this was a 4.6-to-4.7 regression, and not a 4.7.z regression, means that 4.7.4->4.7.5 and such were not increasing your exposure to the issue (much, I guess memory would be tighter while the nodes were rolling).  So the contribution of this bug only blocks 4.6->4.7.z (although other blocking bugs in that 4.7.z might impact 4.7->4.7.z).

Also, the blocker entry for 4.7.5 is academic, because we cut 4.7.5 with no baked-in incoming edges.  More details on that in f190365bec (#732).  But adding the explict entry seems easier than having folks wonder why it's not there, so even though that blocker file is effectively a no-op, I'm keeping it around.