### PR TITLE
Bumping the minor_min to 4.10.14 because of BZ 2079097

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.10.12
+  minor_min: 4.10.14
   minor_max: 4.10.9999
   minor_block_list: []
   z_min: 4.11.0-fc.0


### PR DESCRIPTION
Because https://bugzilla.redhat.com/show_bug.cgi?id=2079097 needs to be
fixed in 4.10.z for the upgrade to 4.11

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>