### PR TITLE
channels/candidate-4.8: Tombstone 4.8.1

### DIFF
--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -12,6 +12,8 @@ tombstones:
 - 4.7.20
 # 4.8.0 unspecified behavior change
 - 4.8.0
+# 4.8.1 s390x missed a kernel bump that went into the other platforms; rerolling as 4.8.2
+- 4.8.1
 versions:
 - 4.7.21
 


### PR DESCRIPTION
s390x missed a kernel bump that went into the other platforms.  We're building 4.8.2 to catch s390x up.