### PR TITLE
blocked-edges/4.11.0*: Link RPMOSTreeTimeout KCS

### DIFF
--- a/blocked-edges/4.11.0-fc.0-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-fc.0-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-fc.0
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-fc.3-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-fc.3-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-fc.3
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.0-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.0-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.0
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.1-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.1-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.1
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.2-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.2-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.2
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.3-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.3-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.3
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.4-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.4-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.4
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.5-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.5-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.5
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.6-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.6-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.6
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rc.7-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rc.7-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0-rc.7
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration

--- a/blocked-edges/4.11.0-rpm-ostree-timeout.yaml
+++ b/blocked-edges/4.11.0-rpm-ostree-timeout.yaml
@@ -1,6 +1,6 @@
 to: 4.11.0
 from: 4\.10\..*
-url: https://bugzilla.redhat.com/show_bug.cgi?id=2111817#c22
+url: https://https://access.redhat.com/solutions/6972394
 name: RPMOSTreeTimeout
 message: |-
   Nodes with substantial numbers of containers and CPU contention may not reconcile machine configuration


### PR DESCRIPTION
The KCS is pretty and mutable.  The bug comment is ugly and frozen.

Generated with:

```console
$ sed -i 's|bugzilla.redhat.com/show_bug.cgi?id=2111817#c22|https://access.redhat.com/solutions/6972394|' $(git grep -l '2111817#c22')
```