### PR TITLE
hack/validate-blocked-edges: Require '.yaml' suffix

### DIFF
--- a/hack/util.py
+++ b/hack/util.py
@@ -7,11 +7,15 @@ import subprocess
 import yaml
 
 
-def walk_yaml(directory, revision=None):
+def walk_yaml(directory, revision=None, allowed_extensions=None):
     if revision is None:
         for root, _, files in os.walk(directory):
             for filename in files:
                 if not filename.endswith('.yaml'):
+                    if allowed_extensions:
+                        _, ext = os.path.splitext(filename)
+                        if ext not in allowed_extensions:
+                            raise ValueError('invalid filename: {!r} (allowed extensions: {})'.format(os.path.join(root, filename), allowed_extensions))
                     continue
                 path = os.path.join(root, filename)
                 with open(path) as f:

--- a/hack/validate-blocked-edges.py
+++ b/hack/validate-blocked-edges.py
@@ -6,7 +6,7 @@ import util
 
 
 def validate_blocked_edges(directory):
-    for path, data in util.walk_yaml(directory=directory):
+    for path, data in util.walk_yaml(directory=directory, allowed_extensions=('.yaml',)):
         try:
             validate_blocked_edge(data=data)
         except Exception as error:


### PR DESCRIPTION
So we catch issues in presubmit CI, to avoid needing post-merge fixups like 4d23a343a9 (#2553).  I've set things up so that we can add `.md` or similar to the allow-list in the future, if we wanted to allow `blocked-edges/README.md`, etc.