### PR TITLE
blocked-edges/4.8.10: Updates from 4.7.24+ already have the Ceph bug

### DIFF
--- a/blocked-edges/4.8.10.yaml
+++ b/blocked-edges/4.8.10.yaml
@@ -1,3 +1,3 @@
 to: 4.8.10
-from: 4[.]7[.].*
+from: 4[.]7[.]2[123]
 # Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23


### PR DESCRIPTION
So tighten the regexp to only block the older entries:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.10-x86_64 | jq -r '.metadata.previous[]' | sort -V | grep -v ^4.8
4.7.21
4.7.22
4.7.23
4.7.24
4.7.25
4.7.26
4.7.28
4.7.29
```