### PR TITLE
blocked-edges/4.12.0-rc.7-AWSOldBootImage: rc.7 does not contain a fix

### DIFF
--- a/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.7
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/COS-1942
+name: AWSOldBootImages
+message: |-
+  4.2 AWS boot images are not compatible with 4.12.0-rc.7, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )


### PR DESCRIPTION
The fix landed in 4.12 after rc.7 was cut

https://issues.redhat.com/browse/OCPBUGS-5384