### PR TITLE
build-suggestions/4.11: Raise minor_min to 4.10.12

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.10.8
+  minor_min: 4.10.12
   minor_max: 4.10.9999
   minor_block_list: []
   z_min: 4.11.0-fc.0


### PR DESCRIPTION
This fixes the `APIRemovedInNextReleaseInUse` alert `expr`, so admins will hear if the minor update to 4.11 would break a current deprecated-API consumer ([bug][1], [`expr` change][2]).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2071030#c6
[2]: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1335/files#diff-d89e2ca0888b4394370e2849c02d91eb0f9857427db974f27408b0398df53f33L19-R19