### PR TITLE
API-1687: blocked-edges/4.15.0*-EarlyAPICertRotation: Extend to more recent RCs

### DIFF
--- a/blocked-edges/4.15.0-rc.1-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.1-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.1
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.2-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.2-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.2
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.3-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.3-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.3
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.4-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.4-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.4
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.5-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.5-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.5
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.7-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.7-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.7
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.0-rc.8-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.8-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0-rc.0
+to: 4.15.0-rc.8
 from: .*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation


### PR DESCRIPTION
1228defeba53 (#4578) thought this was fixed in rc.1, but [apparently not][1].

Generated with:

```console
$ sed -i '/fixedIn/d' blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]' | grep -v '^4[.]15[.]0-\(ec\|rc[.]0\)' | while read VERSION; do sed "s/4.15.0-rc.0/${VERSION}/" blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml > "blocked-edges/${VERSION}-EarlyAPICertRotation.yaml"; done
```

[1]: https://issues.redhat.com/browse/API-1687?focusedId=24231419&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24231419