### PR TITLE
blocked-edges: ConsoleAvailableUpdatesNull fixed in 4.13.0-ec.3

### DIFF
--- a/blocked-edges/4.13.0-ec.2-ConsoleAvailableUpdatesNull.yaml
+++ b/blocked-edges/4.13.0-ec.2-ConsoleAvailableUpdatesNull.yaml
@@ -2,6 +2,7 @@ to: 4.13.0-ec.2
 from: .*
 url: https://issues.redhat.com/browse/CONSOLE-3428
 name: ConsoleAvailableUpdatesNull
+fixedIn: 4.13.0-ec.3
 message: |-
   An administrator console regression breaks the cluster settings page when 'availableUpdates' is null and 'Upgradeable' is 'False'.  You can still use 'oc adm upgrade', address the 'Upgradeable' issues, or wait for a fixed release.
 matchingRules:


### PR DESCRIPTION
[OCPBUGS-6053](https://issues.redhat.com/browse/OCPBUGS-6053)'s openshift/console#12450 is  included in [the new release][3].

[3]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-dev-preview-multi/release/4.13.0-ec.3