### PR TITLE
channels/fast-4.8: Promote 4.8.2

### DIFF
--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -1,6 +1,7 @@
-name: fast-4.8
 feeder:
-  name: candidate-4.8
   errata: public
   filter: 4\.8\.[0-9]+(.*hotfix.*)?
-versions: []
+  name: candidate-4.8
+name: fast-4.8
+versions:
+- 4.8.2


### PR DESCRIPTION
It was promoted to the feeder candidate-4.8 by 693ccc8fa4 (Merge pull request #939 from openshift/pr-candidate-4.8.2, 2021-07-22) 5 days, 3:06:13.159115 ago. https://access.redhat.com/errata/RHSA-2021:2438 is public.