### PR TITLE
OCPCLOUD-2434: blocked-edges/4.14*: Declare AWSECRLegacyCredProvider

### DIFF
--- a/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.0.yaml
+++ b/blocked-edges/4.14.0.yaml
@@ -2,4 +2,4 @@ to: 4.14.0
 from: 4[.]13[.]1[789]
 fixedIn: 4.14.1
 # We want folks to pick up 4.13.19's https://issues.redhat.com/browse/OCPBUGS-19472 to avoid being surprised by SecurityContextConstraint stomping
-# Also AzureDefaultVMType, but we cannot declare that as a conditional risk from 4.13.19 to 4.14.0 because of https://issues.redhat.com/browse/OTA-1043
+# Also AzureDefaultVMType and AWSECRLegacyCredProvider, but we cannot declare that as a conditional risk from 4.13.19 to 4.14.0 because of https://issues.redhat.com/browse/OTA-1043

--- a/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )

--- a/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,14 @@
+to: 4.14.8
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )


### PR DESCRIPTION
We don't know what PromQL looks like for "I'm using (or not) ECR" looks like, so this will go out to all AWS clusters, not just the exposed ones.  Hopefully the content of the linked URI allows them to determine whether or not they're actually exposed.  If/when we figure out how to tighten the PromQL, we can file a follow-up pull request to adjust here.

Generated the 4.14.0 and 4.14.1 content by hand and copied out with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]' | grep -v '^4[.]14[.][01]$' | while read VERSION; do sed "s/4.14.1/${VERSION}/" blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml > "blocked-edges/${VERSION}-AWSECRLegacyCredProvider.yaml"; done
```
