### PR TITLE
Bump minimum for minor upgrades into 4.13 to 4.12.14

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.9
+  minor_min: 4.12.14
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-rc.3


### PR DESCRIPTION
This ensures that preconditions for pre-upgrade validation added in https://issues.redhat.com/browse/OCPBUGS-7898 is present.