### PR TITLE
Retire some older conditional edges which required PromQL eval

### DIFF
--- a/blocked-edges/4.11.0-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.0-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-fc.0-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-fc.0-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-fc.0-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-fc.0 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.3-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-fc.3-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-fc.3-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-fc.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-fc.3-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-fc.3 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.0-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.0-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.0-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.0-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.0-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.0-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.0 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.1-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.1-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.1-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.1-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.1-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.1-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.1 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.2-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.2-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.2-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.2-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.2-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.2-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.2 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.3-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.3-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.3-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.3-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.3 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.4-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.4-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.4-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.4-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.4-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.4-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.4 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.5-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.5-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.5-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.5-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.5-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.5-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.5 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.6-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.6-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.6-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.6-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.6-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.6-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.6 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.7-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.0-rc.7-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.7-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.0-rc.7-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.0-rc.7-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.0-rc.7-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.0-rc.7 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.1-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.1-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.1-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.1-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.1-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.1-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.1 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.10-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.10-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.10-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.10-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.10-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.10-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.10 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.11-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.11-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.11-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.11-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.11-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.11-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.11 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.12-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.12-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.12-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.12-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.12-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.12-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.12 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.13-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.13-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.13-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.13-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.13-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.13-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.13 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.14-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.14-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.14-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.14-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.14-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.14-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.14 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.16-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.16-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.16-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.16-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.16-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.16-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.16 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.17-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.17-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.17-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.17-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.17-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.17-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.17 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.18-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.18-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.18-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.18-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.18-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.18-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.18 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.19-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.19-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.19-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.19-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.19-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.19-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.19 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.2-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.2-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.2-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.2-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.2-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.2-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.2 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.20-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.20-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.20-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.20-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.20-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.20-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.20 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.21-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.21-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.21-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.21-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.21-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.21-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.21 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.22-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.22-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.22-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.22-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.22-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.22-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.22 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.23-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.23-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.23-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.23-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.23-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.23-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.23 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.24-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.24-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.24-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.24-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.24-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.24-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.24 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.25-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.25-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.25-MachineConfigRenderingChurn.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.11.26
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.25-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.25-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.25 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.26-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.26-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.26-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.26-arm64-seccomp-error-524.yaml
@@ -6,9 +6,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.26 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.26-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.26-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.27-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.27-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.27-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.27-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.28-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.28-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.28-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.28-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.29-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.29-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.29-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.29-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.3-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.3-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.3-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.3-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.3-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.3-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.3 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.30-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.30-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.30-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.30-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.31-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.31-AWSOldBootImageLackAfterburn.yaml
@@ -6,17 +6,5 @@ fixedIn: 4.11.33
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.31-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.31-leaked-machineconfig.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.11.33
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.32-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.32-AWSOldBootImageLackAfterburn.yaml
@@ -6,17 +6,5 @@ fixedIn: 4.11.33
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.32-leaked-machineconfig.yaml
+++ b/blocked-edges/4.11.32-leaked-machineconfig.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.11.33
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.4-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.4-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.4-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.4-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.4-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.4-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.4 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.5-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.5-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.5-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.5-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.5-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.5-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.5 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.6-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.6-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.6-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.6-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.6-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.6-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.6 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.7-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.7-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.7-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.7-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.7-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.7-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.7 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.8-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.8-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.8-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.8-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.8-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.8-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.8 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.11.9-AWSOldBootImageLackAfterburn.yaml
+++ b/blocked-edges/4.11.9-AWSOldBootImageLackAfterburn.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImagesLackAfterburn
 message: |-
   4.1 AWS boot images are not compatible with some 4.11 and later, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.2 or later, or otherwise uses 4.2 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.11.9-MachineConfigRenderingChurn.yaml
+++ b/blocked-edges/4.11.9-MachineConfigRenderingChurn.yaml
@@ -5,9 +5,5 @@ name: MachineConfigRenderingChurn
 message: |-
   Clusters with KubletConfigs that do not set 'CSIMigrationOpenStack: true' should remain on 4.10 until they can update to a 4.11 that contains a fix.  Clusters that do not contain any KubeletConfigs are unlikely to be exposed.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource="kubeletconfigs.machineconfiguration.openshift.io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.11.9-arm64-seccomp-error-524.yaml
+++ b/blocked-edges/4.11.9-arm64-seccomp-error-524.yaml
@@ -5,9 +5,5 @@ name: ARM64SecCompError524
 message: |-
   4.11.9 arm64 nodes may expose container creation to seccomp error 524.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(max_over_time(kube_node_labels{label_beta_kubernetes_io_arch="arm64"}[1h]))
-      or
-      0 * group(max_over_time(kube_node_labels[1h]))
+- type: Always
+

--- a/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.0-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.0-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.0, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.1-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.1-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.1, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.2-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.2-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.2, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.3-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.3-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.3, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.4-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.4-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.4, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.5-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.5-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.5, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.6-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.6-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.6, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
@@ -5,17 +5,5 @@ name: AWSOldBootImages
 message: |-
   4.2 AWS boot images are not compatible with 4.12.0-rc.7, and machines created with them will fail to become nodes.  This risk does not apply if a cluster is not on AWS, was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1 or 4.2", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        cluster_infrastructure_provider{type="AWS"}
-        or
-        0 * cluster_infrastructure_provider
-      )
+- type: Always
+

--- a/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.0-rc.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.1-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.2-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.2-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.2-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.3-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.3-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.3-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.4-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.4-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.5-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.5-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.5-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.6-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -5,17 +5,5 @@ name: OldBootImagesPodmanMissingAuthFlag
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.6-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.6-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.7-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -6,17 +6,5 @@ fixedIn: 4.12.9
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.12.7-leaked-machineconfig.yaml
+++ b/blocked-edges/4.12.7-leaked-machineconfig.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.12.8
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
+++ b/blocked-edges/4.12.8-OldBootImagesPodmanMissingAuthFlag.yaml
@@ -6,17 +6,5 @@ fixedIn: 4.12.9
 message: |-
   OCP 4.12 started using --authfile flag with podman to perform in-place upgrade on nodes and it does not work with nodes installed with OCP 4.1 version. This risk does not apply if a cluster was installed with version 4.2 or later.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      topk(1,
-        label_replace(group(cluster_version{type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.1", "", "")
-        or
-        label_replace(0 * group(cluster_version{type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
-      )
-      * on () group_left (type)
-      (
-        group(cluster_infrastructure_provider{type=~"AWS|VSphere|None"})
-        or
-        0 * group(cluster_infrastructure_provider)
-      )
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.1-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.1-StrictPodSecurityViolation.yaml
@@ -5,9 +5,5 @@ name: StrictPodSecurityViolation
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
-      or
-      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.2-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.2-StrictPodSecurityViolation.yaml
@@ -5,9 +5,5 @@ name: StrictPodSecurityViolation
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
-      or
-      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.3-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.3-StrictPodSecurityViolation.yaml
@@ -5,9 +5,5 @@ name: StrictPodSecurityViolation
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
-      or
-      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.3-leaked-machineconfig.yaml
@@ -5,9 +5,5 @@ name: LeakedMachineConfigBlocksMCO
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.4-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-ec.4-StrictPodSecurityViolation.yaml
@@ -5,9 +5,5 @@ name: StrictPodSecurityViolation
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
-      or
-      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})
+- type: Always
+

--- a/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
+++ b/blocked-edges/4.13.0-ec.4-leaked-machineconfig.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.13.0-rc.0
 message: |-
   Machine Config Operator stalls when encountering orphaned KubeletConfig or ContainerRuntimeConfig resources.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(cluster:usage:resources:sum{resource=~"(containerruntimeconfigs|kubeletconfigs)[.]machineconfiguration[.]openshift[.]io"} > 0)
-      or
-      0 * group(cluster:usage:resources:sum)
+- type: Always
+

--- a/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
+++ b/blocked-edges/4.13.0-rc.0-StrictPodSecurityViolation.yaml
@@ -6,9 +6,5 @@ fixedIn: 4.13.0-rc.2
 message: |-
   OCP 4.13 prereleases attempted to enforce PodSecurityViolations, but ended up backing off.  Clusters with violating workloads should either fix their workloads, or avoid updating to 4.13 until that softening lands.
 matchingRules:
-- type: PromQL
-  promql:
-    promql:
-      group(ALERTS{alertname="PodSecurityViolation",alertstate="firing"})
-      or
-      0 * group(ALERTS{alertname="Watchdog",alertstate="firing"})
+- type: Always
+


### PR DESCRIPTION
This is to work around the series of bugs starting with [OCPBUGS-10514](https://issues.redhat.com/browse/OCPBUGS-10514) where it takes 10mins per unique outstanding `type: PromQL` risk to evaluate in versions prior to 4.12.9, 4.11.34, and 4.10.56. If we reduce the number of outstanding PromQL risks by converting them to Always risks when we've had superseding versions with fixes for those risks we can improve the user experience. FWIW, we've not fixed the throttling to warm in a decent time, we've only updated it so that it evaluates risks on the newest versions first under the assumption that the newest version will have the least conditional updates and we can begin offering updates to the best version as quickly as possible while other, older risks, are being evaluated.

All risks modified here have had fixes in superseding versions for no less than six weeks. This gets us back to one outstanding PromQL risk across all channels.

We've done this previously in https://github.com/openshift/cincinnati-graph-data/pull/2968
