### PR TITLE
build-suggestions/4.9: Raise minor_min to 4.8.5

### DIFF
--- a/build-suggestions/4.9.yaml
+++ b/build-suggestions/4.9.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.8.0
+  minor_min: 4.8.5
   minor_max: 4.8.9999
   minor_block_list: []
   z_min: 4.9.0-fc.0


### PR DESCRIPTION
To ensure OLM is [failing closed on missing `maxOpenShiftVersion`][1], because it's no fun if someone updates from 4.8.2 to 4.9 and has all their v1beta1-CRD-based OLM-installed operators break.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1989711#c7