### PR TITLE
`ConsoleAvailableUpdatesNull`: OCPBUGS-6678 is fixed in 4.12.2

### DIFF
--- a/blocked-edges/4.12.1-ConsoleAvailableUpdatesNull.yaml
+++ b/blocked-edges/4.12.1-ConsoleAvailableUpdatesNull.yaml
@@ -2,6 +2,7 @@ to: 4.12.1
 from: .*
 url: https://issues.redhat.com/browse/CONSOLE-3428
 name: ConsoleAvailableUpdatesNull
+fixedIn: 4.12.2
 message: |-
   An administrator console regression breaks the cluster settings page when 'availableUpdates' is null and 'Upgradeable' is 'False'.  You can still use 'oc adm upgrade', address the 'Upgradeable' issues, or wait for a fixed release.
 matchingRules:


### PR DESCRIPTION
From https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.2:

> OCPBUGS-6678: fix run-time error on Cluster Settings when available...