### PR TITLE
stabilization-changes.py: code cleanups

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -60,7 +60,7 @@ def parse_iso8601_delay(delay):
 
 
 def sem_ver_less_than(a, b):
-    "Returns true if a is less than b, per https://semver.org/spec/v2.0.0.html#spec-item-11"
+    """Returns true if a is less than b, per https://semver.org/spec/v2.0.0.html#spec-item-11"""
     a_match = _SEM_VER_REGEXP.match(a)
     if not a_match:
         raise ValueError('invalid semantic version {!r}'.format(a_match))

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -230,7 +230,7 @@ def get_promotions(path):
     process = subprocess.run(['git', 'blame', '--first-parent', '--porcelain', path], check=True, capture_output=True, text=True)
     commits = {}
     lines = {}
-    for line in process.stdout.strip().split('\n'):
+    for i, line in enumerate(process.stdout.strip().split('\n')):
         match = _GIT_BLAME_COMMIT_REGEXP.match(line)
         if match:
             commit = match.group('hash')
@@ -248,7 +248,7 @@ def get_promotions(path):
             continue
         match = _GIT_BLAME_LINE_REGEXP.match(line)
         if not match:
-            raise ValueError('unrecognized blame output for {} (blame line {}): {}'.format(path, i, line))
+            raise ValueError('unrecognized blame output for {} (blame line {}): {}'.format(path, i+1, line))
         lines[match.group('value')] = commit
     promotions = {}
     for line, commit in lines.items():

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -201,7 +201,7 @@ def stabilize_release(version, channel, channel_path, delay, errata, feeder_name
                 channel_path=channel_path,
                 subject=subject,
                 body=body,
-		github_token=github_token,
+                github_token=github_token,
                 **kwargs)
         except Exception as error:
             _LOGGER.error('  failed to promote {} to {}: {}'.format(version, channel['name'], sanitize(error, github_token=github_token)))
@@ -608,7 +608,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--labels',
-	nargs='*',
+        nargs='*',
         help='Set these labels on newly created pull request.  For example: "--labels lgtm approved".',
     )
     parser.add_argument(
@@ -639,7 +639,7 @@ if __name__ == '__main__':
             upstream_github_repo=upstream_github_repo,
             push_github_repo=(args.push_github_repo or upstream_github_repo).strip(),
             github_token=args.github_token.strip() or None,
-	    labels=args.labels,
+            labels=args.labels,
             webhook=args.webhook.strip(),
             waiting_notifications=waiting_notifications,
             upstream_branch=upstream_branch,

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -70,19 +70,19 @@ def sem_ver_less_than(a, b):
     a_groups = a_match.groupdict()
     b_groups = b_match.groupdict()
 
-    if (int(a_groups['major']) < int(b_groups['major'])):
+    if int(a_groups['major']) < int(b_groups['major']):
         return True
-    if (int(a_groups['major']) > int(b_groups['major'])):
+    if int(a_groups['major']) > int(b_groups['major']):
         return False
 
-    if (int(a_groups['minor']) < int(b_groups['minor'])):
+    if int(a_groups['minor']) < int(b_groups['minor']):
         return True
-    if (int(a_groups['minor']) > int(b_groups['minor'])):
+    if int(a_groups['minor']) > int(b_groups['minor']):
         return False
 
-    if (int(a_groups['patch']) < int(b_groups['patch'])):
+    if int(a_groups['patch']) < int(b_groups['patch']):
         return True
-    if (int(a_groups['patch']) > int(b_groups['patch'])):
+    if int(a_groups['patch']) > int(b_groups['patch']):
         return False
 
     if a_groups['prerelease'] and not b_groups['prerelease']:

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -368,7 +368,7 @@ def get_concerns_about_updating_out(version, channel, cache=None):
         cincinnati_uris.append(cincinnati_uri)
         candidate_minor -= 1
 
-    reachable = set([version])
+    reachable = {version}
     while reachable:
         source = reachable.pop()
         targets = updates.get(source, set())

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -572,9 +572,8 @@ def get_remote(repo):
     return _REMOTE_CACHE[repo]
 
 
-if __name__ == '__main__':
+def main():
     import argparse
-
     parser = argparse.ArgumentParser(
         description='Check for stabilization changes as versions are promoted from feeder channels.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -649,3 +648,7 @@ if __name__ == '__main__':
             time.sleep(args.poll)
         else:
             break
+
+
+if __name__ == '__main__':
+    main()

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -501,7 +501,7 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
             raise ValueError('failed to load YAML from {}: {}'.format(channel_path, error))
     versions = set(data['versions'])
     if version in versions:
-        raise ValueError('version {} has already been promoted to {} in {}/{}'.format(version, channel_name, upstream_remote, upstream_branch))
+        raise ValueError('version {} has already been promoted to {} in upstream branch {}'.format(version, channel_name, upstream_branch))
     versions.add(version)
     data['versions'] = list(sorted(versions, key=semver_sort_key))
     with open(channel_path, 'w') as f:


### PR DESCRIPTION
I think this script is now "production" enough to be treated as production code, I'd like to start refactoring it slowly for readability, starting with code cleanups:

- stabilization-changes: fix mixed indentation
- stabilization-changes: populate line number for error output
- stabilization-changes: use set literals
- stabilization-changes: avoid setting some names only conditionally
- stabilization-changes: extract entrypoint to main() to avoid setting globals
- stabilization-changes: use triple quotes for docstrings
- stabilization-changes: remove unncessary parentheses
- stabilization-changes: avoid shadowing `error` names
