### PR TITLE
blocked-edges: extend `AcceleratedNetworkingRace` to 4.13.39

### DIFF
--- a/blocked-edges/4.13.39-AcceleratedNetworkingRace.yaml
+++ b/blocked-edges/4.13.39-AcceleratedNetworkingRace.yaml
@@ -1,0 +1,14 @@
+to: 4.13.39
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OPNET-479
+name: AcceleratedNetworkingRace
+message: Adding a new worker node may fail for clusters running on Azure with Accelerated Networking.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            (
+              group(cluster_operator_conditions{name="aro"})
+              or
+              0 * group(cluster_operator_conditions)
+            )


### PR DESCRIPTION
4.13.39 does not contain the fix. Details available [internally](https://redhat-internal.slack.com/archives/C02MX20TV24/p1712324587997789?thread_ts=1712322104.197949&cid=C02MX20TV24).
