### PR TITLE
OCPCLOUD-2409: blocked-edges/4.14*: Declare AzureDefaultVMType

### DIFF
--- a/blocked-edges/4.14.0-ec.0-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.0-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-ec.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.1-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-ec.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.2-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-ec.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.3-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-ec.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.4-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-ec.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.0-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.0-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.1-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.2-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.3-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.4-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.5-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.5-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.6-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.6-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.7-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.7-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0-rc.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0.yaml
+++ b/blocked-edges/4.14.0.yaml
@@ -1,4 +1,5 @@
 to: 4.14.0
-from: 4[.]13[.]1[78]
+from: 4[.]13[.]1[789]
 fixedIn: 4.14.1
 # We want folks to pick up 4.13.19's https://issues.redhat.com/browse/OCPBUGS-19472 to avoid being surprised by SecurityContextConstraint stomping
+# Also AzureDefaultVMType, but we cannot declare that as a conditional risk from 4.13.19 to 4.14.0 because of https://issues.redhat.com/browse/OTA-1043

--- a/blocked-edges/4.14.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.1-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.2-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.3-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.4-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.5-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.5-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.6-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.6-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.7-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.7-AzureDefaultVMType.yaml
@@ -1,0 +1,20 @@
+to: 4.14.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )


### PR DESCRIPTION
Generated by writing the 4.14.1 risk by hand, and then running:

```console
$ (curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]' | grep -v '^4[.]14[.][01]$') | while read VERSION; do sed "s/4.14.1/${VERSION}/" blocked-edges/4.14.1-AzureDefaultVMType.yaml > "blocked-edges/${VERSION}-AzureDefaultVMType.yaml"; done
```

I also manually added the silent-drop to 4.14.0.  We have almost entirely avoided silent drops since growing the ability to declare conditional risks in 4.10.  But f0dc7e86d1 (#4301) decided to use silent drops for 4.13.17 and 4.13.18 to 4.14.0.  As described in that commit message, there are trade-offs between silent-drops and an Always risk for those updates.  With this commit, we double-down on the silent-drop approach.

Because we're dropping 4.13.19 to 4.14.0 after it has been a supported update for so long, there is a larger risk (than there was for 4.13.17 and 4.13.18 updates) of customers noticing the drop and being confused about where the 4.13.19 to 4.14.0 update went.  That's why we developed the conditional update system in the first place.

That risk is mitigated by the fact that 4.14.0 is fairly old by now, with many subsequent 4.14.z that fix a number of other issues.  So we do not expect there to be much residual interest in 4.13.19 to 4.14.0 updates.

If it turns out that there is enough "where did 4.13.19 to 4.14.0 go?" support load to warrant a pivot, future work could move us to explicitly-declared risk for all of the issues from 4.13.z to 4.14.0, including the original "4.13.19 adds a guard you want first" that f0dc7e86d1 was delivering.  But the price of that pivot is the:

> A silent drop may mean we do not need to support customers who update from 4.13.17 or 18 directly to 4.14.0 and have some mutated SCCs stomped...

trade-off discussed in f0dc7e86d1.