### PR TITLE
channels/candidate-4.[78]: Tombstone 4.7.26 and 4.8.7

### DIFF
--- a/blocked-edges/4.8.7.yaml
+++ b/blocked-edges/4.8.7.yaml
@@ -1,3 +1,0 @@
-to: 4.8.7
-from: 4\.7\..*
-# Networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108

--- a/channels/candidate-4.7.yaml
+++ b/channels/candidate-4.7.yaml
@@ -20,6 +20,8 @@ tombstones:
 - 4.7.20
 # 4.7.25 has a CRI-O path issue for born-before-4.6 clusters: https://bugzilla.redhat.com/show_bug.cgi?id=1995785
 - 4.7.25
+# 4.7.26 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
+- 4.7.26
 versions:
 - 4.6.43
 

--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -12,12 +12,16 @@ tombstones:
 - 4.7.20
 # 4.7.25 has a CRI-O path issue for born-before-4.6 clusters: https://bugzilla.redhat.com/show_bug.cgi?id=1995785
 - 4.7.25
+# 4.7.26 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
+- 4.7.26
 # 4.8.0 unspecified behavior change
 - 4.8.0
 # 4.8.1 s390x missed a kernel bump that went into the other platforms; rerolling as 4.8.2
 - 4.8.1
 # 4.8.6 has a CRI-O path issue for born-before-4.6 clusters: https://bugzilla.redhat.com/show_bug.cgi?id=1995785
 - 4.8.6
+# 4.8.7 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
+- 4.8.7
 versions:
 - 4.7.26
 


### PR DESCRIPTION
These are both vulnerable to [the vSphere networking bug][1].  They could still be useful updates from other versions which are also vulnerable (because vulnerable -> vulnerable is not a regression), but we're pushing 4.7.27 and 4.8.8 out soon with fixes, so tombstoning because we don't need to clutter the supported graph.

I'm also dropping the 4.8.7 edge blocks, because we don't manage edges for candidate-only releases.  If folks want to send candidate-level clusters across those edges, despite them being unsupported, they might discover further issues, which we can use to protect supported clusters taking other, similar edges.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1987108