### PR TITLE
blocked-edges/4.11.4-stale-insights-run-level-label: 4.11.4 isn't fixed

### DIFF
--- a/blocked-edges/4.11.4-stale-insights-run-level-label.yaml
+++ b/blocked-edges/4.11.4-stale-insights-run-level-label.yaml
@@ -1,0 +1,13 @@
+to: 4.11.4
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-959
+name: StaleInsightsRunLevelLabel
+message: |-
+  An 'openshift.io/run-level: 1' annotation on the openshift-insights namespace may cause "container has runAsNonRoot" for the insights operator when updating to 4.11.4.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level="1"}
+      or
+      0 * kube_namespace_labels{namespace="openshift-insights",label_openshift_io_run_level=""}


### PR DESCRIPTION
Extend b76516a207 (#2457) to 4.11.4, because the fix just landed in the development branch [1] and has yet to be backported to 4.11.z.

Generated with:

```console
$ V=4.11.4; sed "s/4[.]11[.]0/${V}/g" blocked-edges/4.11.0-stale-insights-run-level-label.yaml > "blocked-edges/${V}-stale-insights-run-level-label.yaml"
```

[1]: https://github.com/openshift/insights-operator/pull/672