### PR TITLE
blocked-edges/4.14.10-AWSECRLegacyCredProvider: Still exposed

### DIFF
--- a/blocked-edges/4.14.10-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.10-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,26 @@
+to: 4.14.10
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+- type: PromQL
+  promql:
+    # Regex-match pullspecs in kube_pod_container_info 'image' labels for the following patterns that indicate the cluster is using ECR:
+    #  - .*.dkr.ecr.*.amazonaws.com
+    #  - .*.dkr.ecr.*.amazonaws.com.cn
+    #  - .*.dkr.ecr-fips.*.amazonaws.com
+    #  - .*.dkr.ecr.us-iso-east-1.c2s.ic.gov
+    #  - .*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="AWS"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )
+      * on () group_left (namespace, pod, container, image)
+      topk(1,
+        kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
+        or on ()
+        0 * topk(1, kube_pod_container_info{_id=""})
+      )


### PR DESCRIPTION
[OCPBUGS-25662](https://issues.redhat.com/browse/OCPBUGS-25662) is still `Post` for 4.16.
