### PR TITLE
show-edges.py: use raw strings for regexes

### DIFF
--- a/hack/show-edges.py
+++ b/hack/show-edges.py
@@ -20,8 +20,8 @@ import util
 logging.basicConfig(format='%(levelname)s: %(message)s')
 _LOGGER = logging.getLogger(__name__)
 #_LOGGER.setLevel(logging.DEBUG)
-_VERSION_REGEXP = re.compile('^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
-_CHANNEL_REGEXP = re.compile('^(?P<stream>.*)-(?P<major_minor>[1-9]\d*[.][1-9]\d*)$')
+_VERSION_REGEXP = re.compile(r'^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
+_CHANNEL_REGEXP = re.compile(r'^(?P<stream>.*)-(?P<major_minor>[1-9]\d*[.][1-9]\d*)$')
 
 
 def load_channel(channel, revision=None):


### PR DESCRIPTION
My Python 3.12.1 gives me SyntaxWarnings:

```console
$ ./hack/show-edges.py --cincinnati https://api.openshift.com/api/upgrades_info/graph --root-version 4.13.28 eus-4.14
/home/pmuller/Projects/RH/github.com/openshift/cincinnati-graph-data/hack/show-edges.py:23: SyntaxWarning: invalid escape sequence '\d'
  _VERSION_REGEXP = re.compile('^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
/home/pmuller/Projects/RH/github.com/openshift/cincinnati-graph-data/hack/show-edges.py:24: SyntaxWarning: invalid escape sequence '\d'
  _CHANNEL_REGEXP =
re.compile('^(?P<stream>.*)-(?P<major_minor>[1-9]\d*[.][1-9]\d*)$')

```
