### PR TITLE
hack/stabilization-changes: Restore waiting_notifications in stabilize_version

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -161,6 +161,7 @@ def stabilize_channel(name, channel, channels, channel_paths, cache=None, waitin
                 feeder_promotion=feeder_promotion,
                 candidates=candidates,
                 cache=cache,
+                waiting_notifications=waiting_notifications,
                 **kwargs)
     if waiting_notifications:
         yield from get_concerns_about_patch_updates(


### PR DESCRIPTION
0b160190cb (#5128) moved `waiting_notifications` from `kwargs` into an explicitly handled argument in `stabilize_channel`.  That means we need to explicitly pass it down into `stabilize_version` to keep those version notifications in the daily batch message.