### PR TITLE
hack/stabilization-changes: When polling, always pull before checking for stabilization

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -411,6 +411,9 @@ if __name__ == '__main__':
         upstream_remote = 'origin'
         upstream_branch = 'master'
 
+        if args.poll:
+            subprocess.run(['git', 'fetch', upstream_remote], check=True)
+            subprocess.run(['git', 'checkout', '{}/{}'.format(upstream_remote, upstream_branch)], check=True)
         stabilization_changes(
             directory='channels',
             github_repo=args.github_repo.strip(),
@@ -423,7 +426,5 @@ if __name__ == '__main__':
         if args.poll:
             _LOGGER.info('sleeping {} seconds before reconsidering promotions'.format(args.poll))
             time.sleep(args.poll)
-            subprocess.run(['git', 'fetch', upstream_remote], check=True)
-            subprocess.run(['git', 'checkout', '{}/{}'.format(upstream_remote, upstream_branch)], check=True)
         else:
             break


### PR DESCRIPTION
I'd added the pull code in f1ff8663dd (#926), to catch the local state up as the upstream branch advanced (via the bot's own stabilization pull requests landing or via other folks' pull requests).  But we aren't triggering rebuilds of the stabilization-changes image on branch bumps today, so when the robot pod is rescheduled or otherwise comes back up, it may be days or more stale.  We want to catch it up with upstream before the first stabilization check, so it doesn't pester our Slack channel with:

> * FAILED channels/fast-4.6: Promote 4.6.39. It was promoted to the feeder candidate-4.6 by 52f31155ee (Enable 4.6.39 in candidate channel(s), 2021-07-14) 7 days, 14:45:15.448017 ago. https://access.redhat.com/errata/RHBA-2021:2684 is public. version 4.6.39 has already been promoted to fast-4.6 in origin/master

and similar when the new pod comes up.