### PR TITLE
internal-channels/candidate: Drop the 4.9.19 tombstone

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -53,8 +53,6 @@ tombstones:
 - 4.8.30
 # 4.9.1 lacked a baked-in update from 4.8.17
 - 4.9.1
-# 4.9.19 lacked a baked-in update from 4.8.31
-- 4.9.19
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
I'd misunderstood in 0f94f1be90 (#1484), 4.9.19 and 4.9.21 are pretty different:

```console
$ diff -u <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.9.19-x86_64) <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.9.21-x86_64)
--- /dev/fd/63  2022-02-09 23:22:00.745066416 -0800
+++ /dev/fd/62  2022-02-09 23:22:00.750066415 -0800
@@ -1,20 +1,20 @@
-Name:      4.9.19
-Digest:    sha256:79dc491573156e7413c9b39d06b5c10d01f7eee26779cb34aed3d1b93158508c
-Created:   2022-02-01T15:31:25Z
+Name:      4.9.21
+Digest:    sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb
+Created:   2022-02-09T17:32:25Z
 OS/Arch:   linux/amd64
 Manifests: 522
    
-Pull From: quay.io/openshift-release-dev/ocp-release@sha256:79dc491573156e7413c9b39d06b5c10d01f7eee26779cb34aed3d1b93158508c
+Pull From: quay.io/openshift-release-dev/ocp-release@sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb
    
 Release Metadata:
-  Version:  4.9.19
-  Upgrades: 4.8.14, 4.8.15, 4.8.16, 4.8.17, 4.8.18, 4.8.19, 4.8.20, 4.8.21, 4.8.22, 4.8.23, 4.8.24, 4.8.25, 4.8.26, 4.8.27, 4.8.28, 4.8.29, 4.9.0, 4.9.1, 4.9.4, 4.9.5, 4.9.6, 4.9.7, 4.9.8, 4.9.9, 4.9.10, 4.9.11, 4.9.12, 4.9.13, 4.9.15, 4.9.17, 4.9.18
+  Version:  4.9.21
+  Upgrades: 4.8.14, 4.8.15, 4.8.16, 4.8.17, 4.8.18, 4.8.19, 4.8.20, 4.8.21, 4.8.22, 4.8.23, 4.8.24, 4.8.25, 4.8.26, 4.8.27, 4.8.28, 4.8.29, 4.8.30, 4.8.31, 4.9.0, 4.9.1, 4.9.4, 4.9.5, 4.9.6, 4.9.7, 4.9.8, 4.9.9, 4.9.10, 4.9.11, 4.9.12, 4.9.13, 4.9.15, 4.9.17, 4.9.18, 4.9.19, 4.9.20
   Metadata:
-    url: https://access.redhat.com/errata/RHBA-2022:0340
+    url: https://access.redhat.com/errata/RHBA-2022:0488
    
 Component Versions:
   kubernetes 1.22.3
-  machine-os 49.84.202201262103-0 Red Hat Enterprise Linux CoreOS
+  machine-os 49.84.202202081504-0 Red Hat Enterprise Linux CoreOS
    
 Images:
   NAME                                           DIGEST
@@ -27,13 +27,13 @@
   azure-cloud-node-manager                       sha256:157bb5834874ef39366a25375febc0c7671d80d7109762a6a1aea3806b8569d5
   azure-disk-csi-driver                          sha256:f6b4605db40a9b40dc3cefc723233ef785eb0a1b288a65d0c88778a86b45cc5a
   azure-disk-csi-driver-operator                 sha256:ab3cfdb68774dc5aaee5605ba44f319b2917ef7ca516d26493dd4908e88aa048
-  azure-machine-controllers                      sha256:6770840ffb8178dcd2c5479dbdf6ac8bd4c0f17113e4d8d3b9502702c0099f5d
-  baremetal-installer                            sha256:bcc063c8f873132ba01d682c9c4a81c6503360c919be88c86a04062599c39983
+  azure-machine-controllers                      sha256:ff2df74e57ccb2d26cf31cb3e030e42b2cd84a9e5581d5bd80cf252ca7ddf740
+  baremetal-installer                            sha256:1d455ddbf0f4c4d9361f376da5f6bbebea5e486fddd94208b2eac91c6526e05c
   baremetal-machine-controllers                  sha256:c6f69ff3bcaca052d3afdab72a0d85bc8dc7e9fc4855ec70a4fc7ee9d64ecc2c
...
```

It's just 4.9.20 that is similar, except for metadata:

```console
$ diff -u <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.9.20-x86_64) <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.9.21-x86_64)
--- /dev/fd/63  2022-02-09 23:22:47.631063945 -0800
+++ /dev/fd/62  2022-02-09 23:22:47.633063945 -0800
@@ -1,14 +1,14 @@
-Name:      4.9.20
-Digest:    sha256:6b8161883ad71585edefe69da05e5c81427171a0786917db2011d9e5a8f7d1a2
-Created:   2022-02-09T15:07:27Z
+Name:      4.9.21
+Digest:    sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb
+Created:   2022-02-09T17:32:25Z
 OS/Arch:   linux/amd64
 Manifests: 522
    
-Pull From: quay.io/openshift-release-dev/ocp-release@sha256:6b8161883ad71585edefe69da05e5c81427171a0786917db2011d9e5a8f7d1a2
+Pull From: quay.io/openshift-release-dev/ocp-release@sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb
    
 Release Metadata:
-  Version:  4.9.20
-  Upgrades: 4.8.14, 4.8.15, 4.8.16, 4.8.17, 4.8.18, 4.8.19, 4.8.20, 4.8.21, 4.8.22, 4.8.23, 4.8.24, 4.8.25, 4.8.26, 4.8.27, 4.8.28, 4.8.29, 4.9.0, 4.9.1, 4.9.4, 4.9.5, 4.9.6, 4.9.7, 4.9.8, 4.9.9, 4.9.10, 4.9.11, 4.9.12, 4.9.13, 4.9.15, 4.9.17, 4.9.18, 4.9.19
+  Version:  4.9.21
+  Upgrades: 4.8.14, 4.8.15, 4.8.16, 4.8.17, 4.8.18, 4.8.19, 4.8.20, 4.8.21, 4.8.22, 4.8.23, 4.8.24, 4.8.25, 4.8.26, 4.8.27, 4.8.28, 4.8.29, 4.8.30, 4.8.31, 4.9.0, 4.9.1, 4.9.4, 4.9.5, 4.9.6, 4.9.7, 4.9.8, 4.9.9, 4.9.10, 4.9.11, 4.9.12, 4.9.13, 4.9.15, 4.9.17, 4.9.18, 4.9.19, 4.9.20
   Metadata:
     url: https://access.redhat.com/errata/RHBA-2022:0488
$ diff -u0 <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.9.20-x86_64 | jq -r '.metadata.previous[]' | sort -V) <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.9.21-x86_64 | jq -r '.metadata.previous[]' | sort -V)
--- /dev/fd/63  2022-02-09 23:23:29.192061754 -0800
+++ /dev/fd/62  2022-02-09 23:23:29.194061754 -0800
@@ -16,0 +17,2 @@
+4.8.30
+4.8.31
@@ -32,0 +35 @@
+4.9.20
```

So this commit lifts the tombstone off 4.9.19.  No need to tombstone 4.9.20; as 0f94f1be90 pointed out, it was never promoted into `candidate`.