### PR TITLE
API-1687: blocked-edges/4.15.3-EarlyAPICertRotation: Extend to 4.15.2 and .3

### DIFF
--- a/blocked-edges/4.15.2-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.2-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0
+to: 4.15.2
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation

--- a/blocked-edges/4.15.3-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.3-EarlyAPICertRotation.yaml
@@ -1,4 +1,4 @@
-to: 4.15.0
+to: 4.15.3
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation


### PR DESCRIPTION
21684f75cc (#4898) thought this was fixed, but apparently not [OCPBUGS-31384](https://issues.redhat.com/browse/OCPBUGS-31384).