### PR TITLE
blocked-edges/4.11.*: Declare StaleInsightsRunLevelLabel risk

### DIFF
--- a/blocked-edges/4.11.0-fc.0-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-fc.0-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.0
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-fc.0.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-fc.3-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-fc.3-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.3
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-fc.3.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.0-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.0-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.0
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.0.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.1-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.1-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.1
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.1.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.2-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.2-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.2
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.2.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.3-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.3-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.3
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.3.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.4-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.4-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.4
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.4.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.5-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.5-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.5
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.5.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.6-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.6-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.6
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.6.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-rc.7-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-rc.7-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.7
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0-rc.7.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.0-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.0-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.0.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.1-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.1-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.1
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.1.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.2-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.2-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.2
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.2.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}

--- a/blocked-edges/4.11.3-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.3-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.3
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.3.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}


### PR DESCRIPTION
Generated by writing `blocked-edges/4.11.0-stale-insights-run-level-label.yaml` , and then copying it out to the other 4.11 releases with:

```console
$ yaml2json <channels/candidate-4.11.yaml | jq -r '.versions[]' | grep '^4[.]11[.]' | grep -v '^4[.]11[.]0$' | while read V; do sed "s/4[.]11[.]0/${V}/g" blocked-edges/4.11.0-stale-insights-run-level-label.yaml > "blocked-edges/${V}-stale-insights-run-level-label.yaml"; done
```