### PR TITLE
`OVNKubeMasterDSPrestop`: Fixed in 4.12.48

### DIFF
--- a/blocked-edges/4.12.47-OVNKubeMasterDSPrestop.yaml
+++ b/blocked-edges/4.12.47-OVNKubeMasterDSPrestop.yaml
@@ -1,5 +1,6 @@
 to: 4.12.47
 from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|40)[+].*)
+fixedIn: 4.12.48
 url: https://issues.redhat.com/browse/SDN-4196
 name: OVNKubeMasterDSPrestop
 message: |-


### PR DESCRIPTION
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.48:

> [cluster-network-operator](https://github.com/openshift/cluster-network-operator/tree/d74dddd8a429363054fb7d0a17c34f7c19484296)
> ...
> [OCPBUGS-24039](https://issues.redhat.com/browse/OCPBUGS-24039): remove all managed fields used by old manager [#2099](https://github.com/openshift/cluster-network-operator/pull/2099)
> ...