### PR TITLE
Blocking all update edges from ocp 4.8 to 4.9.27

### DIFF
--- a/blocked-edges/4.9.27.yaml
+++ b/blocked-edges/4.9.27.yaml
@@ -1,0 +1,3 @@
+to: 4.9.27
+from: 4\.8\..*
+# etcd data inconsistency issue https://bugzilla.redhat.com/show_bug.cgi?id=2068601


### PR DESCRIPTION
Since we decided not to raise the floor we'll need to chase new 4.9.z
until we're comfortable unblocking 4.8 to 4.9 upgrades again.