### PR TITLE
build-suggestions/4.12: Raise minor_min to 4.11.9

### DIFF
--- a/build-suggestions/4.12.yaml
+++ b/build-suggestions/4.12.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.11.6
+  minor_min: 4.11.9
   minor_max: 4.11.9999
   minor_block_list: []
   z_min: 4.12.0-fc.0


### PR DESCRIPTION
# Preserving add_inheritable_capabilities CRI-O defaulting

[OCPBUGS-1939][1] is going out with [4.11.9][2], and we want to raise the floor for:

1. Running 4.10.
2. Pause compute.
3. Update to 4.11.9 with the fix.
4. Machine-config controller with the fix creates a MachineConfig to lock in the 4.11-and-earlier default behavior.  Paused compute means that this doesn't get rolled out to compute nodes yet, but that's fine, they're on 4.10 still, with the 4.11-and-earlier default.
5. Control plane (and any other unpaused compute) updates to pick up the new rendered MachineConfig, but effectively a no-op, because their 4.11 CRI-O still has the 4.11-and-earlier default too.
6. Update to 4.12.
7. Unpause compute.
8. Compute picks up 4.12 CRI-O and the new MachineConfig at the same time, so it will never use the new-in-4.12 default (until the user deletes the default-preserving MachineConfig at a time of their own choosing).

# Autoscaler PodDisruptionBudget v1beta1 to v1

[OCPBUGS-2046][3] is also going out with 4.11.9, and we want to raise the floor there too.  Without the 4.11.z backport, I expect updates from 4.11 to 4.12 would succeed. But there might be a window during the update when the outgoing autoscaler was trying to use the v1beta1 API vs. a Kube API server that no longer understood that version, and there might not be autoscaling until the incoming autoscaler showed up speaking the v1 API. My main interest in the 4.11.z backport is that if we have this code back in 4.11.z, it won't trip the APIRemovedInNext*ReleaseInUse alerts. So folks on those 4.11.z will be more confident that updates to 4.12 are safe, instead of guessing and then finding out how well they did in the middle of the update.

[1]: https://issues.redhat.com/browse/OCPBUGS-1939
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.11.9
[3]: https://issues.redhat.com/browse/OCPBUGS-2046