### PR TITLE
blocked-edges/4.10.0-fc.2-modified-aws-load-balancer-service: Example conditional update

### DIFF
--- a/blocked-edges/4.10.0-fc.2-modified-aws-load-balancer-service.yaml
+++ b/blocked-edges/4.10.0-fc.2-modified-aws-load-balancer-service.yaml
@@ -1,0 +1,21 @@
+to: 4.10.0-fc.2
+from: 4[.]10[.].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2039339
+name: ModifiedAWSLoadBalancerServiceTags
+message: |-
+  On AWS clusters for Services in the openshift-ingress namespace, service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags annotations that diverge from Infrastructure's status.platformStatus.aws.resourceTags are expected to be clobbered on update to 4.11.  There may or may not be Service annotations like that on this cluster, and you can check by comparing:
+
+    $ oc get -o custom-columns=TAGS:.status.platformStatus.aws.resourceTags infrastructure cluster
+
+  with:
+
+    $ oc -n openshift-ingress get -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,ANNOTATIONS:.metadata.annotations services | grep service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags
+
+  This will not cause issues updating between 4.10 releases.  This conditional update is just a demonstration of the conditional update system.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      cluster_infrastructure_provider{type="AWS"}
+      or
+      0 * cluster_infrastructure_provider


### PR DESCRIPTION
Since 39bc2fb686 (#1056), we've had some example conditional updates back on `* -> 4.7.4`.  But now that 4.10 has feature candidates, this commit adds a conditional edge based on a minor 4.10.0-fc.2 issue that was fixed in fc.3.  Folks interested in seeing conditional edges in action can install fc.0 or fc.1 on AWS, and see that this conditional edge is not recommended.  Or they can install fc.0 or fc.1 on a non-AWS platform to see that the conditional edge is recommended.