### PR TITLE
IR-468: blocked-edges/4.15.*: Declare AzureRegistryImageMigrationUserProvisioned

### DIFF
--- a/blocked-edges/4.15.0-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.0-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.0
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.2-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.2-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.2
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.3-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.3-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.3
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.5-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.5-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.5
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.6-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.6-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.6
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.7-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.7-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.7
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.8-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.8-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.8
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )

--- a/blocked-edges/4.15.9-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.9-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.15.9
+from: 4[.]14[.]([0-9]|1[0-4])[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )


### PR DESCRIPTION
[Flavian pointed out][1] that [OCPBUGS-29525](https://issues.redhat.com/browse/OCPBUGS-29525) took the regression into 4.15.0, so 4.14.(<15) updates into all existing 4.15.z are also exposed, until a fix gets back to a future 4.15.z.

[1]: https://issues.redhat.com/browse/IR-468?focusedId=24553962&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24553962