### PR TITLE
Block 4.10 upgrades from less than 4.9.19

### DIFF
--- a/blocked-edges/4.10.0-fc.0.yaml
+++ b/blocked-edges/4.10.0-fc.0.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-fc.0
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665

--- a/blocked-edges/4.10.0-fc.1.yaml
+++ b/blocked-edges/4.10.0-fc.1.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-fc.1
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665

--- a/blocked-edges/4.10.0-fc.2.yaml
+++ b/blocked-edges/4.10.0-fc.2.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-fc.2
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665

--- a/blocked-edges/4.10.0-fc.3.yaml
+++ b/blocked-edges/4.10.0-fc.3.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-fc.3
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665

--- a/blocked-edges/4.10.0-fc.4.yaml
+++ b/blocked-edges/4.10.0-fc.4.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-fc.4
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665

--- a/blocked-edges/4.10.0-rc.0.yaml
+++ b/blocked-edges/4.10.0-rc.0.yaml
@@ -1,0 +1,4 @@
+to: 4.10.0-rc.0
+from: 4\.9\..*
+# The incoming versions from 4.9 lack pre-requisites set in
+# https://bugzilla.redhat.com/show_bug.cgi?id=2037665


### PR DESCRIPTION
While we raised the minimums someone running versions less than the new minimum may see available 4.10 upgrades in the candidate channel and take them. We'd prefer everyone meet the current minimum version requirements so that we're not chasing down any bugs from those versions.

I can into this because I installed 4.9.18 and it offered me upgrades to 4.10.0-rc.0.