### PR TITLE
OCPCLOUD-2409: blocked-edges/*-AzureDefaultVMType: Born in 4.13 ARO all exposed

### DIFF
--- a/blocked-edges/4.14.0-ec.0-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.0-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-ec.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.1-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-ec.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.2-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-ec.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.3-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-ec.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-ec.4-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.0-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.0-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.1-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.2-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.3-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.4-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.5-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.5-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.6-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.6-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.0-rc.7-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-rc.7-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.1-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.1-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.2-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.2-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.3-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.3-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.4-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.4-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.5-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.5-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.6-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.6-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,

--- a/blocked-edges/4.14.7-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.7-AzureDefaultVMType.yaml
@@ -8,9 +8,17 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
-        label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
       )
       * on () group_left (type)
       topk(1,


### PR DESCRIPTION
Miguel points out that the exposure set [is more complicated][1] than what I'd done in 45eb9ea7c8 (#4541).  It's:

* Azure born in 4.8 or earlier are exposed.  Both ARO (which creates clusters with Hive?) and clusters created via openshift-installer.
* ARO clusters created in 4.13 and earlier are exposed.

Generated by updating the 4.14.1 risk by hand, and then running:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]' | grep -v '^4[.]14[.][01]$' | while read VERSION; do sed "s/4.14.1/${VERSION}/" blocked-edges/4.14.1-AzureDefaultVMType.yaml > "blocked-edges/${VERSION}-AzureDefaultVMType.yaml"; done
```

I break down the new PromQL logic in the commit message.

[1]: https://issues.redhat.com/browse/OCPCLOUD-2409?focusedId=23694976&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-23694976