### PR TITLE
Updating the minor_min for 4.13 to 4.12.8

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.5
+  minor_min: 4.12.8
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-ec.0


### PR DESCRIPTION
As the admin_ack[1] for updating to 4.13 will be available with 4.12.8 version
[1] https://issues.redhat.com//browse/OCPBUGS-8304