### PR TITLE
blocked-edges: Block edges into 4.7.29 and 4.8.10 on Ceph corruption

### DIFF
--- a/blocked-edges/4.7.29.yaml
+++ b/blocked-edges/4.7.29.yaml
@@ -1,0 +1,3 @@
+to: 4.7.29
+from: ^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])[+].*$
+# Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23

--- a/blocked-edges/4.8.10.yaml
+++ b/blocked-edges/4.8.10.yaml
@@ -1,0 +1,3 @@
+to: 4.8.10
+from: 4[.]7[.].*
+# Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23


### PR DESCRIPTION
These releases are still in candidate, but they seem to be headed into fast, so set up their edge blocks to keep folks from slipping into [the vulnerable 4.7.24+ or 4.8+][1].  Transitions within the vulnerable set are allowed.  Testing the complicated regexp vs. 4.7.29's built in edges and joining against supported fast-4.7 versions:

```console
$ join <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.7.29-x86_64 | jq -r '.metadata.previous[] | select(test("^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])$") | not)' | sort) <(curl -s 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=fast-4.7&arch=amd64' | jq -r '.nodes[].version' | sort)
4.7.24
4.7.28
```

And then adding `[+].*` to absorb [the architecture suffix][2].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23
[2]: https://github.com/openshift/cincinnati-graph-data/tree/f653d3828832c0869df0e44dd7af7fc9b2079a63#release-names