### PR TITLE
build-suggestions/4.13: Raise minor_min to 4.12.16

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.12.15
+  minor_min: 4.12.16
   minor_max: 4.12.9999
   minor_block_list: []
   z_min: 4.13.0-rc.3


### PR DESCRIPTION
[4.12.16][1] includes [OCPBUGS-12159](https://issues.redhat.com//browse/OCPBUGS-12159).  Require clusters to pick up this fix before heading to supported 4.13 releases, so single-node OpenShift clusters will not hit an `Available=False` `node-tuning` ClusterOperator.  I'm fuzzy on the detailed mechanism, or whether other flavors besides single-node are exposed, but raising minor_min doesn't have much downside, so I don't think we need to bottom out specific exposure.

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.12.16