### PR TITLE
IR-461: blocked-edges/4.14.*-AzureRegistryImagePreservation: Look for active registry use

### DIFF
--- a/blocked-edges/4.14.0-ec.0-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.0-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-ec.1-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.1-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-ec.2-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.2-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-ec.3-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.3-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-ec.4-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-ec.4-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.0-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.0-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.1-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.1-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.2-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.2-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.3-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.3-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.4-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.4-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.5-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.5-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.6-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.6-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.0-rc.7-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-rc.7-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.1-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.1-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.10-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.10-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.11-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.11-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.12-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.12-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.2-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.2-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.3-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.3-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.4-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.4-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.5-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.5-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.6-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.6-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.7-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.7-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.8-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.8-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )

--- a/blocked-edges/4.14.9-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.9-AzureRegistryImagePreservation.yaml
@@ -8,7 +8,15 @@ matchingRules:
   promql:
     promql: |
       topk(1,
-        cluster_infrastructure_provider{_id="",type="Azure"}
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
         or
-        0 * cluster_infrastructure_provider{_id=""}
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
       )


### PR DESCRIPTION
Some clusters do not excercise the internal image registry, and we do not want to bother those admins about this risk.  Look at `imageregistry_request_duration_seconds_count` (which only records registry activity like `BlobStore.Create`) as a sign that the registry is actively used to handle images.  Compare with
`imageregistry_http_request_duration_seconds_count`, which the registry serves even when it is not actively being used to manage images, as a sign that registry metrics are working, to distinguish between "we know the registry is not being used" and "registry metrics collection is broken, and we're blind to registry use".

[In 4.14, the registry component became an optional component][1], but it is not optional in 4.13.  And it's 4.13 clusters evaluating this PromQL because of the `from: 4[.]13[.].*`.  So we don't have to worry about "what if `imageregistry_http_request_duration_seconds_count` is not available?" cases outside of the "registry metrics collection is broken" case.

The registry does not persist these `*_count` values across container restarts, so there is a window of exposure like:

1. Registry activity increments `imageregistry_request_duration_seconds_count` counters.
2. PromQL correctly identifies "this cluster is using its registry".
3. Registry container restarts, zeroing its `*_count` buckets.
4. If _all_ registry containers restart before there is new registry activity, the `imageregistry_request_duration_seconds_count` signal may go away.
5. New registry activity repopulates `imageregistry_request_duration_seconds_count`, return to step 1.

The chances that all registry pods restart at the same time seems low, outside of:

* Updates or other registry-hosting-node reboots, where clusters that actively use the in-cluster registry are likely to have pods consuming images from that registry need re-pulling, which would drive fresh registry traffic and repopulate `imageregistry_request_duration_seconds_count`.
* Registry reconfiguration, which would not drive fresh registry traffic, but which seems like unlikely admin activity in a cluster where the internal-registry is not being used.

I'm also using the `max_over_time` with a 1 hour lookback to try to smear over small durations of "waiting for new registry activity to repopulate `imageregistry_request_duration_seconds_count`".

And now that the PromQL is getting pretty complicated, I'm also adjusting label management so it's easier to see from the result which clauses are matching for a particular cluster, in case we need to debug why we're matching when we don't expect to, or not matching when we do expect to.

I'm also adding `_id=""` placeholders for HyperShift, see 5cb2e93728 (#3591) for more on that.

Generated by editing 4.14.1's by hand and copying out to the others with:

```console
$ ls blocked-edges/*AzureRegistryImagePreservation.yaml | grep -v '/4[.]14[.]1-A' | while read X; do TO="$(grep '^to: ' "${X}")"; sed "s/^to: .*/${TO}/" blocked-edges/4.14.1-AzureRegistryImagePreservation.yaml > "${X}"; done
```

[1]: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-optional-capabilities