### PR TITLE
blocked-edges/4.14.*-ConsoleImplicitlyEnabled: Tune from versions

### DIFF
--- a/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
-to: 4.14.0-rc.4
-from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
+to: 4.14.0
+from: 4[.](13[.]19|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.0-rc.2-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.2-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.0-rc.2
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.0-rc.3-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.3-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.0-rc.3
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.0-rc.5-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.5-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.0-rc.5
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.0-rc.6-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.6-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.0-rc.6
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.0-rc.7-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-rc.7-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.0-rc.7
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/blocked-edges/4.14.1-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.1-ConsoleImplicitlyEnabled.yaml
@@ -1,5 +1,5 @@
 to: 4.14.1
-from: .*
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
 url: https://issues.redhat.com/browse/OTA-1031
 name: ConsoleImplicitlyEnabled
 message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.

--- a/hack/show-edges.py
+++ b/hack/show-edges.py
@@ -342,8 +342,14 @@ def show_edges(channel, architecture, repository, revision=None, cache='.metadat
             continue
         key = (from_version, to_version)
         if key in blocked:
-            reasons = ', '.join(str(r) for r in sorted(blocked[key]))
-            print('{} -(risks: {})-> {}'.format(from_version, reasons, to_version))
+            if None not in blocked[key]:
+                reasons = ', '.join(sorted(blocked[key]))
+                print('{} -(risks: {})-> {}'.format(from_version, reasons, to_version))
+            elif len([name for name in blocked[key] if name != None]) > 0:
+                reasons = ', '.join(sorted([r or 'SILENT-BLOCK-CINCINNATI-WILL-IGNORE' for r in blocked[key]]))  # https://issues.redhat.com/browse/OTA-1043
+                print('{} -(risks: {})-> {}'.format(from_version, reasons, to_version))
+            else:  # None is the only entry
+                print('{} -(SILENT-BLOCK)-> {}'.format(from_version, to_version))
         else:
             print('{} -> {}'.format(from_version, to_version))
 


### PR DESCRIPTION
[The regression occured in 4.14.0-rc.2][1], so updates like 4.14.0 to 4.14.1 are not exposed.  The new regular expression covers:

* Updates from `4.14.0-ec.*`, since these predate the rc.2 regression.
* Updates from `4.14.0-rc.[01]`, since these predate the rc.2 regression.
* Updates from `4.13.*`, since these predate the 4.14 regression.

4.14.0 is coming back, after 897f57f57e
(#4326) had dropped it, with a special `from` regular expression that replaces the `4.13.*` with `4.13.19`, to avoid having 4.13.17 -> 4.14.0 and 4.13.18 -> 4.14.0 sneak back in, as discussed in 897f57f57e.  The history of the updates from 4.13 to 4.14.0 is now:

* f0dc7e86d1 (#4301) dropped 4.13.17 and 18 from 4.14.0 update sources completely, and merged 2023-10-27, before 4.14.0 entered `candidate-4.*` channels.
* 82ac96beb5 (#4234) landed 2023-10-30 via 6db078f5f5aa9, accidentally pulling updates from 4.13.17 and 18 back into channels because of how Cincinnati currently handles the overlap between:

    ```console
    $ hack/show-edges.py --revision 6db078f5f5aa9 candidate-4.14 | grep ' 4[.]14[.]0$'
    4.13.17 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # my patched show-edges doesn't include this, but Cincinnati will until https://issues.redhat.com/browse/OTA-1043 is fixed
    4.13.18 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # my patched show-edges doesn't include this, but Cincinnati will until https://issues.redhat.com/browse/OTA-1043 is fixed
    4.14.0-ec.0 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    ...
    4.14.0-rc.1 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-rc.2 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # not actually exposed, but 'from' wildcard wasn't precise at this point
    ...
    4.14.0-rc.7 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # not actually exposed, but 'from' wildcard wasn't precise at this point
    ```
    
* c3fc9f0ee0 (#4318) lands, and 4.13.19 to 4.14.0 has `ConsoleImplicitlyEnabled`, as intended:

    ```console
    $ hack/show-edges.py --revision c3fc9f0ee0 candidate-4.14 | grep '^4[.]13[.]19 .* 4[.]14[.]0$'
    4.13.19 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    ```

    But Cincinnati still has the:

    ```
    4.13.17 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.13.18 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    ```

    that we don't want.

* ba3396f36d (#4326) lands, removing the updates from 4.13.17 and 18 which 82ac96beb5 and [OTA-1043](https://issues.redhat.com/browse/OTA-1043) had added, but leaving `ConsoleImplicitlyEnabled` undeclared for 4.13.19 to 4.14.0:

    ```console
    $ hack/show-edges.py --revision ba3396f36d candidate-4.14 | grep '^4[.]13[.].* .* 4[.]14[.]0$'
    4.13.19 -> 4.14.0  # but this is exposed to ConsoleImplicitlyEnabled, although we no longer declare the risk
    ```

* This commit restores the `ConsoleImplicitlyEnabled` risk for 4.14.0, and the fancy `from` regular expressions get the whole thing the way we want it:

    ```console
    $ hack/show-edges.py candidate-4.14 | grep ' 4[.]14[.]0$'
    4.13.19 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # now declares ConsoleImplicitlyEnabled again, fixing ba3396f36d's issues
    4.14.0-ec.0 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0  # continues to declare ConsoleImplicitlyEnabled
    4.14.0-ec.1 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-ec.2 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-ec.3 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-ec.4 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-rc.0 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-rc.1 -(risks: ConsoleImplicitlyEnabled)-> 4.14.0
    4.14.0-rc.2 -> 4.14.0  # this and later no longer claim ConsoleImplicitlyEnabled exposure, because both the source and target release are in the impacted set, and those updates do not increase exposure
    4.14.0-rc.3 -> 4.14.0
    4.14.0-rc.4 -> 4.14.0
    4.14.0-rc.5 -> 4.14.0
    4.14.0-rc.6 -> 4.14.0
    4.14.0-rc.7 -> 4.14.0
    ```

[1]: https://issues.redhat.com/browse/OTA-1031