### PR TITLE
ETCD-511: Set up EtcdBackupMountPointStuck for 4.14.[3-8]->5.15.0 RC0+ edges

### DIFF
--- a/blocked-edges/4.15.0-rc.0-EtcdBackupMountPointStuck.yaml
+++ b/blocked-edges/4.15.0-rc.0-EtcdBackupMountPointStuck.yaml
@@ -1,0 +1,7 @@
+to: 4.15.0-rc.0
+from: 4[.]14[.].[3-8]
+url: https://issues.redhat.com/browse/ETCD-511
+name: EtcdBackupMountPointStuck
+message: Etcd backup mount point sometimes cannot be deleted causing EtcdRecentBackup precondition to fail and block the upgrade.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.1-EtcdBackupMountPointStuck.yaml
+++ b/blocked-edges/4.15.0-rc.1-EtcdBackupMountPointStuck.yaml
@@ -1,0 +1,7 @@
+to: 4.15.0-rc.1
+from: 4[.]14[.].[3-8]
+url: https://issues.redhat.com/browse/ETCD-511
+name: EtcdBackupMountPointStuck
+message: Etcd backup mount point sometimes cannot be deleted causing EtcdRecentBackup precondition to fail and block the upgrade.
+matchingRules:
+- type: Always


### PR DESCRIPTION
- Affects upgrades from 4.14.[3-8] to 4.15
- May not affect all platforms but given 4.15 is not GA yet setting up `Always` seems like an acceptable big hammer