### PR TITLE
PatchesOlderRelease: simplify and strengthen the non-recommendation message

### DIFF
--- a/blocked-edges/4.11.36-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.11.36-PatchesOlderRelease.yaml
@@ -4,6 +4,6 @@ fixedIn: 4.11.37
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease
 message: |-
-  4.11.36 patches 4.11.34 to fix https://issues.redhat.com/browse/OCPBUGS-11663 , which is an installer issue, and not and issue with running clusters.  A number of other changes had landed since 4.11.34 and were shipped in 4.11.35.  We expect those fixes to be useful, but they might also introduce regressions, and because they have not soaked for as long, we did not include them in 4.11.36.  But that means we know 4.11.36 has regressed on all of those bugs compared to 4.11.35, so we do not recommend updating 4.11.35 clusters to 4.11.36.  Later 4.11.z will include both 4.11.36's installer fix and 4.11.35's fixes, and be recommended update targets for 4.11.35.
+  The 4.11.36 release only resolves an installation issue https://issues.redhat.com//browse/OCPBUGS-11663 , which does not affect already running clusters. 4.11.36 does not include fixes delivered in recent 4.11.z releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to 4.11.36 version for this reason.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.12.12-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.12.12-PatchesOlderRelease.yaml
@@ -4,6 +4,6 @@ fixedIn: 4.12.13
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease
 message: |-
-  4.12.12 patches 4.12.10 to fix https://issues.redhat.com//browse/OCPBUGS-11662 , which is an installer issue, and not and issue with running clusters.  A number of other changes had landed since 4.12.10 and were shipped in 4.12.11.  We expect those fixes to be useful, but they might also introduce regressions, and because they have not soaked for as long, we did not include them in 4.12.12.  But that means we know 4.12.12 has regressed on all of those bugs compared to 4.12.10, and possibly also its weekly sibling 4.11.25, so we do not recommend updating 4.11.35 or 4.12.11 clusters to 4.12.12.  Later 4.12.z will include both 4.12.12's installer fix and 4.12.11's fixes, and be recommended update targets for 4.11.35 and 4.12.11.
+  The 4.12.12 release only resolves an installation issue https://issues.redhat.com//browse/OCPBUGS-11662 , which does not affect already running clusters. 4.12.12 does not include fixes delivered in recent 4.11.z and 4.12.z releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to 4.12.12 version for this reason.
 matchingRules:
 - type: Always


### PR DESCRIPTION
I proposed this change in the original PR but we needed to expedite the blocked edge. I think the detailed messaging is actually not that useful for people, and maybe we do not need to stress out that RH fixes can in theory introduce regressions. I also think that the commitment to eventually deliver a union of all fixes is kinda implicit and we do not need to include it, it just dillutes the 'pls dont upgrade to these versions' core message.
