### PR TITLE
hack/stabilization-changes.py: link to commit instead of hash/message, update formatting

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -151,7 +151,7 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
                 time_message = "Current promotion delay will be satisfied on {}".format(feeder_promotion['committer-time'] + delay)
             else:
                 time_message = "Merged {}".format(merged_ago)
-            yield 'Recommend waiting to promote {} to {}; it was promoted the to feeder {} by {} {}){}'.format(
+            yield 'Recommend waiting to promote {} to {}; it was promoted the to feeder {} by {} {}) {}'.format(
                 version,
                 channel_name,
                 feeder_name,

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -105,11 +105,11 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
             public_errata_message = ' {} is{} public.'.format(errata_uri, '' if errata_public else ' not')
     if (delay is not None and version_delay > delay) or errata_public:
         path_without_extension, _ = os.path.splitext(channel_path)
+        commit_link = '<https://github.com/openshift/cincinnati-graph-data/commits/{0}|{0}>'.format(feeder_promotion['hash'][:10])
         subject = '{}: Promote {}'.format(path_without_extension, version)
-        body = 'It was promoted to the feeder {} by {} ({}, {}) {} ago.{}'.format(
+        body = 'It was promoted to the feeder {} by {} ({}) {} ago.{}'.format(
                 feeder_name,
-                feeder_promotion['hash'][:10],
-                feeder_promotion['summary'],
+                commit_link,
                 feeder_promotion['committer-time'].date().isoformat(),
                 version_delay,
                 public_errata_message,

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -147,10 +147,10 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
             time_message = None
             if delay:
                 # Show expected date to promote
-                time_message = "Expected to be promoted on {}".format(feeder_promotion['committer-time'] + delay)
+                time_message = "Current promotion delay will be satisfied on {}".format(feeder_promotion['committer-time'] + delay)
             else:
                 time_message = "Merged {}".format(merged_ago)
-            yield 'Recommend waiting to promote {} to {}; it was promoted the feeder {} by {} {}){}'.format(
+            yield 'Recommend waiting to promote {} to {}; it was promoted the to feeder {} by {} {}){}'.format(
                 version,
                 channel_name,
                 feeder_name,

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -2,7 +2,6 @@
 
 import codecs
 import datetime
-import dateutil.relativedelta
 import http
 import json
 import logging
@@ -95,18 +94,22 @@ def stabilize_channel(name, channel, channels, channel_paths, **kwargs):
             **kwargs)
 
 
-def human_readable_relativedelta(delta):
-    attrs = ['years', 'months', 'days', 'hours', 'minutes']
-    human_readable = ['%d %s' % (getattr(delta, attr), attr if getattr(delta, attr) > 1 else attr[:-1])
-        for attr in attrs if getattr(delta, attr)]
+def human_readable_relativedelta(delay):
+    delta = {}
+    # Convert delay.seconds to hours and minutes
+    delta["days"] = delay.days
+    delta["hours"] = delay.seconds // 3600
+    delta["minutes"] = delay.seconds // 60 % 60
+    human_readable = [
+        '{} {}'.format(delta.get(attr), attr if delta.get(attr) > 1 else attr[:-1])
+            for attr in delta.keys()]
     return "{} ago".format(", ".join(human_readable))
 
 
 def stabilize_release(version, channel_name, channel_path, delay, errata, feeder_name, feeder_promotion, cache, waiting_notifications=True, **kwargs):
     now = datetime.datetime.now()
     version_delay = now - feeder_promotion['committer-time']
-    merged_ago = human_readable_relativedelta(
-        dateutil.relativedelta.relativedelta(now, feeder_promotion['committer-time']))
+    merged_ago = human_readable_relativedelta(version_delay)
     errata_public = False
     public_errata_message = ''
     commit_link = '<https://github.com/openshift/cincinnati-graph-data/commits/{0}|{0}>'.format(feeder_promotion['hash'][:10])

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import codecs
+import collections
 import datetime
 import http
 import json
@@ -95,7 +96,7 @@ def stabilize_channel(name, channel, channels, channel_paths, **kwargs):
 
 
 def human_readable_relativedelta(delay):
-    delta = {}
+    delta = collections.OrderedDict()
     # Convert delay.seconds to hours and minutes
     delta["days"] = delay.days
     delta["hours"] = delay.seconds // 3600

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -113,7 +113,11 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
     merged_ago = human_readable_relativedelta(version_delay)
     errata_public = False
     public_errata_message = ''
-    commit_link = '<https://github.com/openshift/cincinnati-graph-data/commits/{0}|{0}>'.format(feeder_promotion['hash'][:10])
+
+    # Use commit link unless its dummy hash
+    commit_link = ''
+    if feeder_promotion['hash'][:10] != '0'*10:
+        commit_link = '<https://github.com/openshift/cincinnati-graph-data/commits/{0}|{0}>'.format(feeder_promotion['hash'][:10])
     if errata:
         errata_uri, errata_public = public_errata_uri(version=version, channel=feeder_name, cache=cache)
         if errata_uri:
@@ -121,9 +125,10 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
     if (delay is not None and version_delay > delay) or errata_public:
         path_without_extension, _ = os.path.splitext(channel_path)
         subject = '{}: Promote {}'.format(path_without_extension, version)
-        body = 'It was promoted to the feeder {} by {} ({}) {}.{}'.format(
+        body = 'It was promoted to the feeder {} by {} {} ({}) {}.{}'.format(
                 feeder_name,
                 commit_link,
+                feeder_promotion['summary'],
                 feeder_promotion['committer-time'].date().isoformat(),
                 merged_ago,
                 public_errata_message,
@@ -151,11 +156,13 @@ def stabilize_release(version, channel_name, channel_path, delay, errata, feeder
                 time_message = "Current promotion delay will be satisfied on {}".format(feeder_promotion['committer-time'] + delay)
             else:
                 time_message = "Merged {}".format(merged_ago)
-            yield 'Recommend waiting to promote {} to {}; it was promoted the to feeder {} by {} {}) {}'.format(
+            yield 'Recommend waiting to promote {} to {}; it was promoted to the feeder {} by {} {} ({}). {}{}'.format(
                 version,
                 channel_name,
                 feeder_name,
                 commit_link,
+                feeder_promotion['summary'],
+                feeder_promotion['committer-time'].date().isoformat(),
                 time_message,
                 public_errata_message)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyGithub >= 1.55
 PyYAML >= 5.4.0
-python-dateutil >= 2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyGithub >= 1.55
 PyYAML >= 5.4.0
+python-dateutil >= 2.8.2


### PR DESCRIPTION
Show a link to commit instead of hash+commit message, convert dates to human readable (without seconds or milliseconds) and show expected time to merge for promotions.

This changes the webhook bot text from
`* Recommend waiting to promote 4.6.49 to fast-4.6; it was promoted the feeder candidate-4.6 by 7f82da1c9c (Merge pull request #1169 from openshift/pr-candidate-4.6.49, 2021-10-27, 5 days, 20:28:09.641705) https://access.redhat.com/errata/RHBA-2021:4009 is not public.`
to
`* Recommend waiting to promote 4.6.49 to fast-4.6; it was promoted the feeder candidate-4.6 by <https://github.com/openshift/cincinnati-graph-data/commits/7f82da1c9c|7f82da1c9c> Merged 5 days, 20 hours, 27 minutes ago) https://access.redhat.com/errata/RHBA-2021:4009 is not public.`
for non-public erratas 

and  
`* Recommend waiting to promote 4.7.36 to stable-4.7; it was promoted the feeder fast-4.7 by 1843c9c1ac (Merge pull request #1164 from openshift/promote-4.7.36-to-fast-4.7, 2021-10-27, 6 days, 0:58:18.461610)`
to
`* Recommend waiting to promote 4.7.36 to stable-4.7; it was promoted the feeder fast-4.7 by <https://github.com/openshift/cincinnati-graph-data/commits/1843c9c1ac|1843c9c1ac> Expected to be promoted on 2021-11-03 10:55:55)`
for delayed promotions.

Format `<https://foo.com|bar>` should be translated by Slack to a hyperlink