### PR TITLE
hack/stabilization-changes: Set a default socket timeout of 60s

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import socket
 import subprocess
 import textwrap
 import time
@@ -29,6 +30,8 @@ _GIT_BLAME_COMMIT_REGEXP = re.compile(r'^(?P<hash>[0-9a-f]{40}) .*')
 _GIT_BLAME_HEADER_REGEXP = re.compile(r'^(?P<key>[^ \t]+) (?P<value>.*)$')
 _GIT_BLAME_LINE_REGEXP = re.compile(r'^\t(?P<value>.*)$')
 _SEMANTIC_VERSION_DELIMITERS = re.compile('[.+-]')
+
+socket.setdefaulttimeout(60)
 
 
 def parse_iso8601_delay(delay):


### PR DESCRIPTION
We recently had this script hang for a day, with the traceback suggesting it was stuck in `get_cincinnati_channel`'s `urlopen` call.  From [the `urlopen` docs][1]:

> The optional *timeout* parameter specifies a timeout in seconds for blocking operations like the connection attempt (if not specified, the global default timeout setting will be used). This actually only works for HTTP, HTTPS and FTP connections.

And from [the `setdefaulttimeout` docs][2]:

> Set the default timeout in seconds (float) for new socket objects. When the socket module is first imported, the default is `None`. See `settimeout()` for possible values and their respective meanings.

With this commit, we'll fail on these stuck connections instead of hanging.  It seems unlikely that we'd have more than 60s of latency in any of our `urlopen` calls (the update service, the erratas, or Slack's webhook endpoint) and still succeed after that.

[1]: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen
[2]: https://docs.python.org/3/library/socket.html#socket.setdefaulttimeout