### PR TITLE
blocked-edges/4.12.51-RHELKernelHighLoadIOWait: Fixed in 4.12.53

### DIFF
--- a/blocked-edges/4.12.51-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.12.51-RHELKernelHighLoadIOWait.yaml
@@ -1,5 +1,6 @@
 to: 4.12.51
 from: .*
+fixedIn: 4.12.53
 url: https://issues.redhat.com/browse/COS-2705
 name: RHELKernelHighLoadIOWait
 message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."


### PR DESCRIPTION
The 4.12.52 name was burned without adding a release to candidate channels.  4.12.53 addresses this issue, [showing][1]:

> Red Hat Enterprise Linux CoreOS upgraded from 412.86.202402272018-0 to 412.86.202403120448-0 ([diff][2])

And [that diff][2] (internal only, sorry!):

> Package (NEVR)	412.86.202402272018-0	412.86.202403120448-0
> ...
> kernel	kernel-0-4.18.0-372.93.1.el8_6-x86_64	kernel-0-4.18.0-372.96.1.el8_6-x86_64
> ...

which aligns with [Scott's][3]:

> The kernel-4.18.0-372.96.1.el8_6...

so the bug is fixed in 4.12.53.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.53?from=4.12.51
[2]: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/diff.html?arch=x86_64&first_release=412.86.202402272018-0&first_stream=prod%2Fstreams%2F4.12&second_release=412.86.202403120448-0&second_stream=prod%2Fstreams%2F4.12
[3]: https://issues.redhat.com/browse/OCPBUGS-30096?focusedId=24326421&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24326421