### PR TITLE
*: 4.14.14 guards against GCPMintModeRoleAdmin

### DIFF
--- a/blocked-edges/4.15.0-rc.8-GCPMintModeRoleAdmin.yaml
+++ b/blocked-edges/4.15.0-rc.8-GCPMintModeRoleAdmin.yaml
@@ -1,0 +1,21 @@
+to: 4.15.0-rc.8
+from: 4[.](14|15[.]0-ec)[.].*
+url: https://issues.redhat.com/browse/CCO-522
+name: GCPMintModeRoleAdmin
+message: |-
+  GCP clusters in Mint mode may need additional permissions to provision 4.15 CredentialsRequests.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (mode) (cco_credentials_mode{mode="mint"})
+        or
+        0 * group by (mode) (cco_credentials_mode)
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{type="GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider)
+      )

--- a/build-suggestions/4.15.yaml
+++ b/build-suggestions/4.15.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.14.9
+  minor_min: 4.14.14
   minor_max: 4.14.9999
   minor_block_list: []
   z_min: 4.15.0-ec.0


### PR DESCRIPTION
[4.14.14][1] contains [OCPBUGS-28231](https://issues.redhat.com/browse/OCPBUGS-28231).  Raising `minor_min` ensures the next 4.15 release built from that advice will not include update recommendations from any unguarded 4.14, and we can declare that 4.15.z as the fixedIn version and stop carrying the risk.  But rc.8 was built before we had the updated advice in place, and still includes the older 4.14.z as update sources:

```console
$ oc adm release info -o json quay.io/openshift-release-dev/ocp-release:4.15.0-rc.8-x86_64 | jq -c .metadata.previous
["4.14.10","4.14.11","4.14.12","4.14.13","4.14.14","4.14.9","4.15.0-ec.0",...
```

So extend the risk declaration to rc.8 as well.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.14
