### PR TITLE
Raise minimum for upgrades into 4.13 to 4.12.5 to pick up rpmdb compat

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.0
+  minor_min: 4.12.5
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-ec.0


### PR DESCRIPTION
Tracking bug is https://issues.redhat.com/browse/OCPBUGS-7275