### PR TITLE
Tombstone 4.8.40 and 4.9.34

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -53,10 +53,14 @@ tombstones:
 - 4.8.30
 # 4.8.38 and 4.9.30 had misaligned kernel and kernel-rt packages
 - 4.8.38
+# 4.8.40 had IPI installation Bootstrap failiure, https://bugzilla.redhat.com/show_bug.cgi?id=2088196
+- 4.8.40
 # 4.9.1 lacked a baked-in update from 4.8.17
 - 4.9.1
 # 4.8.38 and 4.9.30 had misaligned kernel and kernel-rt packages
 - 4.9.30
+# 4.9.34 had IPI installation Bootstrap failiure, https://bugzilla.redhat.com/show_bug.cgi?id=2088196
+- 4.9.34
 # 4.10.0 had a regression in access to public images https://bugzilla.redhat.com/show_bug.cgi?id=2060605
 - 4.10.0
 # 4.10.1 had a bug in network policies potentially blocking pod egress https://bugzilla.redhat.com/show_bug.cgi?id=2060956


### PR DESCRIPTION
because of https://bugzilla.redhat.com/show_bug.cgi?id=2088196