### PR TITLE
build-suggestions/4.15: 4.14.4 floor for Kuryr removal guard

### DIFF
--- a/build-suggestions/4.15.yaml
+++ b/build-suggestions/4.15.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.14.0-rc.0
+  minor_min: 4.14.4
   minor_max: 4.14.9999
   minor_block_list: []
   z_min: 4.15.0-ec.0


### PR DESCRIPTION
[4.14.4][1] has [OCPBUGS-23011](https://issues.redhat.com/browse/OCPBUGS-23011), and we want folks to pick up that guard before they can launch a supported update to 4.15.

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.14.4