### PR TITLE
internal-channels/candidate: Tombstone 4.9.39

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -61,6 +61,8 @@ tombstones:
 - 4.9.30
 # 4.9.34 had IPI installation Bootstrap failiure, https://bugzilla.redhat.com/show_bug.cgi?id=2088196
 - 4.9.34
+# 4.9.39 will not have an errata published because of OVN static IP issues https://bugzilla.redhat.com/show_bug.cgi?id=2098099#c1
+- 4.9.39
 # 4.10.0 had a regression in access to public images https://bugzilla.redhat.com/show_bug.cgi?id=2060605
 - 4.10.0
 # 4.10.1 had a bug in network policies potentially blocking pod egress https://bugzilla.redhat.com/show_bug.cgi?id=2060956


### PR DESCRIPTION
Continuing in the wake of 97c2ee424d (#2072) and 5f23d4e251 (#2080).

I'm personally not clear on why 4.9.39 would be worse off than 4.9.38, and we've shipped 4.9.38.  So folks making install-time decisions might be better off with 4.9.39 (which fixed some 4.9.38 issues, although not this OVN static IP one) than they were with the still-supported 4.9.38.  But the folks making the errata-publication decisions have decided not to ship 4.9.39, so we are tombstoning in this repository to keep up (and to keep from adding 4.9.39 to fast and later channels if the errata URI is recycled for a later release).
