### PR TITLE
blocked-edges/4.12.7-leaked-machineconfig: Fixed in 4.12.8

### DIFF
--- a/blocked-edges/4.12.7-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.7-leaked-machineconfig.yaml
@@ -2,6 +2,7 @@ to: 4.12.7
 from: .*
 url: https://issues.redhat.com/browse/OCPNODE-1502
 name: LeakedMachineConfigBlocksMCO
+fixedIn: 4.12.8
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:


### PR DESCRIPTION
[OCPBUGS-8261](https://issues.redhat.com/browse/OCPBUGS-8261) is in [4.12.8][2].

[2]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.12.8