### PR TITLE
blocked-edges/4.14.9-AzureDefaultVMType: Fixed in 4.14.10

### DIFF
--- a/blocked-edges/4.14.9-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.9-AzureDefaultVMType.yaml
@@ -1,5 +1,6 @@
 to: 4.14.9
 from: 4[.]13[.].*
+fixedIn: 4.14.10
 url: https://issues.redhat.com/browse/OCPCLOUD-2409
 name: AzureDefaultVMType
 message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.


### PR DESCRIPTION
[4.14.10][1] contains [OCPBUGS-26548](https://issues.redhat.com/browse/OCPBUGS-26548).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.14.10
