### PR TITLE
A prerequsite for 4.9 to 4.10 upgrades has been identified

### DIFF
--- a/build-suggestions/4.10.yaml
+++ b/build-suggestions/4.10.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.9.0
+  minor_min: 4.9.18
   minor_max: 4.9.9999
   minor_block_list: []
   z_min: 4.10.0-fc.0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2037665

While 4.9.18 includes logic to ensure that clusters cannot upgrade
to 4.10 without addressing the pre-requisite it introduces a minor
regression where it incorrectly blips through Upgradeable=False. As
such we will file a subsequent bump to a build with the complete
set of changes when that 4.9.z is tagged. Bumping now will avoid
potential known issues in upgrading between 4.9 and 4.10, so we'll
bump twice.