### PR TITLE
Adding conditional update "PodmanMissingAuthFlag" for 4.11.* to 4.12.*

### DIFF
--- a/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.0-rc.8
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.1
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.2
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.3
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.4
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.5
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.6
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -1,0 +1,21 @@
+to: 4.12.7
+from: 4[.]11[.].*
+url: https://issues.redhat.com/browse/MCO-540
+name: OldBootImagesPodmanMissingAuthFlag
+message: |-
+  OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        or
+        0 * cluster_infrastructure_provider
+      )


### PR DESCRIPTION
Like 034fa0182a (blocked-edges/4.12.*: Declare AWSOldBootImages,
    2022-12-14, #2909) and 957626a4ec , this conditional risk is sticky,
    because we don't have PromQL access to boot-image age, so we cannot automatically distinguish
    between "born in 4.1 and still uses the old boot images" and "born
    in 4.1, but has subsequently updated boot images".  And because of
    a cluster-version operator bug, we don't necessarily have access to
    the cluster's born-in release anyway.

    The CVO bug fix went back via:

    * 4.11.0 https://bugzilla.redhat.com/show_bug.cgi?id=2097067#c12
    * 4.10.24 https://bugzilla.redhat.com/show_bug.cgi?id=2108292#c6
    * 4.9.45 https://bugzilla.redhat.com/show_bug.cgi?id=2108619#c6
    * 4.8.47 https://bugzilla.redhat.com/show_bug.cgi?id=2109962#c6
    * 4.7.59 https://bugzilla.redhat.com/show_bug.cgi?id=2117347#c8
    * 4.6.61 https://bugzilla.redhat.com/show_bug.cgi?id=2118489#c6

   
 So it's possible for someone born in 4.1 to have spend a whole bunch
    of time in 4.9.z and be reporting a 4.9.0-rc.* or something as their
    born-in version.  Work around that by declaring this risk for AWS
    clusters where the born-in version is 4.9 or earlier, expecting that
    we'll have this issue fixed soonish, so folks with old boot images
    will be able to update to a later 4.11, and allowing us to be overly
    broad/cautious with the risk matching here.