### PR TITLE
blocked-edges/4.13.7-RHSB2023001: 4.13.8 has the final fixes

### DIFF
--- a/blocked-edges/4.13.7-RHSB2023001.yaml
+++ b/blocked-edges/4.13.7-RHSB2023001.yaml
@@ -1,0 +1,9 @@
+to: 4.13.7
+from: 4[.]12[.](2[3-9]|3[0-9]) # 4.12.23+
+fixedIn: 4.13.8
+url: https://issues.redhat.com/browse/OTA-1000
+name: RHSB2023001
+message: |-
+  OCP 4.12 clusters in FIPS mode where CVE-2023-3089 (see RHSB-2023-001) was remedied should not update to OCP 4.13 versions where CVE-2023-3089 is not yet fully resolved.
+matchingRules:
+- type: Always


### PR DESCRIPTION
[OCPBUGS-17163][1] [landed in 4.13.8][2], so 4.13.7 was also exposed to FIPS issues.  And with [1] in place, 4.13.8 has (as far as I'm aware) completed the pivot to FIPS libraries, so setting fixedIn 4.13.8.

[1]: https://issues.redhat.com/browse/OCPBUGS-17163
[2]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.8