### PR TITLE
Raising the minor_min for 4.11 to 4.12 upgrades

### DIFF
--- a/build-suggestions/4.12.yaml
+++ b/build-suggestions/4.12.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.11.9
+  minor_min: 4.11.11
   minor_max: 4.11.9999
   minor_block_list: []
   z_min: 4.12.0-fc.0


### PR DESCRIPTION
As https://issues.redhat.com/browse/OCPBUGS-2293 and OCPBUGS-2050 is shipped in 4.11.12

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>