### PR TITLE
channels/eus-4.10: Hold 4.8.z and 4.9.z out

### DIFF
--- a/channels/eus-4.10.yaml
+++ b/channels/eus-4.10.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.(8|10)\.[0-9].*|4\.9\.([3-9][0-9])
+  filter: 4\.10\.[0-9].*
   name: stable
 name: eus-4.10
 versions:


### PR DESCRIPTION
4.9.34 was rebuilt as 4.9.35 after 4.10.15 had already been built, 81edd48b89 (#1923).  Because we didn't rebuild a 4.10.16 to include updates from 4.9.35, that week's releases lack a 4.9 -> 4.10 update recommendation.  Hold 4.9 and 4.8 out of 4.10 for now, to avoid recommending 4.8 -> 4.9.35 -> no-path-to-4.10-just-now updates to those folks.  We'll revert this commit once we get a fresh 4.10.z in stable channels.

Alternative to #1974.