### PR TITLE
blocked-edges/4.13.29-AROBrokenDNSMasq: Fixed in 4.13.30

### DIFF
--- a/blocked-edges/4.13.29-AROBrokenDNSMasq.yaml
+++ b/blocked-edges/4.13.29-AROBrokenDNSMasq.yaml
@@ -1,5 +1,6 @@
 to: 4.13.29
 from: .*
+fixedIn: 4.13.30
 url: https://issues.redhat.com/browse/MCO-958
 name: AROBrokenDNSMasq
 message: |-


### PR DESCRIPTION
[4.13.30][1] contains [OCPBUGS-27096](https://issues.redhat.com/browse/OCPBUGS-27096).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.30
