### PR TITLE
channels: Delay 4.8 promotions into stable-4.9 and eus-4.10

### DIFF
--- a/channels/eus-4.10.yaml
+++ b/channels/eus-4.10.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.(8|10)\.[0-9].*|4\.9\.([3-9][0-9])
+  filter: 4\.10\.[0-9].*|4\.9\.([3-9][0-9])
   name: stable
 name: eus-4.10
 versions:

--- a/channels/stable-4.9.yaml
+++ b/channels/stable-4.9.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.[89]\.[0-9].*
+  filter: 4\.9\.[0-9].*
   name: stable
 name: stable-4.9
 versions:


### PR DESCRIPTION
Continuing in the wake of 97c2ee424d (#2072), 5f23d4e251 (#2080), and f2aef6f664 (#2089).

4.8.43 can update to 4.9.38, but not older 4.9.z:

```console
$ hack/show-edges.py candidate-4.9 | grep '4[.]8[.]43 -.* 4[.]9[.]'
4.8.43 -(blocked: None)-> 4.9.38
4.8.43 -(blocked: None)-> 4.9.39
```

So folks who get into 4.8.43 are stuck without a path to safe 4.9.z until [rhbz#2098099][1] ships with the fix.

4.8.42 can update to 4.9.36 and 4.9.37, so they're fine:

```console
$ hack/show-edges.py candidate-4.9 | grep '4[.]8[.]42 -.* 4[.]9[.]'
4.8.42 -> 4.9.36
4.8.42 -> 4.9.37
4.8.42 -(blocked: None)-> 4.9.38
4.8.42 -(blocked: None)-> 4.9.39
```

4.8.42 already made it into stable channels, but 4.8.43 is currently only through fast.  This commit holds 4.8.43 and later 4.8 out of 4.9 and 4.10 channels, to avoid:

1. User on 4.8.old sets `stable-4.9`.
2. User selects the recommended update to 4.8.43.
3. User cannot update to 4.9 until [rbhz#2098099][1] is fixed.

Instead, we will have:

1. User on 4.8.old sets `stable-4.9`.
2. User selects the recommended update to 4.8.42.
3. User can update to 4.9.36 or 4.9.37 immediately.

We will revert this commit once a fix for [rbhz#2098099][1] reaches stable channels.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2098099