### PR TITLE
OPNET-296: blocked-edges/4.11.*: Declare KeepaliveDSkew

### DIFF
--- a/blocked-edges/4.11.0-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-fc.0-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-fc.0-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-fc.0
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-fc.3-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-fc.3-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-fc.3
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.0-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.0-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.0
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.1-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.1-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.1
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.2-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.2-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.2
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.3-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.3-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.3
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.4-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.4-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.4
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.5-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.5-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.5
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.6-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.6-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.6
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.0-rc.7-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.0-rc.7-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.0-rc.7
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.1-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.1-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.1
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.10-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.10-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.10
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.11-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.11-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.11
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.12-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.12-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.12
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.13-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.13-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.13
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.14-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.14-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.14
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.16-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.16-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.16
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.17-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.17-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.17
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.18-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.18-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.18
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.19-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.19-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.19
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.2-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.2-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.2
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.20-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.20-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.20
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.21-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.21-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.21
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.22-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.22-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.22
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.23-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.23-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.23
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.24-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.24-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.24
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.25-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.25-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.25
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.26-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.26-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.26
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.27-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.27-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.27
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.28-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.28-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.28
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.29-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.29-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.29
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.3-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.3-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.3
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.30-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.30-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.30
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.31-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.31-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.31
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.32-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.32-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.32
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.33-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.33-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.33
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.34-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.34-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.34
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.35-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.35-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.35
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.36-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.36-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.36
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.37-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.37-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.37
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.38-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.38-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.38
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.39-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.39-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.39
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.4-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.4-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.4
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.5-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.5-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.5
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.6-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.6-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.6
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.7-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.7-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.7
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.8-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.8-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.8
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )

--- a/blocked-edges/4.11.9-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.9-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.9
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )


### PR DESCRIPTION
Discussion in [OPNET-296](https://issues.redhat.com/browse/OPNET-296) has some details, but trying to unpack "all on-prem IPI except baremetal IPI" into specifics, [this template][2] is in an on-prem directory configuring keepalived, and it switches on `onPremPlatformAPIServerInternalIP` for enabled vs. disabled. `onPremPlatformAPIServerInternalIP` is true (enabling the keepalived configuration) for:

* BareMetal ([4.10][3] and [4.11][4])
* oVirt ([4.10][3] and [4.11][4])
* OpenStack ([4.10][3] and [4.11][4])
* VSphere ([4.10][3] and [4.11][4]),
* KubeVirt ([4.10][3], [dropped in 4.11][4] #3084)
* Nutanix ([new][7] [in 4.11][4] #2942).

Before 4.11, `ENABLE_UNICAST` [was conditional][8] on `onPremPlatformKeepalivedEnableUnicast`, but since 4.11, it has [always been `yes`][9].  The platforms that were unicast on 4.10's `onPremPlatformKeepalivedEnableUnicast` [were BareMetal and KubeVirt][10].

Putting this all together, AWS and other platforms that don't match the `onPremPlatformAPIServerInternalIP` logic aren't impacted, because they don't enable the keepalived configuration.  BareMetal is not impacted by 4.10-to-4.11 updates, because any to-unicast transition issues will already have been resolved by 4.10.  Remaining `onPremPlatformAPIServerInternalIP` platforms which occur in both 4.10 and 4.11 are interested, and I match them here.

Generated by writing the 4.11.0 declaration by hand, and then copying out to other 4.11 releases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.11' | jq -r '.nodes[].version' | grep '^4[.]11[.]' | grep -v '^4[.]11[.]0$' | while read V; do sed "s/4[.]11[.]0/${V}/g" blocked-edges/4.11.0-KeepalivedMulticastSkew.yaml > "blocked-edges/${V}-KeepalivedMulticastSkew.yaml"; done
$ git add blocked-edges/4.11.*KeepalivedMulticastSkew.yaml
```

[2]: https://github.com/openshift/machine-config-operator/blame/8fa0b7e8903226b3cfb76e6c6f49409cfc0dd0e7/templates/common/on-prem/files/keepalived.yaml#L2
[3]: https://github.com/openshift/machine-config-operator/blob/afb47c916680dd5870e48e5c9cf819f59e12ff4d/pkg/operator/render.go#L282-L294
[4]: https://github.com/openshift/machine-config-operator/blob/8fa0b7e8903226b3cfb76e6c6f49409cfc0dd0e7/pkg/operator/render.go#L282-L294
[7]: https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-nutanix
[8]: https://github.com/openshift/machine-config-operator/blob/afb47c916680dd5870e48e5c9cf819f59e12ff4d/templates/common/on-prem/files/keepalived.yaml#L155-L156
[9]: https://github.com/openshift/machine-config-operator/pull/3016/commits/84d0bae2835e13a1f251024c6c8d63bb5d28e2b0#diff-c4a27bc4c14847dd581f495e992f67cf49b430644e8f113aabfa879de076564dL156
[10]: https://github.com/openshift/machine-config-operator/blob/afb47c916680dd5870e48e5c9cf819f59e12ff4d/pkg/operator/render.go#L249-L250