### PR TITLE
blocked-edges/4.13.6-RHSB2023001: Declare fixedIn 4.13.8 here too

### DIFF
--- a/blocked-edges/4.13.6-RHSB2023001.yaml
+++ b/blocked-edges/4.13.6-RHSB2023001.yaml
@@ -1,5 +1,6 @@
 to: 4.13.6
 from: 4[.]12[.](2[3-9]|3[0-9]) # 4.12.23+
+fixedIn: 4.13.8
 url: https://issues.redhat.com/browse/OTA-1000
 name: RHSB2023001
 message: |-


### PR DESCRIPTION
I haven't dug too far in, but likely because 4.13.7 was tombstoned (cd37f29018, Tombstone 4.13.7, 2023-08-04, #3944), the stabilization script is currently complaining about not realizing when the issue was fixed:

```console
$ hack/stabilization-changes.py
...
ERROR:   failed to promote 4.13.8 to stable: RHSB2023001 affects 4.13.6.  Either declare a fix version or extend the risk to 4.13.8.
...
```

By also declaring fixedIn in the 4.13.6 risk file, we avoid that failure mode.