### PR TITLE
hack/validate-blocked-edges: Python 2 compatability

### DIFF
--- a/hack/validate-blocked-edges.py
+++ b/hack/validate-blocked-edges.py
@@ -19,10 +19,13 @@ def validate_blocked_edges(directory):
             try:
                 validate_blocked_edge(data=data)
             except Exception as error:
-                raise ValueError('invalid blocked edge {}'.format(path)) from error
+                raise ValueError('invalid blocked edge {}: {}'.format(path, error))
 
 
 def validate_blocked_edge(data):
+    for prop in ['to', 'from']:
+        if prop not in data:
+            raise ValueError('{!r} is a required property'.format(prop))
     if 'url' in data and not data['url'].startswith('https://'):
         raise ValueError('url must be an https:// URI, not {!r}'.format(data['url']))
     if 'name' in data and (not isinstance(data['name'], str) or ' ' in data['name']):


### PR DESCRIPTION
Based on [this run][1], ubi8.python.36 currently has:

* `python` for 2.7.5
* `python3` for 3.6.8

and the `python` invocation was [failing with][1]:

      File "/go/src/github.com/openshift/cincinnati-graph-data/hack/validate-blocked-edges.py", line 22
        raise ValueError('invalid blocked edge {}'.format(path)) from error
                                                                    ^
    SyntaxError: invalid syntax

From [PEP 344][2] and [PEP 3109][3], I'd have expected:

```python
raise ... from ...
```

to work with 2.5+ and all 3, but, shrug.  And [we're using `pip3`][4] to install our dependencies.  So invoke this script with `python3` to avoid both issues.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/22076/rehearse-22076-pull-ci-openshift-cincinnati-graph-data-master-validate-blocked-edges/1450657743043039232
[2]: https://www.python.org/dev/peps/pep-0344/
[3]: https://www.python.org/dev/peps/pep-3109/
[4]: https://github.com/openshift/release/blob/7e61829f682e1574513f78c3e94537836d824ab3/ci-operator/config/openshift/cincinnati-graph-data/openshift-cincinnati-graph-data-master.yaml#L21