### PR TITLE
blocked-edges: handle cluster_infrastructure_provider zero values

### DIFF
--- a/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -16,7 +16,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -16,7 +16,7 @@ matchingRules:
       )
       * on () group_left (type)
       (
-        cluster_infrastructure_provider{type=~"AWS|VSphere|None"}
+        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
         or
-        0 * cluster_infrastructure_provider
+        0 * group(cluster_infrastructure_provider)
       )

--- a/blocked-edges/4.7.4-vsphere-hw-17-cross-node-networking.yaml
+++ b/blocked-edges/4.7.4-vsphere-hw-17-cross-node-networking.yaml
@@ -7,6 +7,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      cluster_infrastructure_provider{type=~"VSphere|None"}
+      group(cluster_infrastructure_provider{type=~"VSphere|None"})
       or
-      0 * cluster_infrastructure_provider
+      0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.7.4-zz-vsphere-hostnames-changing.yaml
+++ b/blocked-edges/4.7.4-zz-vsphere-hostnames-changing.yaml
@@ -7,6 +7,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      cluster_infrastructure_provider{type=~"VSphere|None"}
+      group(cluster_infrastructure_provider{type=~"VSphere|None"})
       or
-      0 * cluster_infrastructure_provider
+      0 * group(cluster_infrastructure_provider)


### PR DESCRIPTION
The `cluster_infrastructure_provider` metric has a zero value when its
type is `None`, so in that case we need to check the metric's presence,
rather than value.

Change prepared with (fish shell, sorry):

```
$ sed -r -i -e 's|(cluster_infrastructure_provider\{.*None.*\})|group(\1)|g' blocked-edges/*.yaml
$ git add blocked-edges
$ for file in (git diff --name-only --staged)
      sed -r -i -e 's|0 \* cluster_infrastructure_provider|0 * group(cluster_infrastructure_provider)|g' $file
  end
```

I have tested the new `OldBootImagesPodmanMissingAuthFlag` PromQL on appci which is a matching AWS cluster, and it works. Hideshi tested the same change on a baremetal cluster (with `"type":"None"`) and it also worked for him.

/cc @wking @LalatenduMohanty