### PR TITLE
Revert "channels/eus-4.10: Hold 4.8.z and 4.9.z out"

### DIFF
--- a/channels/eus-4.10.yaml
+++ b/channels/eus-4.10.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.10\.[0-9].*
+  filter: 4\.(8|10)\.[0-9].*|4\.9\.([3-9][0-9])
   name: stable
 name: eus-4.10
 versions:


### PR DESCRIPTION
4.10.16 offers upgrades from 4.9.35 and has been promoted to stable-4.10 and eus-4.10, this is now safe to revert.
Reverts openshift/cincinnati-graph-data#1975