### PR TITLE
channels/candidate-4.[89]: Tombstone 4.8.16

### DIFF
--- a/channels/candidate-4.8.yaml
+++ b/channels/candidate-4.8.yaml
@@ -22,6 +22,8 @@ tombstones:
 - 4.8.6
 # 4.8.7 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 - 4.8.7
+# 4.8.16's amd64 build only has baked-in update edges from 4.7.35
+- 4.8.16
 versions:
 - 4.7.36
 

--- a/channels/candidate-4.9.yaml
+++ b/channels/candidate-4.9.yaml
@@ -2,6 +2,8 @@ name: candidate-4.9
 tombstones:
 # 4.8.7 has a networking issue with vSphere clusters running HW14 and later. SDN Packet loss resulting in service unavailability.  https://bugzilla.redhat.com/show_bug.cgi?id=1987108
 - 4.8.7
+# 4.8.16's amd64 build only has baked-in update edges from 4.7.35
+- 4.8.16
 versions:
 - 4.8.17
 


### PR DESCRIPTION
The amd64 update metadata is broken:

```console
$ for ARCH in x86_64 s390x ppc64le; do echo -n "${ARCH} "; oc adm release info -o json "quay.io/openshift-release-dev/ocp-release:4.8.16-${ARCH}" | jq -c .metadata.previous; done
x86_64 ["4.7.35"]
s390x ["4.7.21","4.7.22","4.7.23","4.7.24","4.7.25","4.7.26","4.7.28","4.7.29","4.7.30","4.7.31","4.7.32","4.7.33","4.7.34","4.7.35","4.8.10","4.8.11","4.8.12","4.8.13","4.8.14","4.8.15","4.8.2","4.8.3","4.8.4","4.8.5","4.8.6","4.8.7","4.8.9"]
ppc64le ["4.7.21","4.7.22","4.7.23","4.7.24","4.7.25","4.7.26","4.7.28","4.7.29","4.7.30","4.7.31","4.7.32","4.7.33","4.7.34","4.7.35","4.8.10","4.8.11","4.8.12","4.8.13","4.8.14","4.8.15","4.8.2","4.8.3","4.8.4","4.8.5","4.8.6","4.8.7","4.8.9"]
```

And we want to make it easy to get from older 4.7 and 4.8 to 4.8.16 or later, especially because it contains the fix for [the egress SDN issue][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2014166