### PR TITLE
requirements: Add requirements for Python scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyGithub >= 1.55
+PyYAML >= 5.4.0


### PR DESCRIPTION
The file is [consumed by source-to-image Python builds][1], which helps for things like running `hack/stabilization-changes.py` in a development cluster.  The format is documented [here][2].  The current latest releases for our two deps are [PyYAML 5.4.1][3] and [PyGithub 1.55][4].  I'm not bothering to freeze out the deeper dependencies, because they seem unlikely to break us, and if they do, we can notice and pin them in the future.

[1]: https://github.com/sclorg/s2i-python-container/tree/9d15b0d9d13777821d90a80f24f4ef0ced198c23/3.6#source-repository-layout
[2]: https://pip.pypa.io/en/latest/cli/pip_install/#requirements-file-format
[3]: https://pypi.org/project/PyYAML/
[4]: https://pypi.org/project/PyGithub/