### PR TITLE
OCPNODE-1619: Bump 4.13 `minor_min` to 4.12.15

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.14
+  minor_min: 4.12.15
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-rc.3


### PR DESCRIPTION
Avoid OCPBUGS-11409:

> The minimally viable upgrade path to 4.13 would have to be 4.12.15 or later.
