### PR TITLE
OTA-874: hack/release-ga: Set minor_min in build-suggestions/4.(y+1).yaml

### DIFF
--- a/hack/release-ga.sh
+++ b/hack/release-ga.sh
@@ -91,3 +91,4 @@ git restore --staged .
 LATEST=$(python -c "import sys, yaml; data = yaml.safe_load(sys.stdin); print(data['versions'][0])" < "channels/stable-${MAJOR_MINOR}.yaml")
 # Use sed instead of doing this in python above to avoid clobbering the nice semantic ordering
 sed -i -e "s|z_min: .*|z_min: ${LATEST}|" "build-suggestions/${MAJOR_MINOR}.yaml"
+sed -i -e "s|minor_min: .*|minor_min: ${LATEST}|" "build-suggestions/${MAJOR}.$((MINOR + 1)).yaml"


### PR DESCRIPTION
They don't need to have updates from the early prereleases once 4.y goes generally available, and a reduced update set makes it easier to spend our update-testing effort on edges that are more likely to have traffic on them.