### PR TITLE
build-suggestions/4.11: Raise minor_min to 4.10.16

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.10.15
+  minor_min: 4.10.16
   minor_max: 4.10.9999
   minor_block_list: []
   z_min: 4.11.0-fc.0


### PR DESCRIPTION
We work really hard to test updates and identify regressions before shipping releases.  But there is a chance we miss something, and need to declare it as a conditional risk affecting 4.10 to 4.11 updates. [rbhz#2087041][1] landed web-console support for conditional updates in 4.10.16, so raising the minimum here ensures all users will have that convenient experience navigating any conditional risks which may have turned up by the time we're recommending supported updates to 4.11.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2087041#c5