### PR TITLE
Revert "channels: Delay 4.8 promotions into stable-4.9 and eus-4.10"

### DIFF
--- a/channels/eus-4.10.yaml
+++ b/channels/eus-4.10.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.10\.[0-9].*|4\.9\.([3-9][0-9])
+  filter: 4\.(8|10)\.[0-9].*|4\.9\.([3-9][0-9])
   name: stable
 name: eus-4.10
 versions:

--- a/channels/stable-4.9.yaml
+++ b/channels/stable-4.9.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.9\.[0-9].*
+  filter: 4\.[89]\.[0-9].*
   name: stable
 name: stable-4.9
 versions:


### PR DESCRIPTION
Reverts openshift/cincinnati-graph-data#2093

4.9.40 has entered stable/EUS channels via #2154, #2155, #2156, so there are now paths out from 4.8.tip into 4.9, and we no longer need to delay these promotions.