### PR TITLE
build-suggestions/4.11: Raise minor_min to 4.10.15

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.10.14
+  minor_min: 4.10.15
   minor_max: 4.10.9999
   minor_block_list: []
   z_min: 4.11.0-fc.0


### PR DESCRIPTION
More around the etcd-snapshot dance, last mentioned in 1ae2c3d3a6 (#1807):

* [4.10.8 pivoted][1] the cluster-version operator to using `ReleaseAccepted`.
* [4.10.14 taught][2] the etcd operator to look at `ReleaseAccepted`.
* [4.10.15 fixed][3] the cluster-version opetator's precondition revisits, which allows it to notice that the etcd operator has completed its snapshot.

We want all three of those in place before folks head off to 4.11.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2064991#c7
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2079660#c6
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2083370#c7