### PR TITLE
Increase fast to stable delay to 7d

### DIFF
--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT48H
+  delay: PT7D
   name: fast-4.6
 name: stable-4.6
 versions:

--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT72H
+  delay: PT7D
   name: fast-4.7
 name: stable-4.7
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT96H
+  delay: PT7D
   name: fast-4.8
 name: stable-4.8
 versions:


### PR DESCRIPTION
Our telemetry analysis works best when we have a certain minimum
number of cluster days and our current delays weren't long enough.
As the fleet grows, participation in the fast channe grows, or we
improve our analysis we will revisit these values.

Aligning them all to the same value also ensures that we're less
likely to push something into stable-4.6 which cannot upgrade to
stable-4.7. We should also consider other solutions to this problem
such as only adding versions which do not match the channels X.Y
after that version has upgrade edges off of that, ie: 4.6.100 would
be added to stable-4.6 per normal delay, however it would not be
added to stable-4.7 until there's an upgrade from 4.6.100 to 4.7.N.