### PR TITLE
blocked-edges/4.10.38-node-creation-fails: Fix "exsiting" typo

### DIFF
--- a/blocked-edges/4.10.38-node-creation-fails.yaml
+++ b/blocked-edges/4.10.38-node-creation-fails.yaml
@@ -3,6 +3,6 @@ from: .*
 url: https://issues.redhat.com/browse/OCPBUGS-2628
 name: OpenStackNodeCreationFails
 message: |-
-  Adding new nodes to the exsiting cluster on OpenStack will fail.
+  Adding new nodes to the existing cluster on OpenStack will fail.
 matchingRules:
 - type: Always


### PR DESCRIPTION
The typo snuck in when the risk was declared in 825b543287 (#2661).