### PR TITLE
blocked-edges/4.11.32-*: AWSOldBootImageLackAfterburn and LeakedMachineConfigBlocksMCO are unfixed

### DIFF
--- a/blocked-edges/4.11.32-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.32-AWSOldBootImageLackAfterburn.yaml
@@ -1,0 +1,21 @@
+to: 4.11.32
+from: 4[.]10[.].*
+url: https://issues.redhat.com/browse/MCO-519
+name: AWSOldBootImagesLackAfterburn
+message: |-
+  4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        cluster_infrastructure_provider{type="AWS"}
+        or
+        0 * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.11.32-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.32-leaked-machineconfig.yaml
@@ -1,0 +1,13 @@
+to: 4.11.32
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-1502
+name: LeakedMachineConfigBlocksMCO
+message: |-
+  Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
+      or
+      0 * group(cluster:usage:resources:sum)


### PR DESCRIPTION
[OCPBUGS-10425](https://issues.redhat.com/browse/OCPBUGS-10425) is Post for 4.11.z for `AWSOldBootImageLackAfterburn`.  [OCPBUGS-8260](https://issues.redhat.com/browse/OCPBUGS-8260) in ON_QA for 4.11.z for `LeakedMachineConfigBlocksMCO`, but [it landed after 4.11.32][3].

[3]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly/release/4.11.0-0.nightly-2023-03-17-003301?from=4.11.32