### PR TITLE
blocked-edges/4.15.0-EarlyAPICertRotation: Fixed in 4.15.2

### DIFF
--- a/blocked-edges/4.15.0-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-EarlyAPICertRotation.yaml
@@ -1,5 +1,6 @@
 to: 4.15.0
 from: 4[.]14[.].*
+fixedIn: 4.15.2
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
 message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.


### PR DESCRIPTION
[4,15.2][1] contains [OCPBUGS-30304](https://issues.redhat.com/browse/OCPBUGS-30304), which addresses the CA-rotation trigger for clusters born in 4.7 or earlier.  We are still working on getting 4.15.z systems to respond gracefully when the rotation happens, e.g. backporting the changes in [OCPBUGS-25821](https://issues.redhat.com//browse/OCPBUGS-25821) to 4.15.z, but as far as we can tell, 4.15.2 clusters will no longer try and roll the `api-int` Certificate Authority, so we're no worse off there than in the 4.14 releases users would be updating from.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.2
