### PR TITLE
OCPCLOUD-2067: Set up `SpuriousCCMOUpgradeableCond` for 4.12.{14-17}

### DIFF
--- a/blocked-edges/4.12.14-SpuriousCCMOUpgradeableCond.yaml
+++ b/blocked-edges/4.12.14-SpuriousCCMOUpgradeableCond.yaml
@@ -1,0 +1,9 @@
+to: 4.12.14
+from: .*
+url: https://issues.redhat.com/browse/OCPCLOUD-2067
+name: SpuriousCCMOUpgradeableCond
+message: |-
+  Cloud Controller Manager Operator can falsely report a Upgradeable=False
+  condition that prevents the cluster from being upgraded to 4.13.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.12.15-SpuriousCCMOUpgradeableCond.yaml
+++ b/blocked-edges/4.12.15-SpuriousCCMOUpgradeableCond.yaml
@@ -1,0 +1,9 @@
+to: 4.12.15
+from: .*
+url: https://issues.redhat.com/browse/OCPCLOUD-2067
+name: SpuriousCCMOUpgradeableCond
+message: |-
+  Cloud Controller Manager Operator can falsely report a Upgradeable=False
+  condition that prevents the cluster from being upgraded to 4.13.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.12.16-SpuriousCCMOUpgradeableCond.yaml
+++ b/blocked-edges/4.12.16-SpuriousCCMOUpgradeableCond.yaml
@@ -1,0 +1,9 @@
+to: 4.12.16
+from: .*
+url: https://issues.redhat.com/browse/OCPCLOUD-2067
+name: SpuriousCCMOUpgradeableCond
+message: |-
+  Cloud Controller Manager Operator can falsely report a Upgradeable=False
+  condition that prevents the cluster from being upgraded to 4.13.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.12.17-SpuriousCCMOUpgradeableCond.yaml
+++ b/blocked-edges/4.12.17-SpuriousCCMOUpgradeableCond.yaml
@@ -1,0 +1,10 @@
+to: 4.12.17
+from: .*
+fixedIn: 4.12.18
+url: https://issues.redhat.com/browse/OCPCLOUD-2067
+name: SpuriousCCMOUpgradeableCond
+message: |-
+  Cloud Controller Manager Operator can falsely report a Upgradeable=False
+  condition that prevents the cluster from being upgraded to 4.13.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Based on Scott's analysis and Mike's information I propose setting up a conditional risk for the most affected versions to softly guide clusters to 4.12.18 which should have a significantly lower incidence rate.