### PR TITLE
Bump 4.14 minor min version to 4.13.6

### DIFF
--- a/build-suggestions/4.14.yaml
+++ b/build-suggestions/4.14.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.13.0-rc.3
+  minor_min: 4.13.6
   minor_max: 4.13.9999
   minor_block_list: []
   z_min: 4.14.0-ec.0


### PR DESCRIPTION
- Following PR includes changes to save the cgroups context in the node config object https://github.com/openshift/machine-config-operator/pull/3793 
- OCP 4.14+ releases default the cgroups version to "v2" 
- The above changes help in restoring the cgroups context during the upgrade of the clusters 
- Hence, it is required for the clusters to upgrade to 4.13.6 before upgrading to 4.14