### PR TITLE
channels/{fast,stable}-4.9: Stub in for candidate-phase 4.9 flow

### DIFF
--- a/channels/fast-4.9.yaml
+++ b/channels/fast-4.9.yaml
@@ -1,0 +1,6 @@
+feeder:
+  errata: public
+  filter: 4\.9\.[0-9]+(.*hotfix.*)?
+  name: candidate-4.9
+name: fast-4.9
+versions: []

--- a/channels/stable-4.9.yaml
+++ b/channels/stable-4.9.yaml
@@ -1,0 +1,5 @@
+feeder:
+  filter: 4\.9\.[0-9]+(.*hotfix.*)?
+  name: fast-4.9
+name: stable-4.9
+versions: []


### PR DESCRIPTION
Now that ART has created candidate-4.9 with 4f8341049f (#997), create fast and stable consumers.  These won't hold any versions until 4.9 GAs, but creating the files with 'filter' makes that policy explicit.  Holding fast and stable 4.(y-1) releases out at this point avoids getting folks on those supported channels too excited about 4.y before it GAs. With the filter on fast-4.y, there is no need for a subsequent filter on stable-4.y, anything in fast is free to flow into stable after the configured delay.  But I've set the same filter in the stable channel anyway, because that's what we'll be using there post GA, while we look at 4.8 -> 4.9 updates in the fast channel before adding them to the stable channel.