### PR TITLE
blocked-edges/4.14.12-AzureRegistryImagePreservation: Not yet fixed

### DIFF
--- a/blocked-edges/4.14.12-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.12-AzureRegistryImagePreservation.yaml
@@ -1,0 +1,14 @@
+to: 4.14.12
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: AzureRegistryImagePreservation
+message: In Azure clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        cluster_infrastructure_provider{_id="",type="Azure"}
+        or
+        0 * cluster_infrastructure_provider{_id=""}
+      )


### PR DESCRIPTION
[OCPBUGS-29003](https://issues.redhat.com/browse/OCPBUGS-29003) is still POST for 4.16, and once it's verified there we'll still need backports through 4.14.