### PR TITLE
blocked-edges: Escape literal periods in 'from'

### DIFF
--- a/blocked-edges/4.11.0-fc.0-cluster-verison-precondition-check.yaml
+++ b/blocked-edges/4.11.0-fc.0-cluster-verison-precondition-check.yaml
@@ -1,5 +1,5 @@
 to: 4.11.0-fc.0
-from: 4.10.14
+from: 4[.]10[.]14
 url: https://bugzilla.redhat.com/show_bug.cgi?id=2072389#c11
 name: ClusterVersionPreconditionCheck
 message: |-

--- a/blocked-edges/4.4.12-to-4.5.4.yaml
+++ b/blocked-edges/4.4.12-to-4.5.4.yaml
@@ -1,3 +1,3 @@
 to: 4.5.4
-from: 4.4.12
+from: 4[.]4[.]12
 # Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd https://bugzilla.redhat.com/show_bug.cgi?id=1861017

--- a/blocked-edges/4.4.12-to-4.5.7.yaml
+++ b/blocked-edges/4.4.12-to-4.5.7.yaml
@@ -1,3 +1,3 @@
 to: 4.5.7
-from: 4.4.12
+from: 4[.]4[.]12
 # Suspected increase I/O during 8.1 to 8.2 RHCOS upgrade tipping over etcd https://bugzilla.redhat.com/show_bug.cgi?id=1861017

--- a/blocked-edges/4.5.41-to-4.6.35.yaml
+++ b/blocked-edges/4.5.41-to-4.6.35.yaml
@@ -1,3 +1,3 @@
 to: 4.6.35
-from: 4.5.41
+from: 4[.]5[.]41
 # Because of a bug in the build pipeline the OS version in 4.5.41 (machine-os 45.82.202106211530-0) is higher than 4.6.35 (machine-os 46.82.202106110228-0)

--- a/blocked-edges/4.5.41-to-4.6.36.yaml
+++ b/blocked-edges/4.5.41-to-4.6.36.yaml
@@ -1,3 +1,3 @@
 to: 4.6.36
-from: 4.5.41
+from: 4[.]5[.]41
 # Because of a bug in the build pipeline the OS version in 4.5.41 (machine-os 45.82.202106211530-0) is higher than 4.6.36 (machine-os 46.82.202106181041-0 )


### PR DESCRIPTION
We've built up some unescaped values over time, most recently in 8467cfc174 (#2069).  In this commit, I escape them, to reduce the risk of folks copy/pasting and forgetting that `from` is a regular expression.