### PR TITLE
build-suggestions/4.13: Raise minor_min to 4.12.0

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.0-rc.0
+  minor_min: 4.12.0
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-ec.0


### PR DESCRIPTION
With 4.12 generally available, we no longer need to recomment 4.12.0-pre-release to 4.13.0-pre-release updates.  By not recommending them, we reduce the recommended updates to transitions that users are more likely to be interested in.

Like 7b5f37a767 (#3075), but for the 4.13 build suggestions.