### PR TITLE
SDN-4160: blocked-edges: Declare OVNWebhookUserConflict for 4.14.0-rc.3, rc.4, and 4.15.0-ec.0

### DIFF
--- a/blocked-edges/4.14.0-rc.3-OVNWebhookUserConflict.yaml
+++ b/blocked-edges/4.14.0-rc.3-OVNWebhookUserConflict.yaml
@@ -1,0 +1,21 @@
+to: 4.14.0-rc.3
+from: .*
+url: https://issues.redhat.com/browse/SDN-4160
+name: OVNCrashOnMigratedDualStack
+message: Possible webhook user conflicts when updating standalone (not Hosted/HyperShift) OVN clusters out of the target release and into one with a fix for the https://issues.redhat.com/browse/OCPBUGS-20104 series.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      ) * on () group_left (invoker)
+      (
+        0 * group by (invoker) (cluster_installer{_id="",invoker="hypershift"})
+        or on ()
+        group by (invoker) (cluster_installer{_id=""})
+        or on ()
+        group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.0-rc.4-OVNWebhookUserConflict.yaml
+++ b/blocked-edges/4.14.0-rc.4-OVNWebhookUserConflict.yaml
@@ -1,0 +1,21 @@
+to: 4.14.0-rc.4
+from: .*
+url: https://issues.redhat.com/browse/SDN-4160
+name: OVNCrashOnMigratedDualStack
+message: Possible webhook user conflicts when updating standalone (not Hosted/HyperShift) OVN clusters out of the target release and into one with a fix for the https://issues.redhat.com/browse/OCPBUGS-20104 series.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      ) * on () group_left (invoker)
+      (
+        0 * group by (invoker) (cluster_installer{_id="",invoker="hypershift"})
+        or on ()
+        group by (invoker) (cluster_installer{_id=""})
+        or on ()
+        group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.15.0-ec.0-OVNWebhookUserConflict.yaml
+++ b/blocked-edges/4.15.0-ec.0-OVNWebhookUserConflict.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-ec.0
+from: .*
+url: https://issues.redhat.com/browse/SDN-4160
+name: OVNCrashOnMigratedDualStack
+message: Possible webhook user conflicts when updating standalone (not Hosted/HyperShift) OVN clusters out of the target release and into one with a fix for the https://issues.redhat.com/browse/OCPBUGS-20104 series.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      ) * on () group_left (invoker)
+      (
+        0 * group by (invoker) (cluster_installer{_id="",invoker="hypershift"})
+        or on ()
+        group by (invoker) (cluster_installer{_id=""})
+        or on ()
+        group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )


### PR DESCRIPTION
The risk is for updating out of the impacted releases to hypothetical future releases with the user change, e.g. from 4.14.0-rc.3 to 4.14.0. But we're warning on * -> 4.14.0-rc.3 (and similar) to help folks dodge the sticky updates entirely, because 4.14.0-rc.2 -> 4.14.0 are not expected to ever have running-as-root webhook listeners.

Pattern-matching `apiserver_storage_objects` from b573872208 (#3786) and `egressips.k8s.ovn.org` from 894fab7974 (#2628).

The risk is only for standalone (non-HyperShift) clusters, but we haven't worked up PromQL for "I'm (not) HyperShift" yet, and it's just prerelease versions, so I'm skipping over that detail for now and declaring the risk for all OVN clusters (standalone and HyperShift) thinking about updating into impacted releases.

Generated by manually writing the rc.e risk, and then copying it around with:

```console
$ for VERSION in 4.14.0-rc.4 4.15.0-ec.0; do sed "s/4.14.0-rc.3/${VERSION}/" blocked-edges/4.14.0-rc.3-OVNWebhookUserConflict.yaml > "blocked-edges/${VERSION}-OVNWebhookUserConflict.yaml"; done
```