### PR TITLE
blocked-edges/4.12.12-PatchesOlderRelease: Explain intentional regressions vs. 4.12.11

### DIFF
--- a/blocked-edges/4.12.12-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.12.12-PatchesOlderRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.12.12
+from: 4[.](11[.]35|12[.]11)
+url: https://access.redhat.com/solutions/7007136
+name: PatchesOlderRelease
+message: |-
+  4.12.12 patches 4.12.10 to fix https://issues.redhat.com//browse/OCPBUGS-11662 , which is an installer issue, and not and issue with running clusters.  A number of other changes had landed since 4.12.10 and were shipped in 4.12.11.  We expect those fixes to be useful, but they might also introduce regressions, and because they have not soaked for as long, we did not include them in 4.12.12.  But that means we know 4.12.12 has regressed on all of those bugs compared to 4.12.10, and possibly also its weekly sibling 4.11.25, so we do not recommend updating 4.11.35 or 4.12.11 clusters to 4.12.12.  Later 4.12.z will include both 4.12.12's installer fix and 4.12.11's fixes, and be recommended update targets for 4.11.35 and 4.12.11.
+matchingRules:
+- type: Always


### PR DESCRIPTION
And also 4.11.35, which was built the same week as 4.12.11 and has a newer RHCOS ([411.86.202304042133-0][1]) and possibly other components compared to 4.12.10 and its almost-clone 4.12.12
([412.86.202303241612-0][2]).

Testing with both #3447 and this change and a local patch extending `candidate-4.12`:

```console
$ git --no-pager diff -U1
diff --git a/channels/candidate-4.12.yaml b/channels/candidate-4.12.yaml
index c2f5e6cd..c97923ea 100644
--- a/channels/candidate-4.12.yaml
+++ b/channels/candidate-4.12.yaml
@@ -72 +72,3 @@ versions:
 - 4.12.11
+- 4.11.36
+- 4.12.12
```

Checking for the effect we want:

```console
$ hack/show-edges.py --root-version 4.11.34 candidate-4.12
WARNING: walked all tag pages, but did not find releases for: 4.12.12
4.11.34 -> 4.11.35
4.11.34 -> 4.11.36
4.11.34 -> 4.12.10
4.11.34 -> 4.12.11
4.11.35 -(blocked: PatchesOlderRelease)-> 4.11.36
4.11.35 -> 4.12.11
4.12.10 -> 4.12.11
```

I'll try again after the release hits Quay and [the release controller][3].

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.11.35
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.10
[3]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.12