### PR TITLE
OPRUN-3267: blocked-edges/4.15.10-OLMOperatorsInFailedState: Fixed in 4.15.11

### DIFF
--- a/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,6 @@
 to: 4.15.10
 from: 4[.]14[.]*
+fixedIn: 4.15.11
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-


### PR DESCRIPTION
[4.15.11][1] includes [OCPBUGS-32311][2].  In cb0259d7e7 (#5132), I'd also thought [OCPBUGS-32439][3] might be relevant, but [it turns out it isn't][4].

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.11
[2]: https://issues.redhat.com/browse/OCPBUGS-32311
[3]: https://issues.redhat.com/browse/OCPBUGS-32439
[4]: https://issues.redhat.com/browse/OCPBUGS-32439?focusedId=24599986&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24599986