### PR TITLE
OTA-1179: OWNERS: Grant sre-approvers root approval status

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,3 +6,13 @@ aliases:
     - LalatenduMohanty
     - PratikMahajan
     - petr-muller
+  sre-approvers:
+    - bennerv
+    - cblecker
+    - dustman9000
+    - fahlmant
+    - jewzaam
+    - jharrington22
+    - NautiluX
+    - rogbas
+    - wanghaoran1988

--- a/README.md
+++ b/README.md
@@ -138,6 +138,39 @@ from: ^4\.1\.(18|20)[+].*$
 
 The `[+].*` portion absorbs [the architecture-suffix](#release-names) from the release name that consumers will use for comparisons.
 
+#### Risks for managed clusters
+
+If site reliability engineers want to declare a risk for managed clusters updating into a release:
+
+1. Pick an impacted target release for `to`, e.g. `4.13.4`.
+2. Build a regular expression for relevant source releases (which would pick up the risk by updating into `to`), e.g. `.*` for "all releases", for `from`.
+3. Find (or create) a URI documenting the risk, e.g. https://access.redhat.com/solutions/7024726 or similar KCS, for `url`.
+4. Create a PascalCaseSlug for the risk, e.g. `MultiNetworkAttachmentsWhereaboutsVersion` for `name`.
+5. Create a sentance or two summarizing the risk for `message`.
+
+And then create a file `blocked-edges/${TO}-${NAME}.yaml`, e.g. `blocked-edges/4.13.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml` with the following content:
+
+```yaml
+to: FIXME
+from: FIXME
+url: FIXME
+name: FIXME
+message: |-
+  FIXME
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      group(sre:telemetry:managed_labels{sre="true"})
+      or
+      0 * group(cluster_version)
+```
+
+to declare that risk only for managed clusters.
+See [here](blocked-edges/4.13.4-MultiNetworkAttachmentsWhereaboutsVersion.yaml) for an example where the values are filled in, although that is using different PromQL, and not the managed-cluster selecting PromQL from the above template.
+
+If the risk applies to multiple target releases, create multiple files with different `to`.
+
 ### Signatures
 
 Add release signatures under `signatures/{algorithm}/{digest}/signature-{number}` (1.2.0).

--- a/build-suggestions/OWNERS
+++ b/build-suggestions/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/channels/OWNERS
+++ b/channels/OWNERS
@@ -1,9 +1,0 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-# This file just uses aliases defined in OWNERS_ALIASES.
-
-approvers:
-  - cincinnati-graph-data-approvers
-reviewers:
-  - cincinnati-graph-data-approvers
-options:
-  no_parent_owners: true

--- a/channels/OWNERS
+++ b/channels/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/deploy/OWNERS
+++ b/deploy/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/graph-data.rs/OWNERS
+++ b/graph-data.rs/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/internal-channels/OWNERS
+++ b/internal-channels/OWNERS
@@ -1,9 +1,0 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-# This file just uses aliases defined in OWNERS_ALIASES.
-
-approvers:
-  - cincinnati-graph-data-approvers
-reviewers:
-  - cincinnati-graph-data-approvers
-options:
-  no_parent_owners: true

--- a/internal-channels/OWNERS
+++ b/internal-channels/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true

--- a/raw/OWNERS
+++ b/raw/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - cincinnati-graph-data-approvers
-  - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+options:
+  no_parent_owners: true


### PR DESCRIPTION
`cincinnati-graph-data-approvers` are not on-call, and update risks that impact the SRE-managed fleet may be discovered while no `cincinnati-graph-data-approvers` are available to declare them.  This pull request creates a new `sre-approvers` alias (populated with @openshift/openshift-team-sd-sre-team-leads) and grants root approval powers so they can:

* Update the `sre-approvers` alias in `OWNERS_ALIASES`, as described in 9982225f97.
* Manage update risks in `blocked-edges/`.
* Use `/override ...` comments in pull requests (which require root-directly approval powers) if needed to bypass any flaking CI and land emergency update risk declarations.

I'm not including `sre-approvers` as reviewers, because when `cincinnati-graph-data-approvers` are available, they'll handle review.  And when they are not available, `sre-approvers` will be driving an emergency response using internal communication channels, and will not need Prow/blunderbuss help in attracting reviewers.

I'm adding `OWNERS` to all the other child directories besides `blocked-edges`, because site reliability engineers will not need access to those locations.  By explicitly dropping them as approvers, Prow advice about relevant approvers will avoid pulling in SREs who are not interested in non-emergency repository activity.