### PR TITLE
Update minimum 4.7.z to 4.8

### DIFF
--- a/build-suggestions/4.8.yaml
+++ b/build-suggestions/4.8.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.7.16
+  minor_min: 4.7.20
   minor_max: 4.7.9999
   minor_block_list: []
   z_min: 4.8.0-rc.0


### PR DESCRIPTION
On account of https://bugzilla.redhat.com/show_bug.cgi?id=1977383
which leads to potential workload disruption during upgrades to
4.8. Note, this is only the assumed target version, this may change.