### PR TITLE
Add 4 days to the stable-4.11 channel delay

### DIFF
--- a/channels/stable-4.11.yaml
+++ b/channels/stable-4.11.yaml
@@ -1,5 +1,5 @@
 feeder:
-  delay: PT0H
+  delay: P4D
   filter: 4[.](10|11)[.][0-9].*
   name: stable
 name: stable-4.11


### PR DESCRIPTION
Currently, 4.11 and 4.12 are on an alternating weekly schedule. This means that 4.11.z will go in one week but won't have an update path to 4.12 for another roughly 7 days while the following 4.12 release cooks in fast channels. By delaying things for another 4 days we're splitting the difference and the maximum delay for those who aren't able to use channels directly, aka ROSA clusters.