### PR TITLE
graph-data.rs: check internal-channels

### DIFF
--- a/graph-data.rs/src/verify_yaml.rs
+++ b/graph-data.rs/src/verify_yaml.rs
@@ -5,6 +5,15 @@ use semver::Version;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use anyhow::Result as Fallible;
+use lazy_static::lazy_static;
+
+lazy_static! {
+  // Channel file locations
+  static ref CHANNEL_DIRS: Vec<String> = vec![
+      plugin::CHANNELS_DIR.to_string(),
+      "internal-channels".to_string(),
+  ];
+}
 
 pub async fn run() -> Fallible<(HashSet<Version>, Vec<Channel>)> {
     let data_dir = PathBuf::from(".");
@@ -34,19 +43,23 @@ pub async fn run() -> Fallible<(HashSet<Version>, Vec<Channel>)> {
         found_versions.insert(v.to.clone());
     }
 
+    let mut all_channels: Vec<Channel> = vec![];
     println!("Verifying channel files are valid");
-    let channel_path = data_dir.join(plugin::CHANNELS_DIR).canonicalize()?;
-    let channels_vec = plugin::deserialize_directory_files::<Channel>(
-        &channel_path,
-        all_files_regex.clone(),
-        &disallowed_errors,
-    )
-    .await?;
-    for c in channels_vec.iter() {
-        for v in c.versions.iter() {
-            found_versions.insert(v.clone());
+    for channel_dir in CHANNEL_DIRS.iter() {
+        let channel_path = data_dir.join(channel_dir).canonicalize()?;
+        let channels_vec = plugin::deserialize_directory_files::<Channel>(
+            &channel_path,
+            all_files_regex.clone(),
+            &disallowed_errors,
+        )
+        .await?;
+        for c in channels_vec.iter() {
+            for v in c.versions.iter() {
+                found_versions.insert(v.clone());
+            }
         }
+        all_channels.extend(channels_vec);
     }
 
-    Ok((found_versions, channels_vec))
+    Ok((found_versions, all_channels))
 }


### PR DESCRIPTION
Apart from officially supported stable/fast/candidate channels we also maintain internal-channels. Releases defined there should be included in the checks as well