### PR TITLE
Carry `AROBrokenDNSMasq` and `OVNKubeMasterDSPrestop`

### DIFF
--- a/blocked-edges/4.12.47-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.12.47-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.12.47
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|40)[+].*)
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.13.29-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.29-AROBrokenDNSMasq.yaml
@@ -1,0 +1,15 @@
+to: 4.13.29
+from: .*
+url: https://issues.redhat.com/browse/MCO-958
+name: AROBrokenDNSMasq
+message: |-
+  Adding a new worker node will fail for clusters running on ARO.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.13.29-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.29-OVNKubeMasterDSPrestop.yaml
@@ -1,0 +1,21 @@
+to: 4.13.29
+from: 4[.](12[.]([0-9]|[1-3][0-9]|40)|13[.]([0-9]|1[0-5]))[+].*
+url: https://issues.redhat.com/browse/SDN-4196
+name: OVNKubeMasterDSPrestop
+message: |-
+  Upgrades can get stuck on OVN clusters that were installed as 4.10 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        label_replace(group(cluster_version{type="initial",version=~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "yes, born in 4.10 or earlier", "", "")
+        or
+        label_replace(0 * group(cluster_version{type="initial",version!~"4[.]([0-9]|10)[.].*"}),"born_by_4_10", "no, born in 4.11 or later", "", "")
+      )
+      * on () group_left(resource)
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )


### PR DESCRIPTION
`AROBrokenDNSMasq`:
- [OCPBUGS-26559](https://issues.redhat.com/browse/OCPBUGS-26559) for 4.14 is in `MODIFIED` so 4.13.29 is affected

`OVNKubeMasterDSPrestop`:
- [OCPBUGS-22293](https://issues.redhat.com/browse/OCPBUGS-22293) for 4.13 is in `MODIFIED` so 4.13.29 and 4.12.47 are still affected
