### PR TITLE
blocked-edges/4.11.40-KeepalivedMulticastSkew: 4.11.40 doesn't fix this issue

### DIFF
--- a/blocked-edges/4.11.40-KeepalivedMulticastSkew.yaml
+++ b/blocked-edges/4.11.40-KeepalivedMulticastSkew.yaml
@@ -1,0 +1,21 @@
+to: 4.11.40
+from: 4[.]10[.].*
+url: https://access.redhat.com/solutions/7007826
+name: KeepalivedMulticastSkew
+message: |-
+  On OpenStack, oVirt, and vSphere infrastructure, updates to 4.11 can cause degraded cluster operators as a result of a multicast-to-unicast keepalived transition, until all nodes have updated to 4.11.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      max(
+        cluster_infrastructure_provider{type=~"OpenStack|oVirt|VSphere"}
+        or
+        0 * cluster_infrastructure_provider
+      )
+      *
+      (
+        group(topk by (node) (1, mcd_update_state{config!~"|rendered-master-.*"}))
+        or
+        0 * group(mcd_update_state)
+      )


### PR DESCRIPTION
[OCPBUGS-13405][1] (openshift/baremetal-runtimecfg#249) is open with a candidate fix for 4.12.z, but the fix needs to land in 4.11.z to help with 4.10-to-4.11 updates.

[1]: https://issues.redhat.com//browse/OCPBUGS-13405
