### PR TITLE
channels/candidate-4.[78]: Tombstone 4.7.35

### DIFF
--- a/channels/candidate-4.7.yaml
+++ b/channels/candidate-4.7.yaml
@@ -22,6 +22,8 @@ tombstones:
 - 4.7.25
 # 4.7.26 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 - 4.7.26
+# 4.7.35 lacks metadata errata URIs for s390x and ppc64le
+- 4.7.35
 versions:
 - 4.6.48
 

--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -14,6 +14,8 @@ tombstones:
 - 4.7.25
 # 4.7.26 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 - 4.7.26
+# 4.7.35 lacks metadata errata URIs for s390x and ppc64le
+- 4.7.35
 # 4.8.0 unspecified behavior change
 - 4.8.0
 # 4.8.1 s390x missed a kernel bump that went into the other platforms; rerolling as 4.8.2


### PR DESCRIPTION
It's missing errata URIs for s390x and ppc64le:

```console
$ for ARCH in x86_64 s390x ppc64le; do echo -n "${ARCH} "; oc adm release info -o json "quay.io/openshift-release-dev/ocp-release:4.7.35-${ARCH}" | jq -c .metadata.metadata; done
x86_64 {"description":"","url":"https://access.redhat.com/errata/RHSA-2021:3931"}
s390x null
ppc64le null

We want update UIs and similar to have that metadata, so they can link cluster admins to it, so the cluster admins can learn what is new with the target release they're considering updating to.