### PR TITLE
blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag: Fixed in 4.12.9

### DIFF
--- a/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -2,6 +2,7 @@ to: 4.12.7
 from: 4[.]11[.].*
 url: https://issues.redhat.com/browse/MCO-540
 name: OldBootImagesPodmanMissingAuthFlag
+fixedIn: 4.12.9
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:


### PR DESCRIPTION
We carry the `fixedIn` in the 4.12.8 file already since https://github.com/openshift/cincinnati-graph-data/pull/3313, but 4.12.8 is not in stable yet:

```
Recommend waiting to promote 4.12.8 to stable; it was promoted the feeder fast by 480ee3c1d7 (Merge pull request #3296 from openshift-ota-bot/promote-4.12.8-to-fast, 2023-03-21, 5 days, 17:05:39.155584)
```

So the stabilization bot considers 4.12.9 for stable and errors out because the version with `fixedIn` is not in the same channel yet:

```
FAILED OldBootImagesPodmanMissingAuthFlag affects 4.12.7.  Either declare a fix version or extend the risk to 4.12.9.
```
