### PR TITLE
blocked-edges/4.10.*: Parallel ceph_fsync risk for 4.10.4 and later

### DIFF
--- a/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.10
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.11
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.12
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.13
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.14
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.15
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.4
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.5
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.6
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.7
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.8
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
@@ -1,0 +1,13 @@
+to: 4.10.9
+from: 4[.]10[.]([0-3]|0-[fr]c[.][0-9])[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      or
+      label_replace(0 * group(cluster_version), "ceph", "no", "", "")


### PR DESCRIPTION
I created the 4.10.4 content, and then copied it to later versions with:

```console
$ yaml2json <channels/candidate-4.10.yaml | jq -r '.versions[]' | grep '4[.]10[.]\([5-9]\|[1-9][0-9]\)' | while read V; do sed "s/to: .*/to: ${V}/" blocked-edges/4.10.4-parallel-ceph_fsync.yaml > "blocked-edges/${V}-parallel-ceph_fsync.yaml"; done
```

4.10.11 was the first to drop updates from the prerelease versions:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.10.10-x86_64 | grep Upgrade
  Upgrades: 4.9.19, 4.9.21, 4.9.22, 4.9.23, 4.9.24, 4.9.25, 4.9.26, 4.9.27, 4.9.28, 4.9.29, 4.10.0-fc.0, 4.10.0-fc.1, 4.10.0-fc.2, 4.10.0-fc.3, 4.10.0-fc.4, 4.10.0-rc.0, 4.10.0-rc.1, 4.10.0-rc.2, 4.10.0-rc.3, 4.10.0-rc.4, 4.10.0-rc.5, 4.10.0-rc.6, 4.10.0-rc.7, 4.10.0-rc.8, 4.10.0, 4.10.1, 4.10.2, 4.10.3, 4.10.4, 4.10.5, 4.10.6, 4.10.7, 4.10.8, 4.10.9
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.10.11-x86_64 | grep Upgrade
  Upgrades: 4.9.19, 4.9.21, 4.9.22, 4.9.23, 4.9.24, 4.9.25, 4.9.26, 4.9.27, 4.9.28, 4.9.29, 4.9.30, 4.10.3, 4.10.4, 4.10.5, 4.10.6, 4.10.7, 4.10.8, 4.10.9, 4.10.10
```

so we can use a simpler `from` regular expression from then on out.

```console
$ sed -i 's/from: .*/from: 4[.]10[.]3[+].*/' blocked-edges/4.10.1[1-9]-parallel-ceph_fsync.yaml
```