### PR TITLE
channels/eus-4.6: Fix 'feeder' config and restore 'filter'

### DIFF
--- a/channels/eus-4.6.yaml
+++ b/channels/eus-4.6.yaml
@@ -1,6 +1,7 @@
--feeder:
+feeder:
   delay: P1W
   name: fast-4.6
+  filter: 4\.6\.[0-9]+(.*hotfix.*)?
 name: eus-4.6
 versions:
 - 4.6.1


### PR DESCRIPTION
63594b5dba (#1173) had a leading `-` that left the `feeder` property unrecognized.  This commit fixes that, and then adds the associated promotions via:

```console
$ hack/stabilization-changes.py
...
* channels/eus-4.6: Promote 4.5.40. It was promoted to the feeder fast-4.6 by f310ef479b (Merge pull request #876 from openshift/promote-4.6.35-to-fast-4.6, 2021-06-22) 126 days, 19:26:09.760711 ago. data://no-token-so-no-pull
* channels/eus-4.6: Promote 4.5.41. It was promoted to the feeder fast-4.6 by 721923edf9 (Merge pull request #901 from openshift/promote-4.5.41-to-fast-4.6, 2021-06-30) 119 days, 2:56:59.788855 ago. data://no-token-so-no-pull
...
```