### PR TITLE
COS-1942: blocked-edges/4.12.*: Declare AWSOldBootImages

### DIFF
--- a/blocked-edges/4.12.0-rc.0-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.0-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.0
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.0, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.1-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.1-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.1
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.1, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.2-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.2-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.2
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.2, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.3-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.3-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.3
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.3, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.4-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.4-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.4
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.4, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.5-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.5-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.5
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.5, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )


### PR DESCRIPTION
This one is sticky, because we don't have PromQL access to boot-image age, so we cannot automatically distinguish between "born in 4.(<=2) and still uses the old boot images" and "born in 4.(<=2), but has subsequently updated boot images".  And because of a cluster-version operator bug, we don't necessarily have access to the cluster's born-in release anyway.  The CVO bug fix went back via:

* [4.11.0](https://bugzilla.redhat.com/show_bug.cgi?id=2097067#c12)
* [4.10.24](https://bugzilla.redhat.com/show_bug.cgi?id=2108292#c6)
* [4.9.45](https://bugzilla.redhat.com/show_bug.cgi?id=2108619#c6)
* [4.8.47](https://bugzilla.redhat.com/show_bug.cgi?id=2109962#c6)
* [4.7.59](https://bugzilla.redhat.com/show_bug.cgi?id=2117347#c8)
* [4.6.61](https://bugzilla.redhat.com/show_bug.cgi?id=2118489#c6)

So it's possible for someone born in 4.2 to have spend a whole bunch of time in 4.9.z and be reporting a `4.9.0-rc.*` or something as their born-in version.  Work around that by declaring this risk for AWS clusters where the born-in version is 4.9 or earlier, expecting that we'll have this issue fixed soonish, so folks with old boot images will be able to update to a later 4.12, and allowing us to be overly broad/cautious with the risk matching here.

I wrote the 4.12.0-rc.0 content manually, and then copied over to the other 4.12s with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.12' | jq -r '.nodes[].version' | grep '^4[.]12[.]' | grep -v '^4[.]12[.]0-rc[.]0$' | while read V; do sed "s/4[.]12[.]0-rc[.]0/${V}/g" blocked-edges/4.12.0-rc.0-AWSOldBootImage.yaml > "blocked-edges/${V}-AWSOldBootImage.yaml"; done
```