### PR TITLE
hack/show-edges: Process manifest lists

### DIFF
--- a/hack/show-edges.py
+++ b/hack/show-edges.py
@@ -248,7 +248,7 @@ def load_nodes(versions, architecture, repository, directory='.nodes'):
         break
 
     if versions_remaining:
-        _LOGGER.warning('walked all tag pages, but did not find releases for: {}'.format(join(', ', sorted(versions_remaining))))
+        _LOGGER.warning('walked all tag pages, but did not find releases for: {}'.format(', '.join(sorted(versions_remaining))))
 
     return nodes
 


### PR DESCRIPTION
Avoid warnings like:

```console
$ hack/show-edges.py eus-4.10
WARNING: unable to get release metadata for quay.io/openshift-release-dev/ocp-release@sha256:97be7dfb62abe6dbf266d7037c0f31fcca9007f232021b0633cf1944a55250a0 {'name': '4.12.0-0.nightly-multi-2022-07-25-220750', 'reversion': False, 'start_ts': 1658787279, 'manifest_digest': 'sha256:97be7dfb62abe6dbf266d7037c0f31fcca9007f232021b0633cf1944a55250a0', 'is_manifest_list': True, 'size': None, 'last_modified': 'Mon, 25 Jul 2022 22:14:39 -0000'} : unsupported media type for quay.io/openshift-release-dev/ocp-release@sha256:97be7dfb62abe6dbf266d7037c0f31fcca9007f232021b0633cf1944a55250a0 manifest: application/vnd.docker.distribution.manifest.list.v2+json
...
```

and speed up repeated show-edges calls by allowing the caching of manifest-list releases.  The automated release team (ART) is committed to keeping the same release metadata in each architecture-specific branch of a manifest-list release image, so it doesn't matter which architecture we drill into when determining metadata for the manifest-list image.