### PR TITLE
blocked-edges/4.13.*-PersistentVolumeDiskIDSymlinks: Convert to Always

### DIFF
--- a/blocked-edges/4.13.0-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-ec.1-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-ec.1-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-ec.2-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-ec.2-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-ec.3-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-ec.3-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-ec.4-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-ec.4-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.0-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.0-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.2-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.2-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.3-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.3-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.4-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.4-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.5-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.5-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.6-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.6-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.7-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.7-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.0-rc.8-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.0-rc.8-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.1-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.1-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.2-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.2-PersistentVolumeDiskIDSymlinks.yaml
@@ -5,9 +5,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always

--- a/blocked-edges/4.13.3-PersistentVolumeDiskIDSymlinks.yaml
+++ b/blocked-edges/4.13.3-PersistentVolumeDiskIDSymlinks.yaml
@@ -6,9 +6,4 @@ name: PersistentVolumeDiskIDSymlinks
 message: |-
   New PersistentVolumes are created bound to an invalid symlink instead of the correct one and thus fail once updated to 4.13.4 or later as the invalid symlink dispears.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(csv_succeeded{name=~"local-storage-operator[.].*"})
-      or
-      0 * group(csv_count)
+- type: Always


### PR DESCRIPTION
To mitigate [slow cache warming][1], like 99161903ac (#3590).  The `fixedIn` 4.13.4 entered `stable-4.13` back in June:

```console
$ git --no-pager blame channels/stable-4.13.yaml | grep ' 4[.]13[.]4$'
90eca13b2 (Automated Stabilization Robot 2023-06-29 08:03:38 +0000 40) - 4.13.4
```

so it's unlikely that there are all that many folks still interested in updating to it, instead of a more recent 4.13.z.  And anyone who is interested can still read the message and ticket, decide whether they're exposed, and update if they feel they aren't exposed (or if they feel they are exposed but can handle being bit).

Generated with:

```console
$ for X in blocked-edges/*PersistentVolumeDiskIDSymlinks*; do CONTENT="$(grep -B100 matchingRules: "${X}"; printf -- '- type: %s\n' Always)"; echo "${CONTENT}" > "${X}"; done
```

[1]: https://issues.redhat.com/browse/OTA-942