### PR TITLE
blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag: Fixed in 4.12.9

### DIFF
--- a/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -2,6 +2,7 @@ to: 4.12.8
 from: 4[.]11[.].*
 url: https://issues.redhat.com/browse/MCO-540
 name: OldBootImagesPodmanMissingAuthFlag
+fixedIn: 4.12.9
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:


### PR DESCRIPTION
[4.12.9][1] includes [OCPBUGS-10505](https://issues.redhat.com/browse/OCPBUGS-10505).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.12.9