### PR TITLE
CCO-522: blocked-edges/4.15.0-rc.0-GCPMintModeRoleAdmin: Declare risk

### DIFF
--- a/blocked-edges/4.15.0-ec.0-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-ec.0-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-ec.0
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-ec.1-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-ec.1-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-ec.1
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-ec.2-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-ec.2-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-ec.2
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-ec.3-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-ec.3-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-ec.3
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-rc.0-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.0-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.0
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-rc.1-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.1-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.1
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-rc.2-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.2-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.2
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/blocked-edges/4.15.0-rc.3-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.3-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.3
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )


### PR DESCRIPTION
The PromQL logic is pretty similar to 4.13.9-AWSMintModeWithoutCredentials.yaml

The exposure is probably somewhere in the 4.15 ECs or RCs, but I'm naively opening with a blanket 4.14 -> 4.15 to get this out the door. We can refine the threshold later as we pin down exactly when in 4.15 the creds started using custom roles.

Generated by manually writing the 4.15.0-rc.0 risk, and copying out to other 4.15 with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]' | grep -v '^4[.]15[.]0-rc[.]0$' | while read VERSION; do sed "s/4.15.0-rc.0/${VERSION}/" blocked-edges/4.15.0-rc.0-GCPMintModeRoleAdmin.yaml > "blocked-edges/${VERSION}-GCPMintModeRoleAdmin.yaml"; done
```