### PR TITLE
Apply 4.6 EOL feeder changes

### DIFF
--- a/channels/eus-4.6.yaml
+++ b/channels/eus-4.6.yaml
@@ -1,7 +1,6 @@
-feeder:
-  delay: PT0H
-  filter: 4\.6\.[0-9]+(.*hotfix.*)?
-  name: stable-4.6
+-feeder:
+  delay: P1W
+  name: fast-4.6
 name: eus-4.6
 versions:
 - 4.6.1

--- a/channels/stable-4.6.yaml
+++ b/channels/stable-4.6.yaml
@@ -1,6 +1,3 @@
-feeder:
-  delay: P1W
-  name: fast-4.6
 name: stable-4.6
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832


### PR DESCRIPTION
Per the OpenShift Life Cycle document 4.6 maintains the previously
defined life cycle which ended non-eus support when 4.9 went GA. As
such additional 4.6.z will only be added to eus-4.6 channel.

https://access.redhat.com/support/policy/updates/openshift