### PR TITLE
blocked-edges/4.15.0-rc.5-GCPMintModeRoleAdmin: Not fixed yet

### DIFF
--- a/blocked-edges/4.15.0-rc.5-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.5-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.5
+from: 4[.](14|15[.]0-ec)[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )


### PR DESCRIPTION
[OCPBUGS-28231](https://issues.redhat.com/browse/OCPBUGS-28231) hasn't landed yet, and we need a new 4.15 release built that only includes 4.14.z with that fix before we can drop this risk.
