### PR TITLE
blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation: Fixed in 4.13.0-rc.2

### DIFF
--- a/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
@@ -2,6 +2,7 @@ to: 4.13.0-rc.0
 from: 4[.]12[.].*
 url: https://issues.redhat.com/browse/AUTH-351
 name: StrictPodSecurityViolation
+fixedIn: 4.13.0-rc.2
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:


### PR DESCRIPTION
rc.2 is the next release after rc.0; not sure why we burned rc.1, but it doesn't matter.  [OCPBUGS-8710](https://issues.redhat.com/browse/OCPBUGS-8710) is verified and [landed in rc.2][2].

[2]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.0-rc.2