### PR TITLE
hack/stabilization-changes: Add support for day durations

### DIFF
--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT168H
+  delay: PT7D
   name: fast-4.6
 name: stable-4.6
 versions:

--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT168H
+  delay: PT7D
   name: fast-4.7
 name: stable-4.7
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT168H
+  delay: PT7D
   name: fast-4.8
 name: stable-4.8
 versions:

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -22,7 +22,7 @@ logging.basicConfig(format='%(levelname)s: %(message)s')
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.DEBUG)
 _ADVISORY_TYPE_REGEXP = re.compile(r'RH[BS]A')
-_ISO_8601_DELAY_REGEXP = re.compile(r'^P((?P<weeks>\d+)W)?(T(?P<hours>\d+)H)?$')
+_ISO_8601_DELAY_REGEXP = re.compile(r'^P((?P<weeks>\d+)W|((?P<days>\d+)D)?(T(?P<hours>\d+)H)?)$')
 _GIT_BLAME_COMMIT_REGEXP = re.compile(r'^(?P<hash>[0-9a-f]{40}) .*')
 _GIT_BLAME_HEADER_REGEXP = re.compile(r'^(?P<key>[^ \t]+) (?P<value>.*)$')
 _GIT_BLAME_LINE_REGEXP = re.compile(r'^\t(?P<value>.*)$')
@@ -33,10 +33,11 @@ def parse_iso8601_delay(delay):
     # https://tools.ietf.org/html/rfc3339#page-13
     match = _ISO_8601_DELAY_REGEXP.match(delay)
     if not match:
-        raise ValueError('invalid or unsupported ISO 8601 duration {!r}.  Tooling currently only supports P<number>WT<number>H for week and/or hour offsets')
+        raise ValueError('invalid or unsupported ISO 8601 duration {!r}.  Tooling currently only supports P<number>W for weeks, or P<number>DT<number>H for day/hour offsets'.format(delay))
     weeks = int(match.group('weeks') or 0)
+    days = int(match.group('days') or 0)
     hours = int(match.group('hours') or 0)
-    return datetime.timedelta(days=7*weeks, hours=hours)
+    return datetime.timedelta(days=7*weeks + days, hours=hours)
 
 
 def stabilization_changes(directory, webhook=None, **kwargs):

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -37,7 +37,7 @@ def parse_iso8601_delay(delay):
     weeks = int(match.group('weeks') or 0)
     days = int(match.group('days') or 0)
     hours = int(match.group('hours') or 0)
-    return datetime.timedelta(days=7*weeks + days, hours=hours)
+    return datetime.timedelta(weeks=weeks, days=days, hours=hours)
 
 
 def stabilization_changes(directory, webhook=None, **kwargs):


### PR DESCRIPTION
From [RFC 3339][1]:

```
Durations:

dur-second        = 1*DIGIT "S"
dur-minute        = 1*DIGIT "M" [dur-second]
dur-hour          = 1*DIGIT "H" [dur-minute]
dur-time          = "T" (dur-hour / dur-minute / dur-second)
dur-day           = 1*DIGIT "D"
dur-week          = 1*DIGIT "W"
dur-month         = 1*DIGIT "M" [dur-day]
dur-year          = 1*DIGIT "Y" [dur-month]
dur-date          = (dur-day / dur-month / dur-year) [dur-time]

duration          = "P" (dur-date / dur-time / dur-week)
```

So fully supported:

* `dur-hour`
* `dur-day` (this commit)
* `dur-week`

Not supported:

* `dur-second`
* `dur-minute`
* `dur-month`
* `dur-year`

Partially supported:

* `dur-time`
* `dur-date`
* `duration`

This allows us to revert 75c9c782a6 (#1103), to regain the more-intuitive days.

[1]: https://datatracker.ietf.org/doc/html/rfc3339#page-13