### PR TITLE
channels/stable-4.9: Promote 4.9.5

### DIFF
--- a/channels/stable-4.9.yaml
+++ b/channels/stable-4.9.yaml
@@ -6,3 +6,4 @@ name: stable-4.9
 versions:
 - 4.9.0
 - 4.9.4
+- 4.9.5


### PR DESCRIPTION
It was promoted to the feeder fast-4.9 by 1ff27c1803 (Merge pull request #1179 from openshift/promote-4.9.5-to-fast-4.9, 2021-11-01) 7 days, 0:08:35.404817 ago.