### PR TITLE
channels/eus-4.6: Promote 4.6.49

### DIFF
--- a/channels/eus-4.6.yaml
+++ b/channels/eus-4.6.yaml
@@ -1,7 +1,7 @@
 feeder:
   delay: P1W
-  name: fast-4.6
   filter: 4\.6\.[0-9]+(.*hotfix.*)?
+  name: fast-4.6
 name: eus-4.6
 versions:
 - 4.6.1
@@ -43,3 +43,4 @@ versions:
 - 4.6.46
 - 4.6.47
 - 4.6.48
+- 4.6.49


### PR DESCRIPTION
It was promoted to the feeder fast-4.6 by 0cfef393d4 (Merge pull request #1191 from openshift/promote-4.6.49-to-fast-4.6, 2021-11-03) 7 days, 0:52:56.103151 ago.