### PR TITLE
Blocking all the incoming edges to 4.7.10, 4.7.14, 4.7.15, 4.7.20

### DIFF
--- a/blocked-edges/4.7.10.yaml
+++ b/blocked-edges/4.7.10.yaml
@@ -1,0 +1,3 @@
+to: 4.7.10
+from: .*
+# Blocking all the incoming edges as these versions are tombstoned in candidate-4.7 channel but accidentally promoted to fast-4.8 channel

--- a/blocked-edges/4.7.14.yaml
+++ b/blocked-edges/4.7.14.yaml
@@ -1,0 +1,3 @@
+to: 4.7.14
+from: .*
+# Blocking all the incoming edges as these versions are tombstoned in candidate-4.7 channel but accidentally promoted to fast-4.8 channel

--- a/blocked-edges/4.7.15.yaml
+++ b/blocked-edges/4.7.15.yaml
@@ -1,0 +1,3 @@
+to: 4.7.15
+from: .*
+# Blocking all the incoming edges as these versions are tombstoned in candidate-4.7 channel but accidentally promoted to fast-4.8 channel

--- a/blocked-edges/4.7.20.yaml
+++ b/blocked-edges/4.7.20.yaml
@@ -1,0 +1,3 @@
+to: 4.7.20
+from: .*
+# Blocking all the incoming edges as these versions are tombstoned in candidate-4.7 channel but accidentally promoted to fast-4.8 channel


### PR DESCRIPTION
As these versions are tombstoned in candidate-4.7 channel but accidentally promoted to fast-4.8 channel in 8da5782

These are the commit id when the versions were the tombstoned: 00045bf4, a6629b78, b63be1be, 54accf9c

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>