### PR TITLE
*: Prepare for 4.13 development

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,0 +1,7 @@
+default:
+  minor_min: 4.12.0-rc.0
+  minor_max: 4.12.9999
+  minor_block_list: []
+  z_min: 4.13.0-ec.0
+  z_max: 4.13.9999
+  z_block_list: []

--- a/channels/candidate-4.13.yaml
+++ b/channels/candidate-4.13.yaml
@@ -1,0 +1,7 @@
+feeder:
+  delay: PT0H
+  filter: 4[.](12|13)[.][0-9].*
+  name: candidate
+name: candidate-4.13
+versions:
+- 4.12.0-rc.0

--- a/hack/release-open.sh
+++ b/hack/release-open.sh
@@ -7,7 +7,7 @@ MAJOR_MINOR="${1}"
 if test -z "${MAJOR_MINOR}"
 then
 	cat <<-EOF >&2
-		This script creates the necessary files for for a new x.y minor release feature freeze.
+		This script creates the necessary files for for a new x.y minor release.
 		Usage:
 		  ${0} MAJOR_MINOR
 		For example:
@@ -34,10 +34,10 @@ PREVIOUS_MINOR="$((MINOR - 1))"
 
 cat <<EOF > "build-suggestions/${MAJOR_MINOR}.yaml"
 default:
-  minor_min: ${MAJOR}.${PREVIOUS_MINOR}.0
+  minor_min: ${MAJOR}.${PREVIOUS_MINOR}.0-rc.0
   minor_max: ${MAJOR}.${PREVIOUS_MINOR}.9999
   minor_block_list: []
-  z_min: ${MAJOR_MINOR}.0-fc.0
+  z_min: ${MAJOR_MINOR}.0-ec.0
   z_max: ${MAJOR_MINOR}.9999
   z_block_list: []
 EOF


### PR DESCRIPTION
Like 2d428f86bc (#2480), but for 4.13.  Run well before feature-freeze, because for 4.13 we plan on cutting sprintly `4.13.0-ec.#` and including them in candidate-4.13.  Generated with:

```console
$ hack/release-open.sh 4.13
$ git add build-suggestions/4.13.yaml channels/*4.13.yaml
```