### PR TITLE
blocked-edges/4.11.7-ovn-namespace: 4.11.7 does not fix the regression

### DIFF
--- a/blocked-edges/4.11.7-ovn-namespace.yaml
+++ b/blocked-edges/4.11.7-ovn-namespace.yaml
@@ -1,9 +1,9 @@
-to: 4.11.6
+to: 4.11.7
 from: .*
 url: https://issues.redhat.com/browse/OCPBUGS-1705
 name: OVNNetworkPolicyLongName
 message: |-
-  A regression may lead to OVN control plane failure and workload disruption when updating to 4.11.6.
+  A regression may lead to OVN control plane failure and workload disruption when updating to 4.11.7.
 matchingRules:
 - type: PromQL
   promql:


### PR DESCRIPTION
Generated by rewording the 4.11.6 `message` to be less specific about when the regression was introduced (and instead just point out that the particular target version being considered is vulnerable).  An then:

```console
$ sed 's/4[.]11[.]6/4.11.7/g' blocked-edges/4.11.6-ovn-namespace.yaml >blocked-edges/4.11.7-ovn-namespace.yaml
```

[OCPBUGS-1750][1] is tracking the 4.11.z fix.

[1]: https://issues.redhat.com//browse/OCPBUGS-1750