### PR TITLE
Carry AROBrokenDNSMasq, OVNKubeMasteRDSPrsetop, and AzureDefaultVMType

### DIFF
--- a/blocked-edges/4.13.28-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.28-AROBrokenDNSMasq.yaml
@@ -1,0 +1,15 @@
+to: 4.13.28
+from: .*
+url: https://issues.redhat.com/browse/MCO-958
+name: AROBrokenDNSMasq
+message: |-
+  Adding a new worker node will fail for clusters running on ARO.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.13.28-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.28-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.28
+from: 4[.](12[.]([0-9]|[1-3][0-9]|40)|13[.]([0-9]|1[0-5]))[+].*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.8-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.8-AROBrokenDNSMasq.yaml
@@ -1,0 +1,15 @@
+to: 4.14.8
+from: .*
+url: https://issues.redhat.com/browse/MCO-958
+name: AROBrokenDNSMasq
+message: |-
+  Adding a new worker node will fail for clusters running on ARO.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.8-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.8-AzureDefaultVMType.yaml
@@ -1,0 +1,28 @@
+to: 4.14.8
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )


### PR DESCRIPTION
None of these have been fixed in relevant streams