### PR TITLE
channels/eus-4.8: Adjust filter to accept 4.6.z and 4.7.(z >= 34)

### DIFF
--- a/channels/eus-4.8.yaml
+++ b/channels/eus-4.8.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.8\.[0-9]+(.*hotfix.*)?
+  filter: 4\.[68]\.[0-9].*|4\.7\.(3[4-9]|[4-9][0-9])
   name: stable-4.8
 name: eus-4.8
 versions:


### PR DESCRIPTION
At least until we hit 4.7.100, which my regexp would reject.  I expect that will never happen, and even if it does, it will be a long way off, and easy to recover from with further regexp tweaks.

This automates part of the promotion process that began manually in 470f191be3 (#1189), so now the stabilization robot will manage 4.7.z and 4.8.z promotion into this channel.  We'll still need to handle 4.6.z promotion manually for now, because the feeder stable-4.8 does not include any 4.6.z.  There are a few options being discussed to get that automated too, but in the meantime, this filter relaxation will reduce the amount of manual toil needed to maintain this channel.