### PR TITLE
blocked-edges/4.14.13-AzureRegistryImagePreservation: Not fixed in 4.14.14

### DIFF
--- a/blocked-edges/4.14.14-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.14-AzureRegistryImagePreservation.yaml
@@ -1,0 +1,22 @@
+to: 4.14.14
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: AzureRegistryImagePreservation
+message: In Azure clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (name, operation, method)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+        or
+        0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
+      )


### PR DESCRIPTION
[4.14.14][1] does not contain [OCPBUGS-29604](https://issues.redhat.com/browse/OCPBUGS-29604) or [OCPBUGS-29755](https://issues.redhat.com/browse/OCPBUGS-29755), although later accepted nightlies do and both bugs are `Verified` for 4.14.z.  Hopefully the next 4.14.z will have both fixes.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.14
