### PR TITLE
OCPNODE-1502: Declare `LeakedMachineConfigBlocksMCO` on 4.11.26+ | 4.12.2+ | 4.13.0-ec.3+

### DIFF
--- a/blocked-edges/4.11.26-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.26-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.26
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.27-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.27-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.27
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.28-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.28-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.28
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.29-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.29-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.29
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.30-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.30-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.30
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.11.31-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.31-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.31
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.2-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.2-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.3-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.3-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.4-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.5-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.5-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.6-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.6-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.12.7-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.7-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.12.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.3
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfi  g resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)

--- a/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.4
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfi  g resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)


### PR DESCRIPTION
According to [OCPNODE-1502](https://issues.redhat.com//browse/OCPNODE-1502):

> Any 4.y cluster has kubeletconfig objects upgrades to cluster 4.11.0-fc.0+
> Any 4.y cluster has containerruntimeconfig objects upgrades to cluster 4.12.0-ec.1+

-> These upgrades could result in orphaning a machineconfig resource

> **Is this a regression?**
> Yes, 4.10.52+, 4.11.26+, 4.12.2+, and 4.13.0-ec.3 landed code that
> pivoted the machine-config components treatment of leaked MachineConfig
> from "ignore" to "block on".

-> Upgrades to these versions could wedge MCO when it encounters an
orphaned machineconfig resource.

Hence, upgrades to 4.10 should not be affected by `LeakedMachineConfigBlocksMCO`, because it should never have an orphaned resource. Upgrades to newer versions are only affected if they start on 4.11+.

I have created the files manually for each affected version and made copies with these fish snippets:

```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13' | jq -r '.nodes[].version' | sort -V | while read V
      if [ "$seenfirst" = 'yes' ]
          sed "s/4[.]13[.]0-ec.3/$V/g" blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml > "blocked-edges/$V-leaked-machineconfig.yaml"
      end
      if [ "$V" = '4.13.0-ec.3' ]
          set seenfirst yes
      end
  end
```
