### PR TITLE
blocked-edges/4.11.31: Extend AWSOldBootImageLackAfterburn

### DIFF
--- a/blocked-edges/4.11.31-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.31-AWSOldBootImageLackAfterburn.yaml
@@ -1,0 +1,21 @@
+to: 4.11.31
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/MCO-519
+name: AWSOldBootImagesLackAfterburn
+message: |-
+  4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )


### PR DESCRIPTION
[OCPBUGS-7559](https://issues.redhat.com/browse/OCPBUGS-7559) is still POST for 4.14, and once it gets fixed there, it will need to go through the backport process before we get a fixed 4.11.z.