### PR TITLE
Require 4.13.0-rc.3 to get to latest builds

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -2,6 +2,6 @@ default:
   minor_min: 4.12.9
   minor_max: 4.12.9999
   minor_block_list: []
-  z_min: 4.13.0-ec.0
+  z_min: 4.13.0-rc.3
   z_max: 4.13.9999
   z_block_list: []


### PR DESCRIPTION
This avoids all the turbulence around 8.6 based EC builds