### PR TITLE
API-1793: build-suggestions/4.16: Raise z_min to ec.1

### DIFF
--- a/build-suggestions/4.16.yaml
+++ b/build-suggestions/4.16.yaml
@@ -2,6 +2,6 @@ default:
   minor_min: 4.15.0
   minor_max: 4.15.9999
   minor_block_list: []
-  z_min: 4.16.0-ec.0
+  z_min: 4.16.0-ec.1
   z_max: 4.16.9999
   z_block_list: []


### PR DESCRIPTION
[4.16.0-ec.1][1] includes [OCPBUGS-26067](https://issues.redhat.com/browse/OCPBUGS-26067), making it compatible with the coming openshift/api#1817 that will bring the [Common Expression Language (CEL)][4] `isIP` and similar into the Infrastucture CRD.  The Infrastructure CRD using `isIP` comes at run level 10, before the Kubernetes API server, which comes at run level 20:

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.16.0-ec.4-x86_64
Extracted release payload from digest sha256:1d715a60966e3c3215c046ac2c70efbe81dcb288d0b0223597cdae35c0c89d61 created at 2024-03-12T20:22:54Z
$ grep -rl infrastructures manifests | grep crd
manifests/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
manifests/0000_10_config-operator_01_infrastructure-Default.crd.yaml
manifests/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
$ grep -rl kube-apiserver-operator manifests | grep deployment
manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
```

So updating straight from ec.0 (which lacks the KAS support for `isIP`) straight to the next Engineering Candidate (which will likely include an Infrastructure CRD that uses `isIP`) would [wedge on reconciling that Infrastructure CRD](https://issues.redhat.com/browse/API-1793).  By raising the floor to ec.1, folks running ec.0 will need to follow a path like:

> 4.16.0-ec.0 -> 4.16.0-ec.4 (picking up the KAS support for isIP) -> 4.16.0-ec.5 (adding isIP use to Infrastructure)

and this commit gets that set up so ec.5 and later do not recommend updates directly from ec.0.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.16.0-ec.1
[4]: https://kubernetes.io/docs/reference/using-api/cel/