### PR TITLE
MCO-457: blocked-edges/4.11.*: Declare MachineConfigRenderingChurn

### DIFF
--- a/blocked-edges/4.11.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-fc.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-fc.0-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-fc.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-fc.3-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-fc.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.0-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.0
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.1-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.1-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.1
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.2-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.2-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.2
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.3-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.4-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.4-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.4
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.5-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.5-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.5
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.6-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.6-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.6
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.0-rc.7-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.7-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.0-rc.7
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.1-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.1-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.1
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.10-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.10-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.10
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.11-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.11-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.11
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.12-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.12-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.12
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.13-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.13-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.13
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.14-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.14-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.14
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.16-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.16-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.16
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.17-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.17-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.17
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.18-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.18-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.18
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.19-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.19-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.19
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.2-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.2-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.2
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.20-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.20-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.20
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.21-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.21-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.21
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.22-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.22-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.22
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.23-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.23-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.23
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.24-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.24-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.24
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.25
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.3-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.3
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.4-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.4-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.4
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.5-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.5-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.5
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.6-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.6-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.6
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.7-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.7-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.7
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.8-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.8-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.8
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.9-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.9-MachineConfigRenderingChurn.yaml
@@ -1,0 +1,13 @@
+to: 4.11.9
+from: 4[.]10[.].*
+url:  https://issues.redhat.com/browse/MCO-457
+name: MachineConfigRenderingChurn
+message: |-
+  Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)


### PR DESCRIPTION
The 4.10 machine-config operator [defaulted `CSIMigrationOpenStack` to `false`][1], but it was [locked to `true` by 4.11 kubelets][2].  In clusters with a KubeletConfig that does not explicitly set `CSIMigrationOpenStack: true`, the slower
KubletConfig-to-MachineConfig translation can [lead to rendering races when updating to 4.11][3], and in some cases a 4.11 kubelet will see a 4.10 configuration and [wedge with][4]:

    cannot set feature gate CSIMigrationOpenStack to false, feature is locked to true

We recommend clusters with KubletConfigs that do not set `CSIMigrationOpenStack: true` remain on 4.10 until they can update to a 4.11 that contains the fix.

Clusters that do not contain any KubeletConfigs are unlikely to be exposed.  And clusters that complete an update to 4.11 without being bitten have made it safely past the race.

Generated by writing 4.11.0-MachineConfigRenderingChurn.yaml, and then copying it out to other 4.11.z with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.11' | jq -r '.nodes[].version' | grep '^4[.]11[.]' | grep -v '^4[.]11[.]0$' | while read V; do sed "s/4[.]11[.]0/${V}/g" blocked-edges/4.11.0-MachineConfigRenderingChurn.yaml > "blocked-edges/${V}-MachineConfigRenderingChurn.yaml"; done
```

[1]: https://github.com/openshift/machine-config-operator/blob/b348c8b67cb4909f04c99b2beb53f80f8a3d9b9a/templates/master/01-master-kubelet/_base/files/kubelet.yaml#L38
[2]: https://github.com/openshift/kubernetes/blob/5766b2ad79b89d0a493ce88fd0f47310dbc3ba84/pkg/features/kube_features.go#L922
[3]: https://issues.redhat.com/browse/OCPBUGS-6018
[4]: https://issues.redhat.com/browse/OCPBUGS-3821