### PR TITLE
Revert temporary feeder adjustments

### DIFF
--- a/channels/eus-4.8.yaml
+++ b/channels/eus-4.8.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.[8]\.[0-9].*
+  filter: 4\.[68]\.[0-9].*|4\.7\.(3[4-9]|[4-9][0-9])
   name: stable
 name: eus-4.8
 versions:

--- a/channels/fast-4.8.yaml
+++ b/channels/fast-4.8.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.[8]\.[0-9].*
+  filter: 4\.[78]\.[0-9].*
   name: fast
 name: fast-4.8
 versions:

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4\.[8]\.[0-9].*
+  filter: 4\.[78]\.[0-9].*
   name: stable
 name: stable-4.8
 versions:


### PR DESCRIPTION
Reverting #2253 and fd6471d96f7fc9c50ae60eafdc4e354897acc827 from #2245, now that #2059 has merged and been deployed to automate that sort of thing.  Testing locally:

```console
$ hack/stabilization-changes.py 
...
* Recommend waiting to promote 4.6.60 to eus-4.8; it was promoted the feeder stable by d0a81cd507 (Merge pull request #2267 from openshift-ota-bot/promote-4.6.60-to-stable, 2022-07-28, 6 days, 7:34:07.861655) No unconditional paths from 4.6.60 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64 https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.7&arch=amd64
* Recommend waiting to promote 4.7.54 to eus-4.8; it was promoted the feeder stable by 0a4c588e81 (Merge pull request #2237 from openshift-ota-bot/promote-4.7.54-to-stable, 2022-07-20, 13 days, 16:05:08.203004) No unconditional paths from 4.7.54 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
* Recommend waiting to promote 4.7.55 to eus-4.8; it was promoted the feeder stable by 3d53395a8a (Merge pull request #2276 from openshift-ota-bot/promote-4.7.55-to-stable, 2022-08-01, 2 days, 7:40:31.208619) No unconditional paths from 4.7.55 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
* Recommend waiting to promote 4.7.54 to fast-4.8; it was promoted the feeder fast by f52425d0b6 (Merge pull request #2198 from openshift-ota-bot/promote-4.7.54-to-fast, 2022-07-13, 20 days, 17:13:26.307807) No unconditional paths from 4.7.54 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
* Recommend waiting to promote 4.7.55 to fast-4.8; it was promoted the feeder fast by 29bf3fa948 (Merge pull request #2250 from openshift-ota-bot/promote-4.7.55-to-fast, 2022-07-25, 9 days, 8:45:28.309862) No unconditional paths from 4.7.55 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
* Recommend waiting to promote 4.10.25 to stable; it was promoted the feeder fast by 6b26ce30d6 (Merge pull request #2274 from openshift-ota-bot/promote-4.10.25-to-fast, 2022-08-01, 2 days, 10:43:53.393093)
* Recommend waiting to promote 4.7.54 to stable-4.8; it was promoted the feeder stable by 0a4c588e81 (Merge pull request #2237 from openshift-ota-bot/promote-4.7.54-to-stable, 2022-07-20, 13 days, 16:05:08.470772) No unconditional paths from 4.7.54 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
* Recommend waiting to promote 4.7.55 to stable-4.8; it was promoted the feeder stable by 3d53395a8a (Merge pull request #2276 from openshift-ota-bot/promote-4.7.55-to-stable, 2022-08-01, 2 days, 7:40:31.472660) No unconditional paths from 4.7.55 to 4.8 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.8&arch=amd64
```

which looks right to me.