### PR TITLE
IR-468: blocked-edges/4.14.*: Declare AzureRegistryImageMigrationUserProvisioned

### DIFF
--- a/blocked-edges/4.14.15-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.15-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.15
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.16-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.16-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.16
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.17-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.17-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.17
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.18-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.18-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.18
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.19-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.19-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.19
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.20-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.20-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.20
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.14.21-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.21-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.21
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )


### PR DESCRIPTION
Generated by writing the 4.14.15 risk, and then copying out to later 4.14.z through the most recent 4.14.21:

```console
$ tail -n2  channels/candidate-4.14.yaml
- 4.14.20
- 4.14.21
```

with:

```console
$ for Z in $(seq 16 21); do sed "s/4.14.15/4.14.${Z}/" blocked-edges/4.14.15-AzureRegistryImageMigrationUserProvisioned.yaml > "blocked-edges/4.14.${Z}-AzureRegistryImageMigrationUserProvisioned.yaml"; done
```

I'm not currently clear on whether updates from `4.14.(<15)` are also exposed; if they are, we can follow up with a bump to the `from` regular expression.