### PR TITLE
Expand PatchesOlderRelease to not recommend any updates

### DIFF
--- a/blocked-edges/4.11.36-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.11.36-PatchesOlderRelease.yaml
@@ -1,5 +1,5 @@
 to: 4.11.36
-from: 4[.]11[.]35
+from: .*
 fixedIn: 4.11.37
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease

--- a/blocked-edges/4.12.12-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.12.12-PatchesOlderRelease.yaml
@@ -1,5 +1,5 @@
 to: 4.12.12
-from: 4[.](11[.]35|12[.]11)
+from: .*
 fixedIn: 4.12.13
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease


### PR DESCRIPTION
4.11.36 and 4.12.12 only address an install time issue and as such
there's no real reason to upgrade to those versions. However, someone
running 4.11.0 may reasonable conclude that 4.11.36 or 4.12.12 are
better than 4.11.35 and 4.12.11, however they're not as they lack the
same set of fixes present in those versions. So lets stop recommending
any updates into these versions.

In retrospect we perhaps should've tried releasing these fixes as
4.11.34.1 and 4.12.10.1 or something. However I wasn't sure that would
work entirely up and down the stack.