### PR TITLE
blocked-edges/4.7.28: Restore nuanced edge blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ If you wish to block specific edges it might look like:
 
 ```yaml
 to: 4.2.0-rc.5
-from: ^4\.1\.(18|20)$
+from: ^4\.1\.(18|20)[+].*$
 ```
+
+The `[+].*` portion absorbs [the architecture-suffix](#release-names) from the release name that consumers will use for comparisons.
 
 [channel-semantics]: https://docs.openshift.com/container-platform/4.3/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
 [Cincinnati]: https://github.com/openshift/cincinnati/

--- a/blocked-edges/4.7.28.yaml
+++ b/blocked-edges/4.7.28.yaml
@@ -1,4 +1,4 @@
 to: 4.7.28
-from: .*
+from: ^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])[+].*$
 # CRI-O leaks files into /run, potentially leading to node out-of-memory issues: https://bugzilla.redhat.com/show_bug.cgi?id=1997062#c24
 # Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23


### PR DESCRIPTION
History:

* 2a70cf5bdc (#1022) attempted nuanced edge blocking.
* 49b580829e (#1025) added anchors, to prevent things like the `4[.]7[.][0-9]` alternative matching (and blocking) `4.7.24`, and similar.
* 9d348f9a08 (#1030), which went to `.*` because the anchored regexp was not matching as expected, and was allowing 4.7.23 -> 4.7.28 and similar.

It turns out that the versions Cincinnati is comparing with are [architecture-suffixed release names][1], not the raw release name from the release image's metadata.  So `4.7.24+amd64`, etc.  The new regular expression restores the multiple alternatives and anchors, but includes a new `[+].*` portion to absorb the architecture suffix.

[1]: https://github.com/openshift/cincinnati-graph-data/tree/f653d3828832c0869df0e44dd7af7fc9b2079a63#release-names