### PR TITLE
Stall updates into stable channel

### DIFF
--- a/channels/eus-4.12.yaml
+++ b/channels/eus-4.12.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P1W
   filter: 4[.](10|11|12)[.][0-9].*
   name: stable
 name: eus-4.12

--- a/channels/stable-4.11.yaml
+++ b/channels/stable-4.11.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P1W
   filter: 4[.](10|11)[.][0-9].*
   name: stable
 name: stable-4.11

--- a/channels/stable-4.12.yaml
+++ b/channels/stable-4.12.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P1W
   filter: 4[.](11|12)[.][0-9].*
   name: stable
 name: stable-4.12


### PR DESCRIPTION
4.11.36 and 4.12.12 were built atop 4.11.34 and 4.12.10 respectively and
are older than 4.11.35 and 4.12.11 therefore we're not recommending updates
to those. These builds were produced to address install time only bugs and
as such there's no real value in getting them into the stable channel,
installers downloads pull from the latest available in customer portal.

Revert this next week and add 4.11.37 and 4.12.13 into stable channel at
the same time.