### PR TITLE
build-suggestions/4.13: Raise z_min to 4.13.0 (the GA release)

### DIFF
--- a/build-suggestions/4.13.yaml
+++ b/build-suggestions/4.13.yaml
@@ -2,6 +2,6 @@ default:
   minor_min: 4.12.16
   minor_max: 4.12.9999
   minor_block_list: []
-  z_min: 4.13.0-rc.3
+  z_min: 4.13.0
   z_max: 4.13.9999
   z_block_list: []


### PR DESCRIPTION
Raising the floor limits the number of update edges we test in CI to the ones that we actually support.  Similar to 7b5f37a767 (#3075) and 581c703404 (#2369).