### PR TITLE
AzureRegistryImagePreservation fixed in 4.14.15

### DIFF
--- a/blocked-edges/4.14.14-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.14-AzureRegistryImagePreservation.yaml
@@ -1,5 +1,6 @@
 to: 4.14.14
 from: 4[.]13[.].*
+fixedIn: 4.14.15
 url: https://issues.redhat.com/browse/IR-461
 name: AzureRegistryImagePreservation
 message: In Azure clusters, the in-cluster image registry may fail to preserve images on update.


### PR DESCRIPTION
From  https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.15


> [CLUSTER-IMAGE-REGISTRY-OPERATOR](https://github.com/openshift/cluster-image-registry-operator/tree/ecff6866688449079d2768c21081070cd7840fda)
> [OCPBUGS-28989](https://issues.redhat.com/browse/OCPBUGS-28989): pkg/storage/s3: enable bucket key on encryption settings [#995](https://github.com/openshift/cluster-image-registry-operator/pull/995)
> [OCPBUGS-29755](https://issues.redhat.com/browse/OCPBUGS-29755): azurepathfix: fix stack hub, government and workload identity setup [#1005](https://github.com/openshift/cluster-image-registry-operator/pull/1005)
> [OCPBUGS-29604](https://issues.redhat.com/browse/OCPBUGS-29604): move azure storage blobs from docker back into /docker [#1001](https://github.com/openshift/cluster-image-registry-operator/pull/1001)
> [Full changelog](https://github.com/openshift/cluster-image-registry-operator/compare/d27b918c32a5bcd04a2aba77c35b73b3f005b3e9...ecff6866688449079d2768c21081070cd7840fda)

> [DOCKER-REGISTRY](https://github.com/openshift/image-registry/tree/b31bf5898f6f6219baae945a42f2f44f7027ce46)
> [OCPBUGS-29604](https://issues.redhat.com/browse/OCPBUGS-29604): vendor: bump distribution to fix azure storage path bug [#394](https://github.com/openshift/image-registry/pull/394)