### PR TITLE
blocked-edges/4.10.*parallel-ceph_fsync: Handle multiple ceph_health_status series

### DIFF
--- a/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")

--- a/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(ceph_health_status, "ceph", "yes", "", "")
+      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
       or
       label_replace(0 * group(cluster_version), "ceph", "no", "", "")


### PR DESCRIPTION
Some clusters have a number of these, mostly differing by instance:

```
  ceph_health_status{..., container="mgr", endpoint="http-metrics", instance="10.128.4.12:9283", job="rook-ceph-mgr", namespace="openshift-storage", pod="rook-ceph-mgr-a-6886bc75b8-m6xkd", prometheus="openshift-monitoring/k8s", receive="true", service="rook-ceph-mgr", ...}  1
  ceph_health_status{..., container="mgr", endpoint="http-metrics", instance="10.128.4.16:9283", job="rook-ceph-mgr", namespace="openshift-storage", pod="rook-ceph-mgr-a-6886bc75b8-m6xkd", prometheus="openshift-monitoring/k8s", receive="true", service="rook-ceph-mgr", ...}  1
  ...
```

But we don't care how many there are, we just care if there are any.  Wrapping `ceph_health_status` in a `group(...)` call ignores all the labels and aggregates down to a single series.

This should avoid `EvaluationFailed` issues like:

    invalid PromQL result length must be one, but is 2