### PR TITLE
hack/stabilization-changes: Conditional edges vs. connectivity

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -245,6 +245,8 @@ def get_concerns_about_updating_out(version, channel, cache=None):
             updates[source].add(target)
         for conditional in cincinnati_data.get('conditionalEdges', []):
             for edge in conditional.get('edges', []):
+                if edge['from'] not in channel_versions or (edge['to'] != version and edge['to'] not in channel_versions):
+                    continue  # even if we promote version, this edge will not be in the target channel
                 if edge['from'] not in updates:
                     updates[edge['from']] = set()
                 updates[edge['from']].add(edge['to'])


### PR DESCRIPTION
Fix a bug where we'd treated a release as connected when it was linked to the target 4.y via conditional updates in the candidate-4.y channel.  With this commit, conditional updates only increase connectivity when the releases are (or will be after promotion) in the target channel.

For example:

* 4.11.24 is in 'fast' and 'candidate-4.12'.
* 4.12.1 is in 'candidate-4.12', with a conditional update from 4.11.24.
* Considering 4.11.24 for promotion into 'fast-4.12':
  * The outgoing logic said "candidate-4.12 has a conditional update to 4.12.1, which is in 4.12, so promote!"
  * The incoming logic says, "candidate-4.12 has a conditional update to 4.12.1, but 4.12.1 is not in fast-4.12, so don't promote yet.