### PR TITLE
hack/release-ga: Add error message when run before fast membership

### DIFF
--- a/hack/release-ga.sh
+++ b/hack/release-ga.sh
@@ -38,7 +38,7 @@ then
 	CHANNELS="$(printf '%s\n%s' "${CHANNELS}" eus)"
 fi
 
-RELEASES="$(grep "^- ${MAJOR}[.]${MINOR}[.][0-9]" internal-channels/fast.yaml)"
+RELEASES="$(grep "^- ${MAJOR}[.]${MINOR}[.][0-9]" internal-channels/fast.yaml || (echo "failed to find ${MAJOR_MINOR} releases in internal-channels/fast.yaml" >&2; exit 1))"
 if test -z "${RELEASES}"
 then
 	VERSIONS='versions: []'


### PR DESCRIPTION
Because of:

```console
$ man grep | grep -A1 'EXIT STATUS'
EXIT STATUS
       Normally the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred.  However, if the -q or --quiet or --silent is used and a line is selected, the exit  status  is  0  even  if  an  error
```

running:

```console
$ hack/release-ga 4.11
```

before there was a 4.11.* release in the fast channel to promote would cause the script to silently exit 1, which was confusing. 
 With this commit, that situation now results in:

```console
$ hack/release-ga.sh 4.11
failed to find 4.11 releases in internal-channels/fast.yaml
```