### PR TITLE
internal-channels/candidate: Tombstone 4.8.30 and 4.9.19

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -49,8 +49,12 @@ tombstones:
 - 4.8.7
 # 4.8.16's amd64 build only has baked-in update edges from 4.7.35
 - 4.8.16
+# 4.8.30 lacks a baked-in update from 4.7.43
+- 4.8.30
 # 4.9.1 lacked a baked-in update from 4.8.17
 - 4.9.1
+# 4.9.19 lacked a baked-in update from 4.8.31
+- 4.9.19
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
They were missing baked-in update edges from the most same-week's previous minor release:

```console
$ diff -u0 <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.30-x86_64 | jq -r '.metadata.previous[]' | sort -V) <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.8.31-x86_64 | jq -r '.metadata.previous[]' | sort -V)
--- /dev/fd/63  2022-02-09 12:12:23.429003517 -0800
+++ /dev/fd/62  2022-02-09 12:12:23.432003517 -0800
@@ -21,0 +22 @@
+4.7.43
@@ -48,0 +50 @@
+4.8.30
$ diff -u0 <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.9.19-x86_64 | jq -r '.metadata.previous[]' | sort -V) <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.9.21-x86_64 | jq -r '.metadata.previous[]' | sort -V)
--- /dev/fd/63  2022-02-09 12:13:30.141000001 -0800
+++ /dev/fd/62  2022-02-09 12:13:30.145000001 -0800
@@ -16,0 +17,2 @@
+4.8.30
+4.8.31
@@ -31,0 +34,2 @@
+4.9.19
+4.9.20
```

4.9.20 was never promoted into candidate, so no need to tombstone it.