### PR TITLE
blocked-edges/4.13.29-OVNKubeMasterDSPrestop: Fixed in 4.13.30

### DIFF
--- a/blocked-edges/4.13.29-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.13.29-OVNKubeMasterDSPrestop.yaml
@@ -1,5 +1,6 @@
 to: 4.13.29
 from: 4[.](12[.]([0-9]|[1-3][0-9]|40)|13[.]([0-9]|1[0-5]))[+].*
+fixedIn: 4.13.30
 url: https://issues.redhat.com/browse/SDN-4196
 name: OVNKubeMasterDSPrestop
 message: |-


### PR DESCRIPTION
[4.13.30][1] contains [OCPBUGS-22293](https://issues.redhat.com/browse/OCPBUGS-22293).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.13.30
