### PR TITLE
blocked-edges/4.7.28: Block all incoming edges while we sort regexps

### DIFF
--- a/blocked-edges/4.7.28.yaml
+++ b/blocked-edges/4.7.28.yaml
@@ -1,3 +1,3 @@
 to: 4.7.28
-from: ^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])$
+from: .*
 # CRI-O leaks files into /run, potentially leading to node out-of-memory issues: https://bugzilla.redhat.com/show_bug.cgi?id=1997062#c24


### PR DESCRIPTION
I don't understand why the regexp I was dropping didn't match 4.7.23, but for some reason it wasn't:

```console
$ CHANNEL=fast-4.7 ~/src/openshift/cincinnati/hack/available-updates.sh 4.7.23
4.7.28  quay.io/openshift-release-dev/ocp-release@sha256:b3f38d58057a12b0477bf28971390db3e3391ce1af8ac06e35d0aa9e8d8e5966       https://access.redhat.com/errata/RHSA-2021:3262
```

We don't want folks going from safe releases to this vulnerable release, so block everyone for a bit while we figure out how to phrase "but not 4.7.24".