### PR TITLE
4.14: Bump `minor_min` to 4.13.19 to pickup the SCC gate

### DIFF
--- a/build-suggestions/4.14.yaml
+++ b/build-suggestions/4.14.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.13.17
+  minor_min: 4.13.19
   minor_max: 4.13.9999
   minor_block_list: []
   z_min: 4.14.0-ec.0


### PR DESCRIPTION
Yet-nonexistent 4.13.19 is likely to be the 4.13 patch release picking up https://github.com/openshift/cluster-version-operator/pull/969 which adds the `Upgradeable=False` gate when modified SCC resources are detected in the cluster. We will want everyone to go through the CVO with this change, to prevent workloads from breaking if they depend on modified system SCC resources.