### PR TITLE
blocked-edges/4.11.17-arm64-seccomp-error-524: 4.11.17 does not contain a fix

### DIFF
--- a/blocked-edges/4.11.17-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.17-arm64-seccomp-error-524.yaml
@@ -1,0 +1,13 @@
+to: 4.11.17
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/RUN-1668
+name: ARM64SecCompError524
+message: |-
+  4.11.17 arm64 nodes may expose container creation to seccomp error 524.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
+      or
+      0 * group(max_over_time(kube_node_labels[1h]))


### PR DESCRIPTION
[OCPBUGS-2637](https://issues.redhat.com/browse/OCPBUGS-2637) is tracking the fix, and it's still New.

Generated with:

```console
$ V=4.11.17; sed "s/4[.]11[.]0/${V}/g" blocked-edges/4.11.0-arm64-seccomp-error-524.yaml > "blocked-edges/${V}-arm64-seccomp-error-524.yaml"
```