### PR TITLE
OTA-1218: Add ga and fleet-approved channels

### DIFF
--- a/hack/release-ga.sh
+++ b/hack/release-ga.sh
@@ -12,7 +12,7 @@ MAJOR_MINOR="${1}"
 if test -z "${MAJOR_MINOR}"
 then
 	cat <<-EOF >&2
-		This script creates the necessary files for for a new x.y minor release which includes fast, stable and, when appropriate, EUS channel files with required metadata for automation.
+		This script creates the necessary files for a new x.y minor release which includes fast, fleet-approved, ga, stable and, when appropriate, EUS channel files with required metadata for automation.
 		Usage:
 		  ${0} MAJOR_MINOR
 		For example:
@@ -21,7 +21,7 @@ then
 	exit 1
 fi
 
-CHANNELS="$(printf '%s\n%s' fast stable)"
+CHANNELS="$(printf '%s\n%s\n%s\n%s' fast fleet-approved ga stable)"
 
 MAJOR="${MAJOR_MINOR%%.*}"
 MINOR="${MAJOR_MINOR##*.}"
@@ -55,12 +55,12 @@ fi
 echo "${CHANNELS}" | while read CHANNEL
 do
 	case "${CHANNEL}" in
-	eus) FEEDER=stable;;
-	*) FEEDER="${CHANNEL}";;
+	eus|fleet-approved|stable) FEEDER=stable;;
+	*) FEEDER=fast;
 	esac
 
 	case "${CHANNEL}" in
-	fast)
+	fast|ga)
 		PREVIOUS_MINOR="$((MINOR - 1))"
 		FILTER="${MAJOR}[.](${PREVIOUS_MINOR=}|${MINOR})[.][0-9].*"
 		;;

--- a/hack/release-stable-minor.sh
+++ b/hack/release-stable-minor.sh
@@ -22,7 +22,7 @@ then
 	exit 1
 fi
 
-CHANNELS="stable"
+CHANNELS="$(printf '%s\n%s' fleet-approved stable)"
 
 MAJOR="${MAJOR_MINOR%%.*}"
 MINOR="${MAJOR_MINOR##*.}"
@@ -41,10 +41,10 @@ fi
 # 4.even get extended update support: https://access.redhat.com/support/policy/updates/openshift#ocp4_phases
 if test "$((MINOR % 2))" -eq 0
 then
-	echo "${MAJOR_MINOR} is an EUS release, will update stable and eus channels"
 	CHANNELS="$(printf '%s\n%s' "${CHANNELS}" eus)"
+	printf "%s is an EUS release, will update the following channels:\n%s\n" "${MAJOR_MINOR}" "${CHANNELS}"
 else
-	echo "${MAJOR_MINOR} is not an EUS release, will update stable channel only (there is no eus channel to update)"
+	printf "%s is not an EUS release, will update the following channels:\n%s\n" "${MAJOR_MINOR}" "${CHANNELS}"
 fi
 
 echo "${CHANNELS}" | while read CHANNEL


### PR DESCRIPTION
As described in the still-in-flight openshift/enhancements#1559, which hopefully is still asking for this change when it merges.  `ga-4.y` is a new alias for `fast-4.y`.  `fleet-approved-4.y` is a new alias for `stable-4.y`.  We're leaving the `internal-channels` names unchanged for now to limit the drift.
