### PR TITLE
Blocking edge from 4.5.41 to 4.6.35 and 4.6.36

### DIFF
--- a/blocked-edges/4.5.41-to-4.6.35.yaml
+++ b/blocked-edges/4.5.41-to-4.6.35.yaml
@@ -1,0 +1,3 @@
+to: 4.6.35
+from: 4.5.41
+# Because of a bug in the build pipeline the OS version in 4.5.41 (machine-os 45.82.202106211530-0) is higher than 4.6.35 (machine-os 46.82.202106110228-0)

--- a/blocked-edges/4.5.41-to-4.6.36.yaml
+++ b/blocked-edges/4.5.41-to-4.6.36.yaml
@@ -1,0 +1,3 @@
+to: 4.6.36
+from: 4.5.41
+# Because of a bug in the build pipeline the OS version in 4.5.41 (machine-os 45.82.202106211530-0) is higher than 4.6.36 (machine-os 46.82.202106181041-0 )


### PR DESCRIPTION
As the OS version in 4.5.41 is higher than 4.6.35 and 4.6.36

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>