### PR TITLE
hack/stabilization-changes: Request Python 3

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import codecs
 import datetime


### PR DESCRIPTION
I've made no attempts at Python 2 compat with this script, and there are some fundamental issues with imports and such that would be tedious to resolve.  The proximal failure is:

```console
$ python2 --version
Python 2.7.18
$ python2 hack/stabilization-changes.py
  File "hack/stabilization-changes.py", line 86
    yield from stabilize_release(
             ^
SyntaxError: invalid syntax
```

This uses the [recommended][1] [shebang][2] for Python 3.

[1]: https://docs.python.org/3/using/unix.html#miscellaneous
[2]: https://www.python.org/dev/peps/pep-0397/