### PR TITLE
blocked-edges/4.15.0-*-PreRelease: Declare prerelease risks and automate

### DIFF
--- a/blocked-edges/4.15.0-ec.0-PreRelease.yaml
+++ b/blocked-edges/4.15.0-ec.0-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-ec.0
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-ec.1-PreRelease.yaml
+++ b/blocked-edges/4.15.0-ec.1-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-ec.1
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-ec.2-PreRelease.yaml
+++ b/blocked-edges/4.15.0-ec.2-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-ec.2
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-ec.3-PreRelease.yaml
+++ b/blocked-edges/4.15.0-ec.3-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-ec.3
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.0-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.0-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.0
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.1-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.1-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.1
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.2-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.2-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.2
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.3-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.3-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.3
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.4-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.4-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.4
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.5-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.5-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.5
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.7-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.7-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.7
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.0-rc.8-PreRelease.yaml
+++ b/blocked-edges/4.15.0-rc.8-PreRelease.yaml
@@ -1,0 +1,8 @@
+to: 4.15.0-rc.8
+from: .*
+url: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html
+name: PreRelease
+message: |-
+  This is a prerelease version, and you should update to 4.15.0 or later releases, even if that means updating to a newer 4.14 first.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Updating `release-ga.sh` to automate the process from 5592c462a9 (#4378), so we don't need to remember to declare these at GA-time, and running the new script on 4.15 to declare those risks.