### PR TITLE
blocked-edges/4.15.0-rc.0: Declare EarlyAPICertRotation

### DIFF
--- a/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.0
+from: .*
+url: https://issues.redhat.com/browse/API-1687
+name: EarlyAPICertRotation
+fixedIn: 4.15.0-rc.1
+message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+matchingRules:
+- type: Always


### PR DESCRIPTION
We could write PromQL that would try and identify older clusters, but with rc.1 already cut, I've just gone with Always for simplicity, and to avoid folks updating to rc.0 while young, forgetting to update further, and then aging into the early, broken CA rotation.