### PR TITLE
Extending AzureRegistryImagePreservation

### DIFF
--- a/blocked-edges/4.14.13-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.13-AzureRegistryImagePreservation.yaml
@@ -1,0 +1,22 @@
+to: 4.14.13
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: AzureRegistryImagePreservation
+message: In Azure clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
+      )


### PR DESCRIPTION
As the fix is not available in 4.14.13