### PR TITLE
channels/stable-4.*: Fix delay "PT7D" to "P1W"

### DIFF
--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: P1W
   name: fast-4.6
 name: stable-4.6
 versions:

--- a/channels/stable-4.7.yaml
+++ b/channels/stable-4.7.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: P1W
   name: fast-4.7
 name: stable-4.7
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT7D
+  delay: P1W
   name: fast-4.8
 name: stable-4.8
 versions:


### PR DESCRIPTION
"one week" puts all the weight on the unit, while "seven days" requires you to think about both the unit and the magnitude ;).

But more importantly, `T7D` is illegal, because [`T` is the marker for "and now we're going to start talking about times"][1], and days are larger than times.

[1]: https://datatracker.ietf.org/doc/html/rfc3339#page-13