### PR TITLE
channels/stable-4.9: Promote 4.9.4

### DIFF
--- a/channels/stable-4.9.yaml
+++ b/channels/stable-4.9.yaml
@@ -5,3 +5,4 @@ feeder:
 name: stable-4.9
 versions:
 - 4.9.0
+- 4.9.4


### PR DESCRIPTION
It was promoted to the feeder fast-4.9 by 3c6edc9ab9 (Merge pull request #1161 from openshift/promote-4.9.4-to-fast-4.9, 2021-10-26) 7 days, 0:41:44.203011 ago.