### PR TITLE
SDN-4019: blocked-edges: Declare MultiNetworkAttachmentsWhereaboutsVersion for 4.12.18+ and 4.13

### DIFF
--- a/blocked-edges/4.12.18-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.18-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.18
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.12.19-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.19-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.19
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.12.20-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.20-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.20
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.12.21-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.21-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.21
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.12.22-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.22-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.22
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-ec.1-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-ec.1-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.1
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-ec.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-ec.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.2
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-ec.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-ec.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.3
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-ec.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-ec.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-ec.4
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.0-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.0-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.0
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.2
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.3
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.4
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.5-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.5-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.5
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.6-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.6-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.6
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.7-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.7-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.7
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.0-rc.8-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.0-rc.8-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.0-rc.8
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.1-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.1-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.1
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.2-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.2
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.3-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.3
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)

--- a/blocked-edges/4.13.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.13.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.13.4
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)


### PR DESCRIPTION
Generated by writing the 4.12.18 risk by hand, and copying it out with:

```console
$ for Z in 19 20 21 22; do sed "s/4[.]12[.]18/4.12.${Z}/g" blocked-edges/4.12.18-MultiNetworkAttachmentsWhereaboutsVersion.yaml > "blocked-edges/4.12.${Z}-MultiNetworkAttachmentsWhereaboutsVersion.yaml"; done
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13' | jq -r '.nodes[].version' | grep '^4[.]13[.]' | while read V; do sed "s/4[.]12[.]18/${V}/g" blocked-edges/4.12.18-MultiNetworkAttachmentsWhereaboutsVersion.yaml > "blocked-edges/${V}-MultiNetworkAttachmentsWhereaboutsVersion.yaml"; done
```