### PR TITLE
COS-2437: blocked-edges: set up `SeccompFilterErrno524` for 4.13.[0-9]

### DIFF
--- a/blocked-edges/4.13.0-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.0-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.0
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.1-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.1-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.1
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.2-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.2-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.2
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.3-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.3-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.3
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.4-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.4-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.4
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.5-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.5-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.5
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.6-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.6-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.6
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.7-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.7-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.7
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.8-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.8-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.8
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.13.9-SeccompFilterErrno524.yaml
+++ b/blocked-edges/4.13.9-SeccompFilterErrno524.yaml
@@ -1,0 +1,8 @@
+to: 4.13.9
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/COS-2437
+name: SeccompFilterErrno524
+message: |-
+  Pods scheduled to nodes running a RHCOS/kernel version with a known defect may fail to start with a CreateContainerError.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Created manually the `4.13.0` file and copied the rest with this fish snippet: 

```
$ for x in (seq 9)
      set z 4.13.$x;
      cp 4.13.0-SeccompFilterErrno524.yaml $z-SeccompFilterErrno524.yaml
      sed -i "s/4.13.0/4.13.$x/g" $z-SeccompFilterErrno524.yaml
  end
```