### PR TITLE
blocked-edges/4.14.10-AWSECRLegacyCredProvider: fixedIn 4.14.11

### DIFF
--- a/blocked-edges/4.14.10-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.10-AWSECRLegacyCredProvider.yaml
@@ -1,5 +1,6 @@
 to: 4.14.10
 from: 4[.]13[.].*
+fixedIn: 4.14.11
 url: https://issues.redhat.com/browse/OCPCLOUD-2434
 name: AWSECRLegacyCredProvider
 message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.


### PR DESCRIPTION
[4.14.11][1] contains [OCPBUGS-27759](https://issues.redhat.com/browse/OCPBUGS-27759).

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.14.11
