### PR TITLE
OCPCLOUD-2582: blocked-edges/4.16.*: Declare CRIAuthPluginRHEL

### DIFF
--- a/blocked-edges/4.16.0-ec.0-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.0-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.0
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.0-ec.1-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.1-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.1
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.0-ec.2-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.2-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.2
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.0-ec.3-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.3-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.3
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.0-ec.4-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.4-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.4
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.0-ec.5-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.5-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.5
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (label_node_openshift_io_os_id)
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )


### PR DESCRIPTION
Generated by writing the ec.0 risk manually, and copying out to the other candidate 4.16 with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]' | grep -v '^4[.]16[.]0-ec[.]0' | while read VERSION; do sed "s/4.16.0-ec.0/${VERSION}/" blocked-edges/4.16.0-ec.0-CRIAuthPluginRHEL.yaml > "blocked-edges/${VERSION}-CRIAuthPluginRHEL.yaml"; done
```