### PR TITLE
blocked-edges/4.12.25-MultiNetworkAttachmentsWhereaboutsVersion: Fixed in 4.12.26

### DIFF
--- a/blocked-edges/4.12.25-MultiNetworkAttachmentsWhereaboutsVersion.yaml
+++ b/blocked-edges/4.12.25-MultiNetworkAttachmentsWhereaboutsVersion.yaml
@@ -1,5 +1,6 @@
 to: 4.12.25
 from: .*
+fixedIn: 4.11.26
 url: https://access.redhat.com/solutions/7024726
 name: MultiNetworkAttachmentsWhereaboutsVersion
 message: |-


### PR DESCRIPTION
[4.12.26][1] includes a verified [OCPBUGS-15588][2].

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.12.26
[2]: https://issues.redhat.com/browse/OCPBUGS-15588