### PR TITLE
blocked-edges/4.11.36-PatchesOlderRelease: Explain intentional regressions vs. 4.11.35

### DIFF
--- a/blocked-edges/4.11.36-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.11.36-PatchesOlderRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.11.36
+from: 4[.]11[.]35
+url: https://access.redhat.com/solutions/7007136
+name: PatchesOlderRelease
+message: |-
+  4.11.36 patches 4.11.34 to fix https://issues.redhat.com/browse/OCPBUGS-11663 , which is an installer issue, and not and issue with running clusters.  A number of other changes had landed since 4.11.34 and were shipped in 4.11.35.  We expect those fixes to be useful, but they might also introduce regressions, and because they have not soaked for as long, we did not include them in 4.11.36.  But that means we know 4.11.36 has regressed on all of those bugs compared to 4.11.35, so we do not recommend updating 4.11.35 clusters to 4.11.36.  Later 4.11.z will include both 4.11.36's installer fix and 4.11.35's fixes, and be recommended update targets for 4.11.35.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Tested with a local tweak:

```console
$ git --no-pager log --oneline -1
0ec85ddf (HEAD -> 4.11.36-pins-4.11.34, wking/4.11.36-pins-4.11.34) blocked-edges/4.11.36-PatchesOlderRelease: Explain intentional regressions vs. 4.11.35
$ git --no-pager diff -U1
diff --git a/channels/candidate-4.11.yaml b/channels/candidate-4.11.yaml
index 95b47d3a..f8289ad7 100644
--- a/channels/candidate-4.11.yaml
+++ b/channels/candidate-4.11.yaml
@@ -116 +116,2 @@ versions:
 - 4.11.35
+- 4.11.36
$ hack/show-edges.py --root-version 4.11.34 candidate-4.11
4.11.34 -> 4.11.35
4.11.34 -> 4.11.36
4.11.35 -(blocked: PatchesOlderRelease)-> 4.11.36
```

So it should do what we want once [4.11.36][1] makes its way to `candidate-4.11` for real.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.11.36?from=4.11.34