### PR TITLE
blocked-edges/4.12.23-MultiNetworkAttachmentsWhereaboutsVersion: 4.12.23 doesn't have the fix

### DIFF
--- a/blocked-edges/4.12.23-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.23-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.12.23
+from: .*
+url: https://issues.redhat.com/browse/SDN-4019
+name: MultiNetworkAttachmentsWhereaboutsVersion
+message: |-
+  Upgrade can get stuck on clusters that have multiple network attachments.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(network_attachment_definition_instances > 0)
+      or
+      0 * group(network_attachment_definition_instances)


### PR DESCRIPTION
[OCPBUGS-15588](https://issues.redhat.com/browse/OCPBUGS-15588) is still Assigned with the 4.12.z backport.  Generated by extending the 4.12 `sed` from a129a714b2 (#3794):

```console
$ Z=23; sed "s/4[.]12[.]18/4.12.${Z}/g" blocked-edges/4.12.18-MultiNetworkAttachmentsWhereaboutsVersion.yaml > "blocked-edges/4.12.${Z}-MultiNetworkAttachmentsWhereaboutsVersion.yaml"
```