### PR TITLE
IR-468: blocked-edges/: Fix PromQL Metric on AzureRegistryImageMigrationUserProvisioned

### DIFF
--- a/blocked-edges/4.14.15-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.15-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.16-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.16-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.17-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.17-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.18-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.18-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.19-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.19-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.20-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.20-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.14.21-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.21-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.0-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.0-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.2-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.2-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.3-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.3-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.5-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.5-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.6-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.6-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.7-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.7-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -14,7 +14,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )

--- a/blocked-edges/4.15.8-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.15.8-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -15,7 +15,7 @@ matchingRules:
       )
       * on () group_left (secret)
       topk(1,
-        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",name="image-registry-private-configuration-user"})
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
         or
         0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
       )


### PR DESCRIPTION
`kube_secret_info` metric should be using `secret=` not `name=`. 

![image](https://github.com/openshift/cincinnati-graph-data/assets/10840174/fd5b7597-1d1f-48b6-9050-7832b4fd6969)
