### PR TITLE
hack/stabilization-changes: Fix conditional-edge clobber

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -245,7 +245,9 @@ def get_concerns_about_updating_out(version, channel, cache=None):
             updates[source].add(target)
         for conditional in cincinnati_data.get('conditionalEdges', []):
             for edge in conditional.get('edges', []):
-                updates[edge['from']] = edge['to']
+                if edge['from'] not in updates:
+                    updates[edge['from']] = set()
+                updates[edge['from']].add(edge['to'])
         cincinnati_uris.append(cincinnati_uri)
         candidate_minor -= 1
 


### PR DESCRIPTION
Fixing a bug from 299823467d (#2582), where I'd clobbered the target set with a single target string.  Now I add to the target set.  Testing locally:

```console
$ hack/stabilization-changes.py 
...
* channels/fast-4.11: Promote 4.10.34. It was promoted to the feeder fast by a9940142aa (Merge pull request #2550 from openshift-ota-bot/promote-4.10.34-to-fast, 2022-09-27) 9 days, 9:32:29.547157 ago. data://no-token-so-no-pull
* channels/fast-4.11: Promote 4.10.35. It was promoted to the feeder fast by d1fab0c171 (Merge pull request #2588 from openshift-ota-bot/promote-4.10.35-to-fast, 2022-10-04) 2 days, 5:21:06.554582 ago. data://no-token-so-no-pull
...
```

Which is what Scott wants in #2608.