### PR TITLE
blocked-edges/4.13.9-AWSMintModeWithoutCredentials: Fixed in 4.13.10

### DIFF
--- a/blocked-edges/4.13.9-AWSMintModeWithoutCredentials.yaml
+++ b/blocked-edges/4.13.9-AWSMintModeWithoutCredentials.yaml
@@ -1,5 +1,6 @@
 to: 4.13.9
 from: 4[.]13[.].*
+fixedIn: 4.13.10
 url: https://issues.redhat.com/browse/NE-1376
 name: AWSMintModeWithoutCredentials
 message: |-


### PR DESCRIPTION
[4.13.10][1] includes [OCPBUGS-17733](https://issues.redhat.com/browse/OCPBUGS-17733).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.10