### PR TITLE
blocked-edges/4.10.16: Parallel ceph_fsync risk for 4.10.4 and later

### DIFF
--- a/blocked-edges/4.10.16-parallel-ceph_fsync.yaml
+++ b/blocked-edges/4.10.16-parallel-ceph_fsync.yaml
@@ -1,0 +1,15 @@
+to: 4.10.16
+from: 4[.]10[.]3[+].*
+url: https://bugzilla.redhat.com/show_bug.cgi?id=2076312#c9
+name: CephParallelFsync
+message: |-
+  This update would introduce a CephFS kernel driver regression, exposing a kernel panic when workloads make parallel ceph_fsync calls to the same file.  The update also introduces many bug fixes as described in the errata, so weigh those against the risk of Ceph kernel panics when deciding whether to update or wait for an OpenShift release that also fixes the Ceph regression.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(ceph_health_status), "ceph", "yes", "", "")
+        or
+        label_replace(0 * group(cluster_version), "ceph", "no", "", "")
+      )


### PR DESCRIPTION
Extend conditional edges into 4.10.16 as we're still waiting on the
kernel fix.