### PR TITLE
channels/fast-4.9: Promote 4.9.0

### DIFF
--- a/channels/fast-4.9.yaml
+++ b/channels/fast-4.9.yaml
@@ -3,4 +3,5 @@ feeder:
   filter: 4\.9\.[0-9]+(.*hotfix.*)?
   name: candidate-4.9
 name: fast-4.9
-versions: []
+versions:
+- 4.9.0


### PR DESCRIPTION
It was promoted to the feeder candidate-4.9 by f5584ac778 (Merge pull request #1129 from openshift/pr-candidate-4.9.0, 2021-10-14) 3 days, 23:34:58.398755 ago. https://access.redhat.com/errata/RHSA-2021:3759 is public.