### PR TITLE
IR-461: blocked-edges/4.14.*: Declare ARORegistryImagePreservation

### DIFF
--- a/blocked-edges/4.14.0-ec.0-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.0-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.1-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.1-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.2-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.2-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.3-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.3-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-ec.4-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.4-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-ec.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.0-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.0-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.1-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.1-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.2-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.2-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.3-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.3-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.4-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.4-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.5-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.5-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.6-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.6-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.0-rc.7-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.7-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.0-rc.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.1-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.1-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.10-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.10-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.10
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.11-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.11-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.11
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.2-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.2-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.3-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.3-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.4-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.4-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.5-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.5-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.6-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.6-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.7-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.7-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.8-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.8-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.8
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )

--- a/blocked-edges/4.14.9-ARORegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.9-ARORegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.9
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: ARORegistryImagePreservation
+message: In ARO clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})
+      )


### PR DESCRIPTION
Generated by hand-writing the 4.14.1 risk and then copying it out to the rest of 4.14:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]' | grep -v '^4[.]14[.][01]$' | while read VERSION; do sed "s/4.14.1/${VERSION}/" blocked-edges/4.14.1-AzureRegistryImagePreservation.yaml > "blocked-edges/${VERSION}-AzureRegistryImagePreservation.yaml"; done
```