### PR TITLE
Extend promotion delays

### DIFF
--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT48H
+  delay: PT72H
   name: fast-4.7
 name: stable-4.7
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,7 +1,7 @@
 name: stable-4.8
 feeder:
   name: fast-4.8
-  delay: PT48H
+  delay: PT96H
   filter: 4\.8\.[0-9]+(.*hotfix.*)?
 versions:
 - 4.8.2


### PR DESCRIPTION
The most current minor goes to 96hr, and in order to avoid the previous
minor not having upgrade paths into the latest minor extend its delay to
reduce the likelihood of that happening. This may be moot until we actually
bring stable channel upgrades to 4.8 and perhaps by the time we achieve
that milestone we decide to get closer to 72, 48, 24 across 4.N, 4.N-1, 4.N-2.

/cc @wking @LalatenduMohanty 