### PR TITLE
*: Prepare for 4.16 development

### DIFF
--- a/build-suggestions/4.16.yaml
+++ b/build-suggestions/4.16.yaml
@@ -1,0 +1,7 @@
+default:
+  minor_min: 4.15.0-rc.0
+  minor_max: 4.15.9999
+  minor_block_list: []
+  z_min: 4.16.0-ec.0
+  z_max: 4.16.9999
+  z_block_list: []

--- a/channels/candidate-4.16.yaml
+++ b/channels/candidate-4.16.yaml
@@ -1,0 +1,15 @@
+feeder:
+  delay: PT0H
+  filter: 4[.](15|16)[.][0-9].*
+  name: candidate
+name: candidate-4.16
+versions:
+- 4.15.0-ec.0
+- 4.15.0-ec.1
+- 4.15.0-ec.2
+- 4.15.0-ec.3
+- 4.15.0-rc.0
+- 4.15.0-rc.1
+- 4.15.0-rc.2
+- 4.16.0-ec.0
+- 4.16.0-ec.1


### PR DESCRIPTION
Like 3eb8e55eb2 (#2758) and 8a890f6859 (#4167), but for 4.16.  Run well before feature-freeze, but ideally we'd have run this before we'd cut 4.16.0-ec.0, to make it easy for folks to test updated into that Engineering Candidate.  Generated with:

```console
$ hack/release-open.sh 4.16
$ git add build-suggestions/4.16.yaml channels/*4.16.yaml
```