### PR TITLE
Use 168H rather than 7D

### DIFF
--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: PT168H
   name: fast-4.6
 name: stable-4.6
 versions:

--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: PT168H
   name: fast-4.7
 name: stable-4.7
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: PT168H
   name: fast-4.8
 name: stable-4.8
 versions:


### PR DESCRIPTION
Apparently our ISO 8601 duration implementation doesn't like D.

```
Traceback (most recent call last):
  File "hack/stabilization-changes.py", line 431, in <module>
    stabilization_changes(
  File "hack/stabilization-changes.py", line 47, in stabilization_changes
    notifications.extend(stabilize_channel(name=name, channel=channel, channels=channels, channel_paths=channel_paths, cache=cache, **kwargs))
  File "hack/stabilization-changes.py", line 60, in stabilize_channel
    delay = parse_iso8601_delay(delay=delay_string)
  File "hack/stabilization-changes.py", line 36, in parse_iso8601_delay
    raise ValueError('invalid or unsupported ISO 8601 duration {!r}.  Tooling currently only supports P<number>WT<number>H for week and/or hour offsets')
ValueError: invalid or unsupported ISO 8601 duration {!r}.  Tooling currently only supports P<number>WT<number>H for week and/or hour offsets
```