### PR TITLE
hack/stabilization-changes: Dedup notifications

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -95,7 +95,11 @@ def stabilization_changes(directories, webhook=None, **kwargs):
     for name, channel in sorted(channels.items()):
         notifications.extend(stabilize_channel(name=name, channel=channel, channels=channels, channel_paths=channel_paths, update_risks=update_risks, cache=cache, **kwargs))
     if notifications:
-        notify(message='* ' + ('\n* '.join(notifications)), webhook=webhook)
+        deduped_notifications = []
+        for notification in notifications:
+            if notification not in deduped_notifications:
+                deduped_notifications.append(notification)
+        notify(message='* ' + ('\n* '.join(deduped_notifications)), webhook=webhook)
 
 
 def stabilize_channel(name, channel, channels, channel_paths, **kwargs):


### PR DESCRIPTION
Avoid redundancies like:

```
  Cincinnati stabilization:
  * FAILED ARM64SecCompError524 affects 4.11.26.  Either declare a fix version or extend the risk to 4.11.27.
  * FAILED ARM64SecCompError524 affects 4.11.26.  Either declare a fix version or extend the risk to 4.11.27.
  * FAILED ARM64SecCompError524 affects 4.11.26.  Either declare a fix version or extend the risk to 4.11.27.
  * channels/fast-4.10: Promote 4.10.51. It was promoted...
```

when a release fails promotion into several channels for the same reason (and we don't currently include the target channel in the notification message, because it doesn't seem helpful).

With this change, we'll only get each message once.  And we'll preserve the previous ordering, so specific channels are still grouped together, regardless of the message strings the `stabilize_channel` function returns.