### PR TITLE
SDN-4196: Set `OVNKubeMasterDNPrestop` on OVN clusters installed before 4.11

### DIFF
--- a/blocked-edges/4.12.41-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.12.41-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.12.41
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.12.42-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.12.42-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.12.42
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.12.43-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.12.43-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.12.43
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.16-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.16-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.16
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.17-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.17-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.17
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.18-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.18-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.18
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.19-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.19-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.19
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.21-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.21-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.21
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.22-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.22-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.22
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.0-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.14.0-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.14.0
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.1-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.14.1-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.14.1
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.2-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.14.2-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.14.2
+from: .*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )


### PR DESCRIPTION
Set up risk on updates to 4.12.41+, 4.13.16+ or 4.14+, on OVN clusters
installed before 4.10.

> clusters that have upgraded from 4.10->4.11 will be vulnerable and
> will be affected by this issue when/if they eventually upgrade to
> 4.12.41+, 4.13.16+ or 4.14+
> ...
> - clusters using the OVNKubernetes CNI and that have previously been upgraded from 4.10
>   to 4.11
> - clusters that were initially installed with 4.11 or newer are not affected.

I created the 4.12.41 file manually and copied it around:

```
$ for ocp12 in (seq 42 43)
    sed -e "s/4.12.41/4.12.$ocp12/" blocked-edges/4.12.41-OVNKubeMasterDSPrestop.yaml > blocked-edges/4.12.$ocp12-OVNKubeMasterDSPrestop.yaml
  end
$ for ocp13 in (seq 16 22)
    sed -e "s/4.12.41/4.13.$ocp13/" blocked-edges/4.12.41-OVNKubeMasterDSPrestop.yaml > blocked-edges/4.13.$ocp13-OVNKubeMasterDSPrestop.yaml
  end
$ for ocp14 in (seq 0 2)
    sed -e "s/4.12.41/4.14.$ocp14/" blocked-edges/4.12.41-OVNKubeMasterDSPrestop.yaml > blocked-edges/4.14.$ocp14-OVNKubeMasterDSPrestop.yaml
  end
```