### PR TITLE
internal-channels/candidate: Tombstone 4.7.58

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -39,6 +39,8 @@ tombstones:
 - 4.7.26
 # 4.7.35 lacks metadata errata URIs for s390x and ppc64le
 - 4.7.35
+# 4.7.58 was rerolled as 4.7.59
+- 4.7.58
 # 4.8.0 unspecified behavior change
 - 4.8.0
 # 4.8.1 s390x missed a kernel bump that went into the other platforms; rerolling as 4.8.2


### PR DESCRIPTION
It was rerolled with similar metadata as 4.7.59:

```console
$ diff -u0 <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.7.58-x86_64 | grep -v created) <(oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.7.59-x86_64 | grep -v created)
--- /dev/fd/63  2022-09-14 10:35:40.915796255 -0700
+++ /dev/fd/62  2022-09-14 10:35:40.918796254 -0700
@@ -2,3 +2,3 @@
-  "image": "quay.io/openshift-release-dev/ocp-release:4.7.58-x86_64",
-  "digest": "sha256:dee33ede78272450743ede855e1a2f1611500e388be212ec0cde68d45b801fa7",
-  "contentDigest": "sha256:dee33ede78272450743ede855e1a2f1611500e388be212ec0cde68d45b801fa7",
+  "image": "quay.io/openshift-release-dev/ocp-release:4.7.59-x86_64",
+  "digest": "sha256:5db88217bbc9ee12d95f3c740eb0217668628e2f1f61b9cb2afdddf16ffb1333",
+  "contentDigest": "sha256:5db88217bbc9ee12d95f3c740eb0217668628e2f1f61b9cb2afdddf16ffb1333",
@@ -35 +35 @@
-        "io.openshift.release": "4.7.58",
+        "io.openshift.release": "4.7.59",
@@ -40 +40 @@
-    "size": 141900403,
+    "size": 141900413,
@@ -49 +49 @@
-        "sha256:3b0d6bdce28f8bc5a4188d6b48832003ca3cf4696198e6b9bfa94a48b0540b3d"
+        "sha256:da1e5bd33a8abae62a508ca0bb7e712227e9c416ea4e80e7d32fb71f363629c8"
@@ -71 +71 @@
-    "version": "4.7.58",
+    "version": "4.7.59",
@@ -163,0 +164 @@
+      "4.7.58",
@@ -170 +171 @@
-      "url": "https://access.redhat.com/errata/RHSA-2022:6303"
+      "url": "https://access.redhat.com/errata/RHSA-2022:6322"
@@ -177,2 +178,2 @@
-      "name": "4.7.58",
-      "creationTimestamp": "2022-09-02T10:43:25Z",
+      "name": "4.7.59",
+      "creationTimestamp": "2022-09-05T03:49:56Z",
```

So there is no reason for customers to prefer 4.7.58 over 4.7.59. 4.7.59 had its errata released and entered the fast channel in 5c70beaee7 (internal-channels/fast: Promote 4.7.59, 2022-09-13, #2489), and the errata referenced from 4.7.48 will never be published. Tombstoning the release informs the stabilization bot, so it will stop complaining like:

  * Recommend waiting to promote 4.7.58 to fast; it was promoted the feeder candidate by 5557a0c718 (Merge pull request #2444 from openshift/pr-candidate-4.7.58, 2022-09-02, 11 days, 5:20:57.769127) https://access.redhat.com/errata/RHSA-2022:6303 is not public.