### PR TITLE
CONTRIBUTING: Fix Product Security link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ This document outlines some of the conventions on development workflow, commit m
 
 ## Security response
 
-If you've found a security issue that you'd like to disclose confidentially, please contact Red Hat's Product Security team.
+If you've found a security issue that you'd like to disclose confidentially, please [contact Red Hat's Product Security team][security].
 
 ## Getting started
 


### PR DESCRIPTION
I had the text and the URL in 8e6934de24, but had forgotten to tie them together.