### PR TITLE
IR-468: blocked-edges/4.14.22-AzureRegistryImageMigrationUserProvisioned: Not fixed yet

### DIFF
--- a/blocked-edges/4.14.22-AzureRegistryImageMigrationUserProvisioned.yaml
+++ b/blocked-edges/4.14.22-AzureRegistryImageMigrationUserProvisioned.yaml
@@ -1,0 +1,20 @@
+to: 4.14.22
+from: 4[.](13[.].*|14[.]([0-9]|1[0-4]))[+].*
+url: https://issues.redhat.com/browse/IR-468
+name: AzureRegistryImageMigrationUserProvisioned
+message: In Azure clusters with the user-provisioned registry storage, the in-cluster image registry component may struggle to complete the cluster update.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+      * on () group_left (secret)
+      topk(1,
+        group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry",secret="image-registry-private-configuration-user"})
+        or
+        0 * group by (secret) (kube_secret_info{_id="",namespace="openshift-image-registry"})
+      )


### PR DESCRIPTION
[OCPBUGS-32450](https://issues.redhat.com/browse/OCPBUGS-32450) is still `POST` for 4.14.

Self-LGTM, because it's late for everyone else.