### PR TITLE
OCPNODE-1705: blocked-edges/4.13.*-PerformanceProfilesCPUQuota: Declare new risk

### DIFF
--- a/blocked-edges/4.13.0-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-ec.1-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-ec.1-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.1
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-ec.2-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-ec.2-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-ec.3-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-ec.3-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-ec.4-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-ec.4-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.0-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.0-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.0
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.2-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.2-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.3-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.3-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.4-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.4-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.5-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.5-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.5
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.6-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.6-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.6
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.7-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.7-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.7
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.0-rc.8-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.0-rc.8-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.8
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.1-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.1-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.1
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.2-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.2-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.3-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.3-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.13.4-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.4-PerformanceProfilesCPUQuota.yaml
@@ -1,0 +1,13 @@
+to: 4.13.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPNODE-1705
+name: PerformanceProfilesCPUQuota
+message: |-
+  Pods may not execute properly because of CPU quota issues on clusters using PerformanceProfiles.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="performanceprofiles.performance.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))


### PR DESCRIPTION
The PromQL approach is similar to what we used in c641333f4a (#2552), except:

* I'm using the PerformanceProfiles resource.
* I'm using `apiserver_storage_objects` instead of `cluster:usage:resources:sum`, to cut out [one lossy layer of indirection][1].

Generated by writing the 4.13.0 declaration by hand, and then copying out to other 4.13 releases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13' | jq -r '.nodes[].version' | grep '^4[.]13[.]' | grep -v '^4[.]13[.]0$' | while read V; do sed "s/4[.]13[.]0/${V}/g" blocked-edges/4.13.0-PerformanceProfilesCPUQuota.yaml > "blocked-edges/${V}-PerformanceProfilesCPUQuota.yaml"; done
$ git add blocked-edges/4.13.*PerformanceProfilesCPUQuota.yaml
```

[1]: https://github.com/openshift/cluster-monitoring-operator/blob/70dd5c9a414448ace1d07090730510d5922b6b18/jsonnet/rules.libsonnet#L291-L292C20