### PR TITLE
hack/stabilization-changes: Treat conditional edges as connected

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -243,6 +243,9 @@ def get_concerns_about_updating_out(version, channel, cache=None):
             if source not in updates:
                 updates[source] = set()
             updates[source].add(target)
+        for conditional in cincinnati_data.get('conditionalEdges', []):
+            for edge in conditional.get('edges', []):
+                updates[edge['from']] = edge['to']
         cincinnati_uris.append(cincinnati_uri)
         candidate_minor -= 1
 
@@ -253,10 +256,10 @@ def get_concerns_about_updating_out(version, channel, cache=None):
         for target in targets:
             target_major_minor = '.'.join(target.split('.', 2)[:2])
             if target_major_minor == channel_major_minor:
-                return  # we have an unconditional update path to the target major.minor.
+                return  # we have update path to the target major.minor.
         reachable.update(targets)  # maybe additional hops will get us to the target major.minor.
 
-    return ' No unconditional paths from {} to {} in {}'.format(version, channel_major_minor, ' '.join(cincinnati_uris))
+    return ' No paths from {} to {} in {}'.format(version, channel_major_minor, ' '.join(cincinnati_uris))
 
 
 def get_cincinnati_channel(arch='amd64', channel='', update_service='https://api.openshift.com/api/upgrades_info/v1/graph', cache=None):


### PR DESCRIPTION
So we don't have to do things like 38394e3f4e (#2497) manually.  Personally, whether a conditional update feels connected or disconnected is a bit murky. The `StaleInsightsRunLevelLabel` risk feels connected, because it's a small slice of the relevant fleet, and because it is very easy to manually mitigate (just remove the old label to make your cluster invulnerable).  `RPMOSTreeTimeout` feels disconnected, because it's an `Always` (so the entire relevant fleet), and it's difficult to mitigate either prophylactically or post-update if you get bit.  So there's some risk with this change that folks get an update recommendation to a 4.(y-1).z that doesn't have a workable-for-them path to their desired 4.y.  But at least there will be a conditional risk there explaining what we're concerend about, and in some cases they will be able to accept the risk or mitigate before updating.