### PR TITLE
Carry `AROBrokenDNSMasq`, `AWSECRLegacyCredProvider` and `AzureDefaultVMType` to 4.14.9

### DIFF
--- a/blocked-edges/4.14.9-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.14.9-AROBrokenDNSMasq.yaml
@@ -1,0 +1,15 @@
+to: 4.14.9
+from: .*
+url: https://issues.redhat.com/browse/MCO-958
+name: AROBrokenDNSMasq
+message: |-
+  Adding a new worker node will fail for clusters running on ARO.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.9-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.9-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,26 @@
+to: 4.14.9
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )
+      * on () group_left (namespace, pod, container, image)
+      topk(1,
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
+        or on ()
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )

--- a/blocked-edges/4.14.9-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.9-AzureDefaultVMType.yaml
@@ -1,0 +1,28 @@
+to: 4.14.9
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        (
+          0 * group(cluster_operator_conditions{_id=""})
+          + on () group_left (born_by_4_9)
+          topk(1,
+            label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+            or
+            label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+          )
+        )
+      )
+      * on () group_left (type)
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )


### PR DESCRIPTION
`AROBrokenDNSMasq`:
- [OCPBUGS-26559](https://issues.redhat.com/browse/OCPBUGS-26559) for 4.14 got `VERIFIED` today but is not yet present in https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.9 so 4.14.9 is still affected

`AWSECRLegacyCredProvider`:
- [OCPBUGS-25662](https://issues.redhat.com/browse/OCPBUGS-25662) for 4.16 is still in `POST`, so 4.14.9 is still affected

`AzureDefaultVMType`:
- [OCPBUGS-26548](https://issues.redhat.com/browse/OCPBUGS-26548) for 4.14 is still in `POST`, so 4.14.9 is still affected
