### PR TITLE
OPRUN-3267: blocked-edges/4.15.10-OLMOperatorsInFailedState: Not fixed yet

### DIFF
--- a/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
@@ -1,0 +1,15 @@
+to: 4.15.10
+from: 4[.]14[.]*
+url: https://issues.redhat.com/browse/OPRUN-3267
+name: OLMOperatorsInFailedState
+message: |-
+  The Operator Lifecycle Manager (OLM) operators can't be upgraded and may incorrectly report failed status.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(csv_succeeded{_id=""})
+        or
+        0 * group(csv_count{_id=""})
+      )


### PR DESCRIPTION
I'm a bit confused by the current state of [OPRUN-3267](https://issues.redhat.com/browse/OPRUN-3267).  I see:

* openshift/operator-framework-olm#736, although [that seems to have just-missed 4.15.10][3].
* openshift/operator-framework-olm#738, which is still in flight.

I'm not sure if we're waiting for both or not, but either way, 4.15.10 doesn't have what we need, so I'm extending that risk here.

[3]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.15.0-0.nightly/release/4.15.0-0.nightly-2024-04-19-015656?from=4.15.10