### PR TITLE
internal-channels/candidate: Tombstone 4.9.44

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -71,6 +71,8 @@ tombstones:
 - 4.10.2
 # 4.10.7 shares errata with 4.10.8
 - 4.10.7
+# 4.9.44 is dropped to include fix for https://bugzilla.redhat.com/show_bug.cgi?id=2103982#c16
+- 4.9.44
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
4.9.44 is dropped as it needs the fix for https://bugzilla.redhat.com/show_bug.cgi?id=2103982#c16

The fix is already available in the latest 4.9.z nightly.
Without the fix it will cause a regression for clusters upgrading from
4.9.z versions.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>