### PR TITLE
COS-2705: block edges for versions with 4.18.0-372.88.1.el8_6 or later kernel

### DIFF
--- a/blocked-edges/4.11.58-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.11.58-RHELKernelHighLoadIOWait.yaml
@@ -1,0 +1,7 @@
+to: 4.11.58
+from: .*
+url: https://issues.redhat.com/browse/COS-2705
+name: RHELKernelHighLoadIOWait
+message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
+matchingRules:
+  - type: Always

--- a/blocked-edges/4.12.48-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.48-RHELKernelHighLoadIOWait.yaml
@@ -1,0 +1,7 @@
+to: 4.12.48
+from: .*
+url: https://issues.redhat.com/browse/COS-2705
+name: RHELKernelHighLoadIOWait
+message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
+matchingRules:
+  - type: Always

--- a/blocked-edges/4.12.48-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.48-RHELKernelHighLoadIOWait.yaml
@@ -1,7 +1,0 @@
-to: 4.12.48
-from: .*
-url: https://issues.redhat.com/browse/COS-2705
-name: RHELKernelHighLoadIOWait
-message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
-matchingRules:
-  - type: Always

--- a/blocked-edges/4.12.49-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.49-RHELKernelHighLoadIOWait.yaml
@@ -1,0 +1,7 @@
+to: 4.12.49
+from: .*
+url: https://issues.redhat.com/browse/COS-2705
+name: RHELKernelHighLoadIOWait
+message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
+matchingRules:
+  - type: Always

--- a/blocked-edges/4.12.50-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.50-RHELKernelHighLoadIOWait.yaml
@@ -1,0 +1,7 @@
+to: 4.12.50
+from: .*
+url: https://issues.redhat.com/browse/COS-2705
+name: RHELKernelHighLoadIOWait
+message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
+matchingRules:
+  - type: Always

--- a/blocked-edges/4.12.51-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.51-RHELKernelHighLoadIOWait.yaml
@@ -1,0 +1,7 @@
+to: 4.12.51
+from: .*
+url: https://issues.redhat.com/browse/COS-2705
+name: RHELKernelHighLoadIOWait
+message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."
+matchingRules:
+  - type: Always


### PR DESCRIPTION
After rebooting into kernel-4.18.0-372.88.1.el8_6 or later kernel nodes experience high load average and io_wait times 
Nodes may fail to start or stop pods, probes may fail 
Workload and host processes may become unresponsive and workload may be disrupted