### PR TITLE
blocked-edges/4.7.28: Expand blocked release to include fast-4.8 zombies

### DIFF
--- a/blocked-edges/4.7.28.yaml
+++ b/blocked-edges/4.7.28.yaml
@@ -1,4 +1,4 @@
 to: 4.7.28
-from: ^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])[+].*$
+from: ^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0-9]|4[.]7[.]2[0123])[+].*$
 # CRI-O leaks files into /run, potentially leading to node out-of-memory issues: https://bugzilla.redhat.com/show_bug.cgi?id=1997062#c24
 # Internal registry is rejecting the container creation due to sha256 layer mismatch when CephFS is used for the PV https://bugzilla.redhat.com/show_bug.cgi?id=1999591#c23


### PR DESCRIPTION
A few releases slipped into fast-4.8, despite being tombzoned in candidate releases, 4c53c7b4bd (#1035).  Because I'd been comparing with fast-4.7 when developing the 4.7.28 blocker regexp, 2a70cf5bdc (#1022), those zombie releases still had edges:

```console
$ join <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.7.28-x86_64 | jq -r '.metadata.previous[] | select(test("^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[1236789]|4[.]7[.]2[123])$") | not)' | sort) <(curl -s 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=fast-4.8&arch=amd64' | jq -r '.nodes[].version' | sort)
4.7.10
4.7.14
4.7.15
4.7.20
4.7.24
```

With this commit, I'm extending the regular expression to exclude them, except for 4.7.24 which is already vulnerable to the bugs impacting 4.7.28:

```console
$ join <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.7.28-x86_64 | jq -r '.metadata.previous[] | select(test("^(4[.]6[.].*|4[.]7[.][0-9]|4[.]7[.]1[0-9]|4[.]7[.]2[0123])$") | not)' | sort) <(curl -s 'https://api.openshift.com/api/upgrades_info/v1/graph?channel=fast-4.8&arch=amd64' | jq -r '.nodes[].version' | sort)
4.7.24
```