### PR TITLE
SPLAT-984: blocked-edges/4.13.0-*: Declare `NutanixCCMNeedsConfigMap`

### DIFF
--- a/blocked-edges/4.13.0-ec.1-NutanixCCMNeedsConfigMap.yaml
+++ b/blocked-edges/4.13.0-ec.1-NutanixCCMNeedsConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.13.0-ec.1
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/SPLAT-984
+name: NutanixCCMNeedsConfigMap
+message: |-
+  Cloud Controller Manager needs a ConfigMap with user-provided information on Nutanix in OCP 4.13 and upgrades hang when it does not exist.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(absent(kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"}),  "has_cm", "no", "", "")
+        or
+        label_replace(0 * kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"},  "has_cm", "yes", "", "")
+      )
+      * on () group_left(type)
+      (
+        cluster_infrastructure_provider{type=~"Nutanix"}
+        or
+        0  * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.13.0-ec.2-NutanixCCMNeedsConfigMap.yaml
+++ b/blocked-edges/4.13.0-ec.2-NutanixCCMNeedsConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.13.0-ec.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/SPLAT-984
+name: NutanixCCMNeedsConfigMap
+message: |-
+  Cloud Controller Manager needs a ConfigMap with user-provided information on Nutanix in OCP 4.13 and upgrades hang when it does not exist.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(absent(kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"}),  "has_cm", "no", "", "")
+        or
+        label_replace(0 * kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"},  "has_cm", "yes", "", "")
+      )
+      * on () group_left(type)
+      (
+        cluster_infrastructure_provider{type=~"Nutanix"}
+        or
+        0  * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.13.0-ec.3-NutanixCCMNeedsConfigMap.yaml
+++ b/blocked-edges/4.13.0-ec.3-NutanixCCMNeedsConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.13.0-ec.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/SPLAT-984
+name: NutanixCCMNeedsConfigMap
+message: |-
+  Cloud Controller Manager needs a ConfigMap with user-provided information on Nutanix in OCP 4.13 and upgrades hang when it does not exist.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(absent(kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"}),  "has_cm", "no", "", "")
+        or
+        label_replace(0 * kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"},  "has_cm", "yes", "", "")
+      )
+      * on () group_left(type)
+      (
+        cluster_infrastructure_provider{type=~"Nutanix"}
+        or
+        0  * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.13.0-ec.4-NutanixCCMNeedsConfigMap.yaml
+++ b/blocked-edges/4.13.0-ec.4-NutanixCCMNeedsConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.13.0-ec.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/SPLAT-984
+name: NutanixCCMNeedsConfigMap
+message: |-
+  Cloud Controller Manager needs a ConfigMap with user-provided information on Nutanix in OCP 4.13 and upgrades hang when it does not exist.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(absent(kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"}),  "has_cm", "no", "", "")
+        or
+        label_replace(0 * kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"},  "has_cm", "yes", "", "")
+      )
+      * on () group_left(type)
+      (
+        cluster_infrastructure_provider{type=~"Nutanix"}
+        or
+        0  * cluster_infrastructure_provider
+      )

--- a/blocked-edges/4.13.0-rc.0-NutanixCCMNeedsConfigMap.yaml
+++ b/blocked-edges/4.13.0-rc.0-NutanixCCMNeedsConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.13.0-rc.0
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/SPLAT-984
+name: NutanixCCMNeedsConfigMap
+message: |-
+  Cloud Controller Manager needs a ConfigMap with user-provided information on Nutanix in OCP 4.13 and upgrades hang when it does not exist.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(absent(kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"}),  "has_cm", "no", "", "")
+        or
+        label_replace(0 * kube_configmap_info{namespace="openshift-cloud-controller-manager", configmap="cloud-conf"},  "has_cm", "yes", "", "")
+      )
+      * on () group_left(type)
+      (
+        cluster_infrastructure_provider{type=~"Nutanix"}
+        or
+        0  * cluster_infrastructure_provider
+      )


### PR DESCRIPTION
Generated by writing the rc.0 declaration by hand, and then copying out to other 4.13 prereleases with:

```
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13' | \
    jq -r '.nodes[].version' | \
    grep '^4[.]13[.]' | \
    grep -v '^4[.]13[.]0-rc[.]0$' | while read V;
        do sed "s/4[.]13[.]0-rc[.]0/${V}/g" 4.13.0-rc.0-NutanixCCMNeedsConfigMap.yaml  > "${V}-NutanixCCMNeedsConfigMap.yaml";
    done
```

I am not sure how we eventually limit this, though. This will be resolved by 4.12 having an `Upgradeable=false` in some version (until the user provides the CM). We would bump the minimum version in 4.12 to have this fix, but we would still need to carry the conditional risk for all future 4.13 versions? Because this will never have a `fixedIn` version in 4.13. Not sure.
