### PR TITLE
API-1687: blocked-edges/4.15.9-EarlyAPICertRotation: Fixed in 4.15.10

### DIFF
--- a/blocked-edges/4.15.9-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.9-EarlyAPICertRotation.yaml
@@ -1,5 +1,6 @@
 to: 4.15.9
 from: 4[.]14[.].*
+fixedIn: 4.15.10
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
 message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.


### PR DESCRIPTION
We thought this was fixed in rc.1, but it wasn't, c74c248daf (#4841).

Then we thought it was fixed in 4.15.2, but it wasn't, b474a45779 (#4981).

Now we think it's fixed in [4.15.10][1], wihch contains all three of:

* openshift/cluster-kube-apiserver-operator#1662: OCPBUGS-31807: Use RotatedSigningCASecret in update only mode
* openshift/cluster-kube-controller-manager-operator#801: OCPBUGS-31807: use RotatedSigningCASecret and RotatedSelfSignedCertKeySecret only in update mode
* openshift/kubernetes#1939: OCPBUGS-31807: UPSTREAM: <carry>: allow type mutation for specific secrets

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.10