### PR TITLE
Extending NetPolicyTimeoutsHostNetworkedPodTraffic

### DIFF
--- a/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.13.33-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -1,6 +1,7 @@
 to: 4.13.33
 # 4.13 before 4.13.30 and 4.12.before 4.12.48
 from: 4[.](13[.]([0-9]|[1-2][0-9])|12[.]([0-9]|[1-3][0-9]|4[0-7]))[+].*
+fixedIn: 4.13.34
 url: https://issues.redhat.com/browse/SDN-4481
 name: NetPolicyTimeoutsHostNetworkedPodTraffic
 message: |-


### PR DESCRIPTION
Extending the risk for 4.13.34 as the bug is not available in the release.