### PR TITLE
AUTH-351: blocked-edges/4.13.0-*: Declare StrictPodSecurityViolation

### DIFF
--- a/blocked-edges/4.13.0-ec.1-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.1-StrictPodSecurityViolation.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.1
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/AUTH-351
+name: StrictPodSecurityViolation
+message: |-
+  OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
+      or
+      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})

--- a/blocked-edges/4.13.0-ec.2-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.2-StrictPodSecurityViolation.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/AUTH-351
+name: StrictPodSecurityViolation
+message: |-
+  OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
+      or
+      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})

--- a/blocked-edges/4.13.0-ec.3-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.3-StrictPodSecurityViolation.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/AUTH-351
+name: StrictPodSecurityViolation
+message: |-
+  OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
+      or
+      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})

--- a/blocked-edges/4.13.0-ec.4-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.4-StrictPodSecurityViolation.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/AUTH-351
+name: StrictPodSecurityViolation
+message: |-
+  OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
+      or
+      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})

--- a/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.0
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/AUTH-351
+name: StrictPodSecurityViolation
+message: |-
+  OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
+      or
+      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})


### PR DESCRIPTION
Generated by writing the rc.0 declaration by hand, and then copying out to other 4.13 prereleases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13' | jq -r '.nodes[].version' | grep '^4[.]13[.]' | grep -v '^4[.]13[.]0-rc[.]0$' | while read V; do sed "s/4[.]13[.]0-rc[.]0/${V}/g" blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml > "blocked-edges/${V}-StrictPodSecurityViolation.yaml"; done
```