### PR TITLE
`NetPolicyTimeoutsHostNetworkedPodTraffic`: Exclude cloud platforms from exposure

### DIFF
--- a/blocked-edges/4.12.48-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.12.48-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.12.48-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.12.48-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.13.30-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.30-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.13.30-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.30-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.13.31-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.31-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.13.31-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.31-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.13.32-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.32-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.13.32-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.32-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.14.10-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.10-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.10-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.10-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.14.11-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.11-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.11-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.11-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.14.12-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.12-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.12-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.12-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.14.9-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.9-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.9-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.14.9-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.15.0-rc.1-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.1-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.0-rc.1-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.1-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.15.0-rc.2-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.2-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.0-rc.2-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.2-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.15.0-rc.3-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.3-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.0-rc.3-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.3-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.15.0-rc.4-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.4-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.0-rc.4-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.4-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )

--- a/blocked-edges/4.15.0-rc.5-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.5-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -7,9 +7,9 @@ message: |-
   Clusters where Ingress Controller uses HostNetwork endpoint publishing strategy and certain NetworkPolicy configurations
   may experience network traffic disruptions in namespaces that allowed traffic before the upgrade.
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(max_over_time(apiserver_storage_objects{resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-      or
-      0 * group(max_over_time(apiserver_storage_objects[1h]))
+  - type: PromQL
+    promql:
+      promql: |
+        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+        or
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.0-rc.5-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.15.0-rc.5-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -10,6 +10,14 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
-        or
-        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        topk by (_id) (1,
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal|VSphere|OpenStack|Nutanix|Libvirt|KubeVirt|EquinixMetal|External"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on (_id) group_left (resource)
+        topk by (_id) (1,
+          group(max_over_time(apiserver_storage_objects{_id="",resource="networkpolicies.networking.k8s.io"}[1h]) > 0)
+          or
+          0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+        )


### PR DESCRIPTION
- `NetPolicyTimeoutsHostNetworkedPodTraffic`: Add `_id==""` placeholders
- `NetPolicyTimeoutsHostNetworkedPodTraffic`: Limit exposure to baremetal-ish platforms
