### PR TITLE
blocked-edges/4.11.9-ovn-namespace: 4.11.9 does not fix the regression

### DIFF
--- a/blocked-edges/4.11.9-ovn-namespace.yaml
+++ b/blocked-edges/4.11.9-ovn-namespace.yaml
@@ -1,0 +1,13 @@
+to: 4.11.9
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-1705
+name: OVNNetworkPolicyLongName
+message: |-
+  A regression may lead to OVN control plane failure and workload disruption when updating to 4.11.9.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}[1h]))
+      or
+      0 * group(max_over_time(cluster:usage:resources:sum[1h]))


### PR DESCRIPTION
Like 2d6b5fb45f (#2557), and a82acb43be (#2599), but for 4.11.9.  Generated with:

```console
$ sed 's/4[.]11[.]6/4.11.9/g' blocked-edges/4.11.6-ovn-namespace.yaml >blocked-edges/4.11.9-ovn-namespace.yaml
```

[OCPBUGS-1750][1] is `MODIFIED` with happy noises from QE, so odds are good that 4.11.10 will have the fix, but we'll see once it's built.

[1]: https://issues.redhat.com/browse/OCPBUGS-1750