### PR TITLE
build-suggestions/4.9: Bump minor_min to 4.8.12

### DIFF
--- a/build-suggestions/4.9.yaml
+++ b/build-suggestions/4.9.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.8.11
+  minor_min: 4.8.12
   minor_max: 4.8.9999
   minor_block_list: []
   z_min: 4.9.0-fc.0


### PR DESCRIPTION
It was bumped to 4.8.11 in fb730b7114 (#1065) to pick up [the Ceph data corruption fix][1].  I'm bumping it to 4.8.12 to pick up [etcd backups][2].  There will be at least one more bump further on to pick up [admin acks][3], but we don't need to wait for that before raising the floor.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1996680
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1999777#c19
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1999092