### PR TITLE
Fix AROBrokenDNSMasq

### DIFF
--- a/blocked-edges/4.13.25-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.25-AROBrokenDNSMasq.yaml
@@ -9,13 +9,7 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )

--- a/blocked-edges/4.13.26-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.26-AROBrokenDNSMasq.yaml
@@ -9,13 +9,7 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )

--- a/blocked-edges/4.13.27-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.27-AROBrokenDNSMasq.yaml
@@ -1,9 +1,9 @@
-to: 4.14.3
+to: 4.13.27
 from: .*
 url: https://issues.redhat.com/browse/MCO-958
 name: AROBrokenDNSMasq
 message: |-
-  Adding a new worker node will fail for clusters running on ARO
+  Adding a new worker node will fail for clusters running on ARO.
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.14.2-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.2-AROBrokenDNSMasq.yaml
@@ -9,13 +9,7 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )

--- a/blocked-edges/4.14.4-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.4-AROBrokenDNSMasq.yaml
@@ -9,13 +9,7 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )

--- a/blocked-edges/4.14.5-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.5-AROBrokenDNSMasq.yaml
@@ -9,14 +9,8 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )
 

--- a/blocked-edges/4.14.6-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.6-AROBrokenDNSMasq.yaml
@@ -9,13 +9,7 @@ matchingRules:
   promql:
     promql: |
       (
-        group by (name) (cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{name="aro"})
         or
-        0 * group by (name) (cluster_operator_conditions)
-      )
-      * on () group_left (type)
-      (
-        group by (type) (cluster_infrastructure_provider{type="Azure"})
-        or
-        0 * group by (type) (cluster_infrastructure_provider)
+        0 * group(cluster_operator_conditions)
       )

--- a/blocked-edges/4.14.7-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.7-AROBrokenDNSMasq.yaml
@@ -1,9 +1,9 @@
-to: 4.14.3
+to: 4.14.7
 from: .*
 url: https://issues.redhat.com/browse/MCO-958
 name: AROBrokenDNSMasq
 message: |-
-  Adding a new worker node will fail for clusters running on ARO
+  Adding a new worker node will fail for clusters running on ARO.
 matchingRules:
 - type: PromQL
   promql:


### PR DESCRIPTION
On non ARO clusters the query was emitting multiple zero values. Also the ARO operator will only exist on ARO clusters so no need to pay attention to whether or not the cluster is on Azure.

Also extend to 4.13.27 and 4.14.7