### PR TITLE
OTA-1004: build-suggestions/4.14: minor-min 4.13.7 for Kube-API removal ack

### DIFF
--- a/build-suggestions/4.14.yaml
+++ b/build-suggestions/4.14.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.13.6
+  minor_min: 4.13.7
   minor_max: 4.13.9999
   minor_block_list: []
   z_min: 4.14.0-ec.0


### PR DESCRIPTION
[4.13.7][1] contains [OCPBUGS-16613][2], openshift/cluster-version-operator#948.

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.7
[2]: https://issues.redhat.com/browse/OCPBUGS-16613