### PR TITLE
blocked-edges/4.11.2-PodmanTermStorageCorruption: Declare regression

### DIFF
--- a/blocked-edges/4.11.2-PodmanTermStorageCorruption.yaml
+++ b/blocked-edges/4.11.2-PodmanTermStorageCorruption.yaml
@@ -1,0 +1,13 @@
+to: 4.11.2
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-631
+name: PodmanTermStorageCorruption
+message: |-
+  BareMetal, Nutanix, OpenStack, oVirt, and VSphere platforms may fail to update nodes in environments where it takes over 20 seconds to retrieve the Machine Config Daemon image.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      cluster_infrastructure_provider{type=~"BareMetal|Nutanix|OpenStack|oVirt|VSphere"}
+      or
+      0 * cluster_infrastructure_provider


### PR DESCRIPTION
1. [This][1] landed after 4.11.1 and was shipped in 4.11.2, adding a 20s `timeout` to `baremetalRuntimeCfgImage` `podman run ...` calls.
2. The `baremetalRuntimeCfgImage` stuff gets enabled for [a number of infrastructure providers][2].
3. A Podman bug in TERM handling means that timeout TERMs can result in corrupted storage: containers/storage#1136.
4. That corruption bubbles up with errors like:

        Can't read link "/var/lib/containers/storage/overlay/..." because it does not exist. A storage corruption might have occurred

    or maybe:

      Image ... exists in local storage but may be corrupted (remove the image to resolve the issue): layer not known

     or maybe both, [OCPBUGS-631][4].
5. 4.11.3 and later [fix the regression][4] by separating the possibly-slow image pull from the container run.

[1]: https://github.com/openshift/machine-config-operator/pull/3287/files#diff-255f8a4599166f31961853ea8626f969ca4231c55aacbc20a5bb3ceb640f911dR48
[2]: https://github.com/openshift/machine-config-operator/blob/d33d8dc3d2cad2247f67dff5989256315000e2d1/pkg/controller/template/render.go#L512
[4]: https://issues.redhat.com/browse/OCPBUGS-631