### PR TITLE
OCPCLOUD-2434: EWSECRLegacyCredProvider: Detect actual ECR usage from pullspecs

### DIFF
--- a/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.0-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.1-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.2-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.3-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-ec.4-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.0-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.1-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.2-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.3-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.4-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.5-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.6-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-rc.7-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.1-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.2-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.3-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.4-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.5-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.6-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.7-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
@@ -6,9 +6,21 @@ message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies 
 matchingRules:
 - type: PromQL
   promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
     promql: |
       topk(1,
         cluster_infrastructure_provider{_id="",type="AWS"}
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
+      * on () group_left()(
+      topk(1,
+        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        or on ()
+        0 * group(kube_pod_container_info{_id=""})
+      ))

--- a/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.8-AWSECRLegacyCredProvider.yaml
@@ -18,9 +18,9 @@ matchingRules:
         or
         0 * cluster_infrastructure_provider{_id=""}
       )
-      * on () group_left()(
+      * on () group_left (namespace, pod, container, image)
       topk(1,
-        group(kube_pod_container_info{_id="",image=~".*[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|.*[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov"})
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
         or on ()
-        0 * group(kube_pod_container_info{_id=""})
-      ))
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )


### PR DESCRIPTION
Joel Speed says:

> Looking into the fix for this, I found sources saying that ECR creds should be used for any image matching the following globs
> `"*.dkr.ecr.*.amazonaws.com"`
> `"*.dkr.ecr.*.amazonaws.com.cn"`
> `"*.dkr.ecr-fips.*.amazonaws.com"`
> `"*.dkr.ecr.us-iso-east-1.c2s.ic.gov"`
> `"*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"`

We can use the `kube_pod_container_info` metric that is labeled with an `image` label that contains pullspec, so we can regex-match over these and detect that a cluster is actually using ECR from the presence of a pod containing a container using an image from ECR.

The regex is a bit hairy so I added a comment. [PromQL is using RE2 syntax](https://prometheus.io/docs/prometheus/latest/querying/basics/):

> All regular expressions in Prometheus use [RE2 syntax](https://github.com/google/re2/wiki/Syntax)

Here is the regex101.com session for toying with the regex: https://regex101.com/r/OIjQoS/1

I have used the PromQL conceptually on b01 and b03, testing for the usage of a CoreDNS image coming from the CI registry:

```promql
topk(1,
  cluster_infrastructure_provider{_id="",type="AWS"}
  or
  0 * cluster_infrastructure_provider{_id=""}
)
* on () group_left()
(topk(1,
  group(kube_pod_container_info{_id="",image=~"registry[.]ci[.]openshift[.]org/ci/coredns:.*"})
  or on ()
  0 * group(kube_pod_container_info{_id=""})
))
```

Build01 uses it and I get a metric with value 1:
![image](https://github.com/openshift/cincinnati-graph-data/assets/712614/7c334cba-316c-4b1d-a6ef-29c9ac1dec86)

Build03 does not and I get a metric with value 0:
![image](https://github.com/openshift/cincinnati-graph-data/assets/712614/874a7f15-e5dc-4bb7-abb0-2079ac49aea3)

I modified one of the YAML files manually and then I used my IDE's search-and-replace feature to modify all others.
