### PR TITLE
blocked-edges/4.11.8-ovn-namespace: 4.11.8 does not fix the regression

### DIFF
--- a/blocked-edges/4.11.8-ovn-namespace.yaml
+++ b/blocked-edges/4.11.8-ovn-namespace.yaml
@@ -1,0 +1,13 @@
+to: 4.11.8
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-1705
+name: OVNNetworkPolicyLongName
+message: |-
+  A regression may lead to OVN control plane failure and workload disruption when updating to 4.11.8.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}[1h]))
+      or
+      0 * group(max_over_time(cluster:usage:resources:sum[1h]))


### PR DESCRIPTION
Like 2d6b5fb45f (#2557), but for 4.11.8.  Generated with:

```console
$ sed 's/4[.]11[.]6/4.11.8/g' blocked-edges/4.11.6-ovn-namespace.yaml >blocked-edges/4.11.8-ovn-namespace.yaml
```