### PR TITLE
OTA-858: hack/stabilization-changes: Add risk-extension guards with fixedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Create/edit an appropriate file in `blocked_edges/`.
 * `url` (optional, [string][json-string]), with a URI documenting the blocking reason.
     For example, this could link to a bug's impact statement or knowledge-base article.
 * `name` (optional, [string][json-string]), with a CamelCase reason suitable for [a `ClusterOperatorStatusCondition` `reason` property][api-reason].
+* `fixedIn` (optional, [string][json-string]), with the update-target release where the exposure was fixed, either directly, or because that target is newer than the 4.(y-1).z release where the exposure was fixed.
+    This feeds risk-extension guards that require either a `fixedIn` declaration or an extension of unfixed risks to later releases to avoid shipping a release that is still exposed to a risk without declaring that risk.
 * `message` (optional, [string][json-string]), with a human-oriented message describing the blocking reason, suitable for [a `ClusterOperatorStatusCondition` `message` property][api-message].
 * `matchingRules` (optional, [array][json-array]), defining conditions for deciding which clusters have the update recommended and which do not.
     The array is ordered by decreasing precedence.

--- a/blocked-edges/4.11.23-duplicate-release.yaml
+++ b/blocked-edges/4.11.23-duplicate-release.yaml
@@ -2,6 +2,7 @@ to: 4.11.23
 from: .*
 url:  https://access.redhat.com/errata/RHSA-2023:0069
 name: DuplicateRelease
+fixedIn: 4.11.24
 message: |-
   4.11.23 was replaced with 4.11.24. Please update to 4.11.24, it is an identical release except for the errata link.
 matchingRules:

--- a/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
@@ -2,6 +2,7 @@ to: 4.11.25
 from: 4[.]10[.].*
 url: https://access.redhat.com/solutions/6984140
 name: MachineConfigRenderingChurn
+fixedIn: 4.11.26
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:


### PR DESCRIPTION
With this change, the script will complain like:

```
* Recommend waiting to promote 4.11.24 to fast-4.12; it was promoted the feeder fast by f5a8c3b3ef (Merge pull request #3024 from openshift-ota-bot/promote-4.11.24-to-fast, 2023-01-19, 4 days, 3:10:10.409875)  DuplicateRelease affects 4.11.23.  Either declare a fix version or extend the risk to 4.11.24.  No paths from 4.11.24 to 4.12 in https://api.openshift.com/api/upgrades_info/v1/graph?channel=candidate-4.12&arch=amd64
```

as it wonders if `DuplicateRelease` (which affects updates into 4.11.23) affects 4.11.24 or not.  Graph administrators can either:

* declare `fixedIn` (like I'm doing in this commit) or
* extend the risk to the new release (like we'd done in d44b7a4710 (#3032) and similar.

But the guard should keep us from accidentally promoting releases where we haven't gotten around to evaluating risk extension yet.