### PR TITLE
blocked-edges/4.11.52-incompatible-python-update-breaking-baremetal-provisioning: Not fixed yet

### DIFF
--- a/blocked-edges/4.11.52-incomptiable-python-update-breaking-baremetal-provisioning.yaml
+++ b/blocked-edges/4.11.52-incomptiable-python-update-breaking-baremetal-provisioning.yaml
@@ -1,0 +1,12 @@
+to: 4.11.52
+from: .*
+url: https://issues.redhat.com/browse/METAL-739
+name: BrokenBaremetalProvisioning
+message: The target release fails to provision and de-provision new baremetal machines required for scaling of a cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{type="BareMetal"})
+      or
+      0 * group(cluster_infrastructure_provider)


### PR DESCRIPTION
[4.11.52][1] does not include a fix for [OCPBUGS-20486](https://issues.redhat.com/browse/OCPBUGS-20486).

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.11.52
