### PR TITLE
blocked-edges/4.11.52-incomptiable-python-update-breaking-baremetal-provisioning: Fixed in 4.11.53

### DIFF
--- a/blocked-edges/4.11.52-incomptiable-python-update-breaking-baremetal-provisioning.yaml
+++ b/blocked-edges/4.11.52-incomptiable-python-update-breaking-baremetal-provisioning.yaml
@@ -1,5 +1,6 @@
 to: 4.11.52
 from: .*
+fixedIn: 4.11.53
 url: https://issues.redhat.com/browse/METAL-739
 name: BrokenBaremetalProvisioning
 message: The target release fails to provision and de-provision new baremetal machines required for scaling of a cluster.


### PR DESCRIPTION
[4.11.53][1] includes [OCPBUGS-20486](https://issues.redhat.com/browse/OCPBUGS-20486).

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.11.53