### PR TITLE
Bumping the minor_min for 4.12 to 4.11.6

### DIFF
--- a/build-suggestions/4.12.yaml
+++ b/build-suggestions/4.12.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.11.0
+  minor_min: 4.11.6
   minor_max: 4.11.9999
   minor_block_list: []
   z_min: 4.12.0-fc.0


### PR DESCRIPTION
Because the admin_ack for API removal in 4.12 got released in 4.11.6. See OCPBUGS-1251 and https://access.redhat.com/articles/6955381 for more information

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>