### PR TITLE
internal-channels/candidate: Tombstone 4.10.7 (rerolled as 4.10.8)

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -59,6 +59,8 @@ tombstones:
 - 4.10.1
 # 4.10.2 had a bug in network policies potentially blocking pod egress https://bugzilla.redhat.com/show_bug.cgi?id=2060956
 - 4.10.2
+# 4.10.7 shares errata with 4.10.8
+- 4.10.7
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
```console
$ diff -u0 <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.10.7-x86_64) <(oc adm release info quay.io/openshift-release-dev/ocp-release:4.10.8-x86_64)
--- /dev/fd/63  2022-04-01 16:11:16.480328693 -0700
+++ /dev/fd/62  2022-04-01 16:11:16.482328693 -0700
@@ -1,3 +1,3 @@
-Name:      4.10.7
-Digest:    sha256:347fcefa4cff84074fa56ff73a483b9fee7ba98b9a71752763502f11182a11af
-Created:   2022-04-01T03:01:24Z
+Name:      4.10.8
+Digest:    sha256:0696e249622b4d07d8f4501504b6c568ed6ba92416176a01a12b7f1882707117
+Created:   2022-04-01T19:36:11Z
@@ -7 +7 @@
-Pull From: quay.io/openshift-release-dev/ocp-release@sha256:347fcefa4cff84074fa56ff73a483b9fee7ba98b9a71752763502f11182a11af
+Pull From: quay.io/openshift-release-dev/ocp-release@sha256:0696e249622b4d07d8f4501504b6c568ed6ba92416176a01a12b7f1882707117
@@ -10,2 +10,2 @@
-  Version:  4.10.7
-  Upgrades: 4.9.19, 4.9.21, 4.9.22, 4.9.23, 4.9.24, 4.9.25, 4.9.26, 4.9.27, 4.10.0-fc.0, 4.10.0-fc.1, 4.10.0-fc.2, 4.10.0-fc.3, 4.10.0-fc.4, 4.10.0-rc.0, 4.10.0-rc.1, 4.10.0-rc.2, 4.10.0-rc.3, 4.10.0-rc.4, 4.10.0-rc.5, 4.10.0-rc.6, 4.10.0-rc.7, 4.10.0-rc.8, 4.10.0, 4.10.1, 4.10.2, 4.10.3, 4.10.4, 4.10.5, 4.10.6
+  Version:  4.10.8
+  Upgrades: 4.9.19, 4.9.21, 4.9.22, 4.9.23, 4.9.24, 4.9.25, 4.9.26, 4.9.27, 4.10.0-fc.0, 4.10.0-fc.1, 4.10.0-fc.2, 4.10.0-fc.3, 4.10.0-fc.4, 4.10.0-rc.0, 4.10.0-rc.1, 4.10.0-rc.2, 4.10.0-rc.3, 4.10.0-rc.4, 4.10.0-rc.5, 4.10.0-rc.6, 4.10.0-rc.7, 4.10.0-rc.8, 4.10.0, 4.10.1, 4.10.2, 4.10.3, 4.10.4, 4.10.5, 4.10.6, 4.10.7
@@ -13 +13 @@
-    url: https://access.redhat.com/errata/RHBA-2022:1162
+    url: https://access.redhat.com/errata/RHSA-2022:1162
```

The reroll was to get the RHSA URI in place (the presense of the CVE fix was not known when the 4.10.7 release was built).