### PR TITLE
Dockerfile: For easy graph-data image construction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.1
+WORKDIR /home
+COPY . graph-data
+RUN mkdir -p /var/lib/cincinnati/graph-data
+CMD cp -rp graph-data/* /var/lib/cincinnati/graph-data


### PR DESCRIPTION
Loosely based on [1], but simplified because we have the data in the
local directory and don't need to curl it down.  We still need to
dynamically move it into the expected directory when this image is
invoked as an init-container [2].

[1]: https://docs.openshift.com/container-platform/4.8/updating/installing-update-service.html#update-service-graph-data_update-service
[2]: https://github.com/openshift/cincinnati-operator/blob/1a746871611d4ccb07aa7599c9eac0ef21df56d1/docs/graph-data-init-container.md