### PR TITLE
internal-channels/candidate: Tombstone 4.10.2

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -57,6 +57,8 @@ tombstones:
 - 4.10.0
 # 4.10.1 had a bug in network policies potentially blocking pod egress https://bugzilla.redhat.com/show_bug.cgi?id=2060956
 - 4.10.1
+# 4.10.2 had a bug in network policies potentially blocking pod egress https://bugzilla.redhat.com/show_bug.cgi?id=2060956
+- 4.10.2
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
The 4.10.2 fix [was incomplete][1], and we'll need a 4.10.3.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2060956#c5