### PR TITLE
`MultiNetworkAttachmentsWhereaboutsVersion`: extend 4.12 | fix in 4.13

### DIFF
--- a/blocked-edges/4.12.25-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.25-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,6 +1,5 @@
-to: 4.13.4
+to: 4.12.25
 from: .*
-fixedIn: 4.13.5
 url: https://issues.redhat.com/browse/SDN-4019
 name: MultiNetworkAttachmentsWhereaboutsVersion
 message: |-


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-15476 VERIFIED (4.13) and
  present in 4.13.5 (https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.13.5)
- https://issues.redhat.com/browse/OCPBUGS-15588 still in ON_QA (4.12)
