### PR TITLE
blocked-edges/4.13.38-AcceleratedNetworkingRace: Not fixed in 4.13.38

### DIFF
--- a/blocked-edges/4.13.38-AcceleratedNetworkingRace.yaml
+++ b/blocked-edges/4.13.38-AcceleratedNetworkingRace.yaml
@@ -1,0 +1,15 @@
+to: 4.13.38
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OPNET-479
+name: AcceleratedNetworkingRace
+message: |-
+  Adding a new worker node may fail for clusters running on Azure with Accelerated Networking.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )


### PR DESCRIPTION
[OCPBUGS-30256](https://issues.redhat.com/browse/OCPBUGS-30256) is still `Assigned`, although nmstate/nmstate#2573 did merge a few days ago.
