### PR TITLE
channels/stable-4.8: Promote 4.8.4

### DIFF
--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -6,3 +6,4 @@ name: stable-4.8
 versions:
 - 4.8.2
 - 4.8.3
+- 4.8.4


### PR DESCRIPTION
It was promoted to the feeder fast-4.8 by b08946faaa (Merge pull request #973 from openshift/promote-4.8.4-to-fast-4.8, 2021-08-10) 4 days, 0:08:15.936925 ago.