### PR TITLE
blocked-edges/4.11.58-RHELKernelHighLoadIOWait: Fixed in 4.11.59

### DIFF
--- a/blocked-edges/4.11.58-RHELKernelHighLoadIOWait.yaml
+++ b/blocked-edges/4.11.58-RHELKernelHighLoadIOWait.yaml
@@ -1,5 +1,6 @@
 to: 4.11.58
 from: .*
+fixedIn: 4.11.59
 url: https://issues.redhat.com/browse/COS-2705
 name: RHELKernelHighLoadIOWait
 message: "After rebooting into kernel-4.18.0-372.88.1.el8_6 or later, kernel nodes experience high load average and io_wait times. The nodes might fail to start or stop pods and probes may fail. Workload and host processes may become unresponsive and workload may be disrupted."


### PR DESCRIPTION
[Scott][1]:

> I've verified that 4.11.59 has the desired kernel, editted for clarity
>
> ```console
> $ oc get clusterversion
> NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
> version   4.11.59   True        False         114s    Cluster version is 4.11.59
>
> $ oc get nodes -o wide
> NAME                                     OS-IMAGE               KERNEL-VERSION
> ci-ln-impy1ik-72292-72vz9-master-0       411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ci-ln-impy1ik-72292-72vz9-master-1       411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ci-ln-impy1ik-72292-72vz9-master-2       411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ci-ln-impy1ik-72292-72vz9-worker-a-hl79v 411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ci-ln-impy1ik-72292-72vz9-worker-b-wngk8 411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ci-ln-impy1ik-72292-72vz9-worker-c-kl49g 411.86.202403120448-0  4.18.0-372.96.1.el8_6.x86_64
> ```

[1]: https://issues.redhat.com/browse/OCPBUGS-30278?focusedId=24392766&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24392766