### PR TITLE
Use UBI9 in image builds

### DIFF
--- a/graph-data.rs/Dockerfile
+++ b/graph-data.rs/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest as builder
+FROM registry.access.redhat.com/ubi9/ubi:latest as builder
 
 WORKDIR /opt/app-root/src/
 COPY . .
@@ -10,7 +10,7 @@ RUN dnf update -y \
 RUN cargo test --manifest-path graph-data.rs/Cargo.toml \
     && cargo install --locked --path graph-data.rs
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ENV RUST_LOG=actix_web=error,dkregistry=error
 


### PR DESCRIPTION
UBI9 is likely to receive Rust version updates, reducing the friction with our dependency updates ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati-graph-data/4042/pull-ci-openshift-cincinnati-graph-data-master-images/1701283949705170944#1:build-log.txt%3A586))
