### PR TITLE
channels/eus-4.10: Promote 4.10.4

### DIFF
--- a/channels/eus-4.10.yaml
+++ b/channels/eus-4.10.yaml
@@ -5,3 +5,4 @@ feeder:
 name: eus-4.10
 versions:
 - 4.10.3
+- 4.10.4


### PR DESCRIPTION
It was promoted to the feeder stable by 37c8bb64bb (Merge pull request #1660 from openshift/promote-4.10.4-to-stable, 2022-03-23) 0:47:45.378523 ago.