### PR TITLE
`CRIAuthPluginRHEL`: Extend to 4.16.0-ec.6 and bump `minor_min` to 4.15.11

### DIFF
--- a/blocked-edges/4.16.0-ec.6-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.6-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-ec.6
+from: ^4[.]15[.].([0-9]|10)[+].*$
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            topk(1,
+              group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+              or
+              0 * group by (type) (cluster_infrastructure_provider{_id=""})
+            )
+            * on () group_left (label_node_openshift_io_os_id)
+            topk(1,
+              group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+              or
+              0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+            )

--- a/build-suggestions/4.16.yaml
+++ b/build-suggestions/4.16.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.15.4
+  minor_min: 4.15.11
   minor_max: 4.15.9999
   minor_block_list: []
   z_min: 4.16.0-ec.1


### PR DESCRIPTION
[CRIAuthPluginRHEL: Extend to 4.16.0-ec.6](https://github.com/openshift/cincinnati-graph-data/commit/b4c086ffd7cbd84672e57f6be9982817dfd6f661)

`CRIAuthPluginRHEL` is a risk that needs to be fixed in the outbound version. OCPBUGS-30970 is fixed in 4.15.11 so extend the risk only for edges from 4.15.10 and lower.

---

[Bump minor_min to 4.15.11 to avoid CRIAuthPluginRHEL](https://github.com/openshift/cincinnati-graph-data/commit/14aaacebc197c62230eaa8187cb8e5c7857f1f8c)