### PR TITLE
  blocked-edges: `EarlyAPICertRotation` not fixed in 4.15.8

### DIFF
--- a/blocked-edges/4.15.8-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.8-EarlyAPICertRotation.yaml
@@ -1,0 +1,14 @@
+to: 4.15.8
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/API-1687
+name: EarlyAPICertRotation
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.7 or earlier", "", "")
+          or
+          label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+        )


### PR DESCRIPTION
  https://issues.redhat.com/browse/OCPBUGS-31384 still in `POST`, no
  backports yet
