### PR TITLE
build-suggestions/4.9: Raise 4.9 z_min to 4.9.0

### DIFF
--- a/build-suggestions/4.9.yaml
+++ b/build-suggestions/4.9.yaml
@@ -5,7 +5,7 @@ default:
   minor_min: 4.8.14
   minor_max: 4.8.9999
   minor_block_list: []
-  z_min: 4.9.0-fc.0
+  z_min: 4.9.0
   z_max: 4.9.9999
   z_block_list: []
 # s390x:


### PR DESCRIPTION
Now that 4.9 is GA, so we cut down on the edges getting tested by pruning these candidate-only entries.  This is similar to 4.8's 7ce799a7f8 (#1065).