### PR TITLE
`PerformanceProfilesCPUQuota`: fixed in 4.13.5

### DIFF
--- a/blocked-edges/4.13.4-PerformanceProfilesCPUQuota.yaml
+++ b/blocked-edges/4.13.4-PerformanceProfilesCPUQuota.yaml
@@ -1,5 +1,6 @@
 to: 4.13.4
 from: 4[.]12[.].*
+fixedIn: 4.13.5
 url: https://issues.redhat.com/browse/OCPNODE-1705
 name: PerformanceProfilesCPUQuota
 message: |-


### PR DESCRIPTION
[4.13.5](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.13.5) has RHCOS [413.92.202307140015-0](https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/diff.html?arch=x86_64&first_release=413.92.202306141213-0&first_stream=prod%2Fstreams%2F4.13-9.2&second_release=413.92.202307140015-0&second_stream=prod%2Fstreams%2F4.13-9.2) which has `cri-o-0-1.26.3-11.rhaos4.13.git78941bf.el9-x86_64` and `git78941bf` is the merge of https://github.com/cri-o/cri-o/pull/7013 which is the fix for OCPBUGS-14021
