### PR TITLE
blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic: Fixed in 4.12.50

### DIFF
--- a/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
+++ b/blocked-edges/4.12.49-NetPolicyTimeoutsHostNetworkedPodTraffic.yaml
@@ -1,6 +1,7 @@
 to: 4.12.49
 # 4.12 before 4.12.48 and 4.11
 from: 4[.](12[.]([0-9]|[1-3][0-9]|4[0-7])|11[.].*)[+].*
+fixedIn: 4.12.50
 url: https://issues.redhat.com/browse/SDN-4481
 name: NetPolicyTimeoutsHostNetworkedPodTraffic
 message: |-


### PR DESCRIPTION
[4.12.50][1] contains [OCPBUGS-29302](https://issues.redhat.com/browse/OCPBUGS-29302).

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.50