### PR TITLE
build-suggestions/4.10: Bump minor min to 4.9.19

### DIFF
--- a/build-suggestions/4.10.yaml
+++ b/build-suggestions/4.10.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.9.18
+  minor_min: 4.9.19
   minor_max: 4.9.9999
   minor_block_list: []
   z_min: 4.10.0-fc.0


### PR DESCRIPTION
Following up on 430e5364fa (#1401), now that 4.9.19 has been named, includes openshift/cluster-kube-scheduler-operator#403, and [rhbz#2037665][2] has been VERIFIED.

[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2037665