### PR TITLE
channels/candidate-4.[89]: Tombstone 4.8.9 on missing errata URI

### DIFF
--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -22,6 +22,8 @@ tombstones:
 - 4.8.6
 # 4.8.7 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 - 4.8.7
+# 4.8.9's metadata lacked an errata URI
+- 4.8.9
 versions:
 - 4.7.28
 

--- a/channels/candidate-4.9.yaml
+++ b/channels/candidate-4.9.yaml
@@ -1,4 +1,7 @@
 name: candidate-4.9
+tombstones:
+# 4.8.9's metadata lacked an errata URI
+- 4.8.9
 versions:
 - 4.8.9
 


### PR DESCRIPTION
Compare:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.9-x86_64 | jq .metadata
{
  "kind": "cincinnati-metadata-v0",
  "version": "4.8.9",
  "previous": [
    "4.7.21",
    ...
    "4.8.7"
  ]
}
```

And:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.5-x86_64 | jq .metadata
{
  "kind": "cincinnati-metadata-v0",
  "version": "4.8.5",
  "previous": [
    "4.7.21",
    ...
    "4.8.4"
  ],
  "metadata": {
    "description": "",
    "url": "https://access.redhat.com/errata/RHSA-2021:3121"
  }
}
```