### PR TITLE
hack/exposure-length: Add a script showing known-exposure length

### DIFF
--- a/hack/exposure-length.sh
+++ b/hack/exposure-length.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Risk declaration until fixed release declared.  Usage:
+#
+#  $ hack/exposure-length.sh [RISK_NAME ...]
+#
+# With no RISK_NAMEs, it will list the duration of all the fixedIn
+# risks.  With RISK_NAMEs, it will only list the duration of those
+# risks.  For example:
+#
+#  $ hack/exposure-length.sh KeepalivedMulticastSkew DualStackNeedsController
+
+calculate_exposure() {
+	RISK="$1"
+	RISK_DECLARED="$(git log -G "^name: ${RISK}\$" --first-parent --date=short --format='%ad' blocked-edges | tail -n1)"
+	FIX_PATH="$(grep -r40 "^name: ${RISK}\$" blocked-edges | sed -n 's/-fixedIn: .*//p' | head -n1)"
+	FIX_DECLARED="$(git log -G "^fixedIn: " --first-parent --date=short --format='%ad' "${FIX_PATH}" | tail -n1)"
+	RISK_DECLARED_SECONDS="$(date --date "${RISK_DECLARED}" '+%s')"
+	FIX_DECLARED_SECONDS="$(date --date "${FIX_DECLARED}" '+%s')"
+	DURATION_SECONDS=$((FIX_DECLARED_SECONDS - RISK_DECLARED_SECONDS))
+	DURATION_DAYS=$((DURATION_SECONDS / 86400))
+	printf '%s - %s (%s days): %s\n' "${RISK_DECLARED}" "${FIX_DECLARED}" "${DURATION_DAYS}" "${RISK}"
+}
+
+if test "$#" -eq 0
+then
+	RISKS="$(grep -h '^name: ' $(grep -rl fixedIn blocked-edges) | sort | uniq | sed 's/name: //')"
+	set -- ${RISKS}
+fi
+
+while test "$#" -gt 0
+do
+	RISK="$1"
+	shift
+	calculate_exposure "${RISK}"
+done


### PR DESCRIPTION
Timeline for an update-risk bug:

1. Releases named with vulnerable code.
2. Someone notices the issue.
3. Update risk declared.
4. Release with the fix named.
5. `fixedIn` added so that release can enter `candidate-*`.

The duration `T2 - T1` can be long, because many of these risks are rare corner cases.  `T3 - T2` can be short, or it can be long if it takes us some time to understand the severity of the issue.  This script measures `T5 - T3`, so we have a convenient handle on that phase.