### PR TITLE
COS-2747: blocked-edges/4.12.*: Declare AMD19hFirmware

### DIFF
--- a/blocked-edges/4.12.45-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.45-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.45
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.46-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.46-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.46
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.47-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.47-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.47
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.48-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.48-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.48
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.49-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.49-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.49
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.50-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.50-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.50
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )

--- a/blocked-edges/4.12.51-AMD19hFirmware.yaml
+++ b/blocked-edges/4.12.51-AMD19hFirmware.yaml
@@ -1,0 +1,15 @@
+to: 4.12.51
+from: 4[.](11[.].*|12[.]([0-9]|[1-3][0-9]|4[0-4])[+].*)
+url: https://issues.redhat.com/browse/COS-2747
+name: AMD19hFirmware
+message: |-
+  Nodes with AMD 19h family CPUs  (Bergamo, Milan, etc.) can fail to boot after applying operating system updates.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      topk(1,
+        group by (vendor, family) (node_cpu_info{_id="",vendor="AuthenticAMD",family="25"})
+        or
+        0 * group by (vendor, family) (node_cpu_info{_id=""})
+      )


### PR DESCRIPTION
The `h` suffix in `19h` stands for "hexadecimal", so `19h` is decimal 25. The first `group by` matches CPUs exposed to the firmware bug with a value of one.  The second `group by` shows that the `node_cpu_info` metric is working on at least some nodes.

I'm preserving `vendor` and `family` in the groupings, because it's nice to be able to say "we aren't matching this risk for your cluster, because we see..." and then point out an Intel CPU, or an AMD CPU with a different family, or some other example of why we don't think the risk applies to that cluster.  The `topk` ensures that if we have both risk-matching CPUs and non-matching CPUs, we prefer the matching result (value 1) over the non-matching result(s) (value 0).

The `_id=""` portion is a pattern to support HyperShift and other systems that could query the cluster's data out of a PromQL engine that stored data for multiple clusters.  More context in 5cb2e93728 (#3591).

Generated by writing the 4.12.45 risk by hand and copying it out to other impacted patch versions with:

```console
$ for Z in $(seq 46 51); do sed "s/4.12.45/4.12.${Z}/" blocked-edges/4.12.45-AMD19hFirmware.yaml > "blocked-edges/4.12.${Z}-AMD19hFirmware.yaml"; done
```

And then I set `fixedIn: 4.12.53` in the 4.12.51 risk (we never had a 4.12.52 release, so 4.12.53 is the next one after 4.12.51).