### PR TITLE
channels/candidate-4.9: Tombstone 4.9.1

### DIFF
--- a/channels/candidate-4.9.yaml
+++ b/channels/candidate-4.9.yaml
@@ -4,6 +4,8 @@ tombstones:
 - 4.8.7
 # 4.8.16's amd64 build only has baked-in update edges from 4.7.35
 - 4.8.16
+# 4.9.1 lacked a baked-in update from 4.8.17
+- 4.9.1
 versions:
 - 4.8.17
 


### PR DESCRIPTION
4.8.16 was tombstoned on broken update metadata in 1315738335 (#1158).  It was rerolled as 4.8.17, so we need to reroll 4.9.1 with metadata that includes 4.8.17 as an update source.