### PR TITLE
build-suggestions/4.14: Bump minor_min to 4.13.17

### DIFF
--- a/build-suggestions/4.14.yaml
+++ b/build-suggestions/4.14.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.13.14
+  minor_min: 4.13.17
   minor_max: 4.13.9999
   minor_block_list: []
   z_min: 4.14.0-ec.0


### PR DESCRIPTION
To pick up [the DeploymentConfig perservation fix][1] which is [new in 4.13.17][2].  This also pull in [the update-risk cache-warming fix][3], which will be useful for quickly evaluating any 4.13-to-4.14 risks when folks on 4.13.z switch to fast-4.14 or other channels with updates to 4.14.z.

[1]: https://issues.redhat.com/browse/OCPBUGS-20321
[2]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.17
[3]: https://issues.redhat.com/browse/OCPBUGS-19828