### PR TITLE
OTA-1031: blocked-edges/4.14.0*: Declare ConsoleImplicitlyEnabled

### DIFF
--- a/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.2-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.2-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.2
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.3-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.3-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.3
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.4-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.4-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.4
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.5-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.5-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.5
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.6-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.6-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.6
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0-rc.7-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.7-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.0-rc.7
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.1-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.1-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,10 @@
+to: 4.14.1
+from: .*
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 - max(cluster_version_capability{name="Console"})


### PR DESCRIPTION
Generated by writing the rc.2 risk by hand, and then running:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]0-rc[.][3-9]' | while read VERSION; do sed "s/4.14.0-rc.2/${VERSION}/" blocked-edges/4.14.0-rc.2-ConsoleImplicitlyEnabled.yaml > "blocked-edges/${VERSION}-ConsoleImplicitlyEnabled.yaml"; done
```