### PR TITLE
build-suggestions/4.11: Raise z_min to 4.11.0 (the GA release)

### DIFF
--- a/build-suggestions/4.11.yaml
+++ b/build-suggestions/4.11.yaml
@@ -2,6 +2,6 @@ default:
   minor_min: 4.10.16
   minor_max: 4.10.9999
   minor_block_list: []
-  z_min: 4.11.0-fc.0
+  z_min: 4.11.0
   z_max: 4.11.9999
   z_block_list: []


### PR DESCRIPTION
Not many folks still running pre-GA 4.11, and they are candidate releases anyway.  Having them update out to 4.11.0 might leave them exposed to whatever bugs we fix in 4.11.(>0), but they're already probably exposed to them in their current candidate release.  And they can add a second hop to get out to 4.11.(>0) and pick up fixes. Raising the floor limits the number of update edges we test in CI to the ones that we actually support.

Similiar to 4.10's 07a7e88994 (#1752).