### PR TITLE
blocked-edges/4.15.0-*-EtcdBackupMountPointStuck: Drop . from 'from' regexp

### DIFF
--- a/blocked-edges/4.15.0-rc.0-EtcdBackupMountPointStuck.yaml
+++ b/blocked-edges/4.15.0-rc.0-EtcdBackupMountPointStuck.yaml
@@ -1,5 +1,5 @@
 to: 4.15.0-rc.0
-from: 4[.]14[.].[3-8]
+from: 4[.]14[.][3-8]
 url: https://issues.redhat.com/browse/ETCD-511
 name: EtcdBackupMountPointStuck
 message: Etcd backup mount point sometimes cannot be deleted causing EtcdRecentBackup precondition to fail and block the upgrade.

--- a/blocked-edges/4.15.0-rc.1-EtcdBackupMountPointStuck.yaml
+++ b/blocked-edges/4.15.0-rc.1-EtcdBackupMountPointStuck.yaml
@@ -1,5 +1,5 @@
 to: 4.15.0-rc.1
-from: 4[.]14[.].[3-8]
+from: 4[.]14[.][3-8]
 url: https://issues.redhat.com/browse/ETCD-511
 name: EtcdBackupMountPointStuck
 message: Etcd backup mount point sometimes cannot be deleted causing EtcdRecentBackup precondition to fail and block the upgrade.

--- a/blocked-edges/4.15.0-rc.2-EtcdBackupMountPointStuck.yaml
+++ b/blocked-edges/4.15.0-rc.2-EtcdBackupMountPointStuck.yaml
@@ -1,5 +1,5 @@
 to: 4.15.0-rc.2
-from: 4[.]14[.].[3-8]
+from: 4[.]14[.][3-8]
 url: https://issues.redhat.com/browse/ETCD-511
 name: EtcdBackupMountPointStuck
 message: Etcd backup mount point sometimes cannot be deleted causing EtcdRecentBackup precondition to fail and block the upgrade.


### PR DESCRIPTION
The extra period snuck in with 7520d171e6 (#4581), and kept the single-patch-digit source releases from matching.  With this commit, they start matching:

```console
$ hack/show-edges.py --root-version 4.14.8 candidate-4.15 | grep '^4[.]14[.]8 '
4.14.8 -> 4.14.10
4.14.8 -(risks: AROBrokenDNSMasq)-> 4.14.9
4.14.8 -(risks: EtcdBackupMountPointStuck)-> 4.15.0-rc.1
4.14.8 -(risks: EtcdBackupMountPointStuck)-> 4.15.0-rc.2
```