### PR TITLE
blocked-edges/4.8.5: Restore updates from 4.7.24

### DIFF
--- a/blocked-edges/4.8.5.yaml
+++ b/blocked-edges/4.8.5.yaml
@@ -1,5 +1,5 @@
 to: 4.8.5
-from: 4[.]7[.].*|4[.]8[.][234]
+from: 4[.]7[.]2[123]|4[.]8[.][234]
 # Networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 # CRI-O leaks files into /run, potentially leading to node out-of-memory issues: https://bugzilla.redhat.com/show_bug.cgi?id=1997062#c24
 # Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23


### PR DESCRIPTION
4.8.5's baked-in update sources include some 4.7 which did not have the new vSphere HW 14 vulnerability:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.5-x86_64 | jq -r '.metadata.previous[] | select(startswith("4.7.") and . != "4.7.24")'
4.7.21
4.7.22
4.7.23
```

We want to keep blocking updates from those releases to 4.8, because that would regress their network handling on update.  But 4.7.24 is already vulnerable, so updating from 4.7.24 to 4.8.5 does not make the situation worse.  This commit restores those 4.7.24 to 4.8.5 recommendations.

No need to mess with earlier 4.8.z, because 4.8.4 was built before 4.7.24 and does not include it as an update source:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.4-x86_64 | jq -r '.metadata.previous[] | select(startswith("4.7."))'
4.7.21
4.7.22
4.7.23
```

So all of those would regress on updating to 4.8.4.