### PR TITLE
blocked-edges/4.10.*parallel-ceph_fsync: Wrap in topk

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ The `[+].*` portion absorbs [the architecture-suffix](#release-names) from the r
 [api-reason]: https://github.com/openshift/api/blob/67c28690af52a69e0b8fa565916fe1b9b7f52f10/config/v1/types_cluster_operator.go#L131-L133
 [channel-semantics]: https://docs.openshift.com/container-platform/4.3/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
 [Cincinnati]: https://github.com/openshift/cincinnati/
-[cluster-condition-type-registry]: https://github.com/openshift/enhancements/pull/821#FIXME
-[cluster-condition-type-registry-promql]: https://github.com/openshift/enhancements/pull/821#FIXME
+[cluster-condition-type-registry]: https://github.com/openshift/enhancements/blob/master/enhancements/update/targeted-update-edge-blocking.md#cluster-condition-type-registry
+[cluster-condition-type-registry-promql]: https://github.com/openshift/enhancements/blob/master/enhancements/update/targeted-update-edge-blocking.md#promql
 [image-arch]: https://github.com/opencontainers/image-spec/blame/v1.0.1/config.md#L103
 [iso-8601-durations]: https://en.wikipedia.org/wiki/ISO_8601#Durations
 [json-array]: https://datatracker.ietf.org/doc/html/rfc8259#section-5

--- a/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.10-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.11-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.12-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.13-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.14-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.15-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.4-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.5-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.6-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.7-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.8-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )

--- a/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.9-parallel-ceph_fsync.yaml
@@ -8,6 +8,8 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      label_replace(group(ceph_health_status), "ceph", "yes", "", "")
-      or
-      label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )


### PR DESCRIPTION
Continuing to clean up the PromQL from 707ec48c76 (#1915), which I'd previously revised in da76bd14ab (#1932).  We'd still been getting:

    invalid PromQL result length must be one, but is 2

The semantics for [`or` are][1]:

> `vector1 or vector2` results in a vector that contains all original elements (label sets + values) of `vector1` and additionally all elements of `vector2` which do not have matching label sets in `vector1`.

I'd missed the `+ values` part of it, but it meant that when:

    label_replace(group(ceph_health_status), "ceph", "yes", "", "")

hit, returning a series like `{ceph="yes"}=1`, and:

    label_replace(0 * group(cluster_version), "ceph", "no", "", "")

hit, returning a series like `{ceph="no"}=0`, we'd return both of those series.  This commit wraps the expression in a [`topk(1, ...)`][2], so we only get the largest series (i.e. `{ceph="yes"}=1` wins).

Also tacking on a separate commit to fix two FIXME URIs in the README, now that the enhancement has landed.

[1]: https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
[2]: https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators