### PR TITLE
internal-channels/candidate: Tombstone 4.10.27

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -73,6 +73,8 @@ tombstones:
 - 4.10.7
 # 4.9.44 is dropped to include fix for https://bugzilla.redhat.com/show_bug.cgi?id=2103982#c16
 - 4.9.44
+# 4.10.27 fails to install, and as an update target, on AWS C2S/SC2S: https://bugzilla.redhat.com/show_bug.cgi?id=2115267
+- 4.10.27
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
On AWS clusters in us-iso-east-1 (and other regions that don't have dualstack endpoints), 4.10.27 [fails to install][1], and updates to it, from both 4.10 and 4.9, [fail to complete][1].  We could release 4.10.27 and protect existing clusters by declaring a conditional update risk, but currently tombstoning the release is the only mechanism for protecting folks from installing the broken release.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2115267