### PR TITLE
Bumping the minor_min to 4.8.9999 for 4.9 build

### DIFF
--- a/build-suggestions/4.9.yaml
+++ b/build-suggestions/4.9.yaml
@@ -2,7 +2,7 @@
 # If you specify an arch it must have the full set of values
 ---
 default:
-  minor_min: 4.8.14
+  minor_min: 4.8.9999
   minor_max: 4.8.9999
   minor_block_list: []
   z_min: 4.9.0


### PR DESCRIPTION
This PR should be considered after we merge https://github.com/openshift/cincinnati-graph-data/pull/1663. This is done for bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=2068601 

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>