### PR TITLE
modify EarlyAPICertRotation risk to include promql

### DIFF
--- a/blocked-edges/4.15.0-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.0
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier or older than one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.1-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.1-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.1
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.2-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.2-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.2
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.3-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.3-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.3
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.4-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.4-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.4
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.5-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.5-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.5
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.7-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.7-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.7
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )

--- a/blocked-edges/4.15.0-rc.8-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.8-EarlyAPICertRotation.yaml
@@ -1,7 +1,14 @@
 to: 4.15.0-rc.8
-from: .*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters older than around one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
-- type: Always
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )


### PR DESCRIPTION
All clusters originally installed on OpenShift Container Platform (OCP) version 4.7 or earlier. Clusters installed on 4.8 or later and new 4.15 installs are unaffected.

due to history pruning in the CVO we cannot reliably detect born in versions less than 4.9.
Therefore the conditional update rule will be updated to omit update recommendations in all clusters born in 4.9 or earlier