### PR TITLE
blocked-edges/4.13.0-ec.*-leaked-machineconfig: Drop whitespace from 'ContainerRuntimeConfi  g'

### DIFF
--- a/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
@@ -3,7 +3,7 @@ from: .*
 url: https://issues.redhat.com/browse/OCPNODE-1502
 name: LeakedMachineConfigBlocksMCO
 message: |-
-  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfi  g resources.
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
@@ -3,7 +3,7 @@ from: .*
 url: https://issues.redhat.com/browse/OCPNODE-1502
 name: LeakedMachineConfigBlocksMCO
 message: |-
-  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfi  g resources.
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
 - type: PromQL
   promql:


### PR DESCRIPTION
Following up on 472ed90abc (#3243).