### PR TITLE
blocked-edges/4.13.0-ec.4-leaked-machineconfig: Fixed in 4.13.0-rc.0

### DIFF
--- a/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
@@ -2,6 +2,7 @@ to: 4.13.0-ec.4
 from: .*
 url: https://issues.redhat.com/browse/OCPNODE-1502
 name: LeakedMachineConfigBlocksMCO
+fixedIn: 4.13.0-rc.0
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:


### PR DESCRIPTION
[OCPBUGS-7719](https://issues.redhat.com/browse/OCPBUGS-7719) is in [4.13.0-rc.0][2].

[2]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.0-rc.0?from=4.13.0-ec.4