### PR TITLE
blocked-edges/4.11.*: Declare ARM64SecCompError524 regression

### DIFF
--- a/blocked-edges/4.11.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-fc.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-fc.0-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-fc.0 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-fc.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-fc.3-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-fc.3 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.0-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.0 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.1-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.1-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.1
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.1 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.2-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.2-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.2
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.2 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.3-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.3 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.4-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.4-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.4
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.4 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.5-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.5-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.5
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.5 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.6-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.6-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.6
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.6 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.0-rc.7-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.7-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.7
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.0-rc.7 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.1-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.1-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.1
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.1 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.10-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.10-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.10
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.10 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.11-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.11-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.11
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.11 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.12-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.12-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.12
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.12 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.13-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.13-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.13
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.13 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.14-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.14-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.14
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.14 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.2-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.2-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.2
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.2 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.3-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.3 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.4-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.4-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.4
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.4 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.5-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.5-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.5
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.5 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.6-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.6-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.6
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.6 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.7-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.7-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.7
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.7 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.8-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.8-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.8
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.8 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))

--- a/blocked-edges/4.11.9-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.9-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.9
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.9 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))


### PR DESCRIPTION
Although as I point out in [RUN-1668](https://issues.redhat.com//browse/RUN-1668), [rhbz#2140163][2] makes it sound like the risk might be 4.10-to-4.11, not 4.11-to-4.12, so we may need to refine this later.

[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2140163#c2