### PR TITLE
hack/stabilization-changes: Conditional edges vs. connectivity v2

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -245,7 +245,7 @@ def get_concerns_about_updating_out(version, channel, cache=None):
             updates[source].add(target)
         for conditional in cincinnati_data.get('conditionalEdges', []):
             for edge in conditional.get('edges', []):
-                if edge['from'] not in channel_versions or (edge['to'] != version and edge['to'] not in channel_versions):
+                if edge['to'] not in channel_versions or (edge['from'] != version and edge['from'] not in channel_versions):
                     continue  # even if we promote version, this edge will not be in the target channel
                 if edge['from'] not in updates:
                     updates[edge['from']] = set()


### PR DESCRIPTION
0a4013aed4 (#3064) flipped the `source`/`target` `from`/`to` sense when porting this logic from the unconditional-edge block a few lines up.  Fix that, so:

```console
$ hack/show-edges.py --cincinnati https://api.openshift.com/api/upgrades_info/graph --root-version 4.11.24 candidate-4.12
4.11.24 -> 4.11.25
4.11.24 -(blocked: ConsoleAvailableUpdatesNull)-> 4.12.1
4.11.25 -(blocked: ConsoleAvailableUpdatesNull)-> 4.12.1
```

will result in:

```console
$ hack/stabilization-changes.py
...
* channels/fast-4.12: Promote 4.11.24. It was promoted to the feeder fast by f5a8c3b3ef (Merge pull request #3024 from openshift-ota-bot/promote-4.11.24-to-fast, 2023-01-19) 11 days, 15:25:56.493972 ago. data://no-token-so-no-pull
* channels/fast-4.12: Promote 4.11.25. It was promoted to the feeder fast by 83a0fcf68c (Merge pull request #3041 from openshift-ota-bot/promote-4.11.25-to-fast, 2023-01-23) 7 days, 14:48:11.943448 ago. data://no-token-so-no-pull
...
```