### PR TITLE
Add an additional 1w delay when adding 4.8.z to stable-4.8 and eus-4.8

### DIFF
--- a/channels/eus-4.8.yaml
+++ b/channels/eus-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P1W
   filter: 4\.[68]\.[0-9].*|4\.7\.(3[4-9]|[4-9][0-9])
   name: stable
 name: eus-4.8

--- a/channels/stable-4.8.yaml
+++ b/channels/stable-4.8.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P1W
   filter: 4\.[78]\.[0-9].*
   name: stable
 name: stable-4.8


### PR DESCRIPTION
This minimizes the impact of 4.8.56 and 4.8.57 shipping before an upgrade path to 4.9 is available. This delay is on top of the normal P1W delay for the internal channel promotion from fast to stable. There's no need to adjust delays into 4.9 channels because the existing upgradability checks will ensure that 4.8.z doesn't go into those channels before an upgrade path is available.