### PR TITLE
OPRUN-3267: Adding OLMOperatorsInFailedState risk

### DIFF
--- a/blocked-edges/4.15.0-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.0-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.0
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.2-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.2-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.2
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.3-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.3-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.3
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.5-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.5-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.5
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.6-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.6-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.6
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.7-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.7-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.7
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.8-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.8-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.8
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )

--- a/blocked-edges/4.15.9-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.9-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.9
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) based operators going to failed state after updating to 4.15.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )


### PR DESCRIPTION
Both OCPBUGS-31080 and OCPBUGS-24009 has same symptoms and mostlikely related. We are adding a single risk for both of these bugs. However if we come to know if these bugs are separate then we will add separate risks.

Used below script to generate the files

$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]' | grep -v '^4[.]15[.]0' | grep -v '0-[er]c[.]'| while read VERSION; do sed "s/4.15.0/${VERSION}/" blocked-edges/4.15.0-OLMOperatorsInFailedState.yaml > "blocked-edges/${VERSION}-OLMOperatorsInFailedState.yaml"; done