### PR TITLE
build-suggestions/4.11: Raise minor_min to 4.10.8

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.10.0
+  minor_min: 4.10.8
   minor_max: 4.10.9999
   minor_block_list: []
   z_min: 4.11.0-fc.0


### PR DESCRIPTION
So we know that the cluster-version operator will be [using `ReleaseAccepted`][3] to pass the RecentBackup message to the etcd operator.  Details on the dance change [here][1].  CVO [pivot to using `ReleaseAccepted`][3] shipped [in 4.10.8][2].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2076793
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2064991#c7
[3]: https://github.com/openshift/cluster-version-operator/pull/753/files#diff-db97dc5ae62ef3b4c4dabfdc43cbc3ae0ceae9b58748cadebde679e32b5bec2bR160