### PR TITLE
channels/stable-4.8: Promote 4.8.3

### DIFF
--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,7 +1,8 @@
-name: stable-4.8
 feeder:
-  name: fast-4.8
   delay: PT96H
   filter: 4\.8\.[0-9]+(.*hotfix.*)?
+  name: fast-4.8
+name: stable-4.8
 versions:
 - 4.8.2
+- 4.8.3


### PR DESCRIPTION
It was promoted to the feeder fast-4.8 by 6c1dd9adcb (Merge pull request #959 from openshift/promote-4.8.3-to-fast-4.8, 2021-08-03) 4 days, 0:13:40.762332 ago.