### PR TITLE
channels/candidate-4.[67]: Tombstone 4.6.37

### DIFF
--- a/channels/candidate-4.6.yaml
+++ b/channels/candidate-4.6.yaml
@@ -19,6 +19,8 @@ tombstones:
 - 4.6.24
 # Shares an errata with a later release
 - 4.6.33
+# 4.6.37 regressed on proxy handling https://bugzilla.redhat.com/show_bug.cgi?id=1978041
+- 4.6.37
 versions:
 - 4.5.41
 

--- a/channels/candidate-4.7.yaml
+++ b/channels/candidate-4.7.yaml
@@ -6,6 +6,8 @@ tombstones:
 - 4.6.24
 # Shares an errata with a later release
 - 4.6.33
+# 4.6.37 regressed on proxy handling https://bugzilla.redhat.com/show_bug.cgi?id=1978041
+- 4.6.37
 # 4.7.10 installer segfaults on install-config serviceEndpoints https://bugzilla.redhat.com/show_bug.cgi?id=1958420
 - 4.7.10
 # 4.7.14 moved monitoring to hard-anti-affinity, and that can conflict with volume affinity https://bugzilla.redhat.com/show_bug.cgi?id=1967614


### PR DESCRIPTION
The fix for [rhbz#1926944][1], which landed in 4.6.37, caused a regression in proxy handling in 4.6.37 ([rbhz#1978041][2]).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1926944
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1978041