### PR TITLE
`CRIAuthPluginRHEL`: Extend to 4.16.0-rc.0 but limit outgoing to <=4.15.11

### DIFF
--- a/blocked-edges/4.16.0-ec.0-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.0-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.0
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.1-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.1-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.1
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.2-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.2-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.2
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.3-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.3-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.3
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.4-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.4-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.4
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.5-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.5-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.5
-from: 4[.]15[.].*
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-ec.6-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-ec.6-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0-ec.6
-from: ^4[.]15[.].([0-9]|10)[+].*$
+from: ^4[.]15[.]([0-9]|10)[+].*$
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.

--- a/blocked-edges/4.16.0-rc.0-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-rc.0-CRIAuthPluginRHEL.yaml
@@ -1,0 +1,20 @@
+to: 4.16.0-rc.0
+from: ^4[.]15[.]([0-9]|10)[+].*$
+url: https://issues.redhat.com/browse/OCPCLOUD-2582
+name: CRIAuthPluginRHEL
+message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          group by (type) (cluster_infrastructure_provider{_id="",type=~"Azure|GCP"})
+          or
+          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        )
+        * on () group_left (label_node_openshift_io_os_id)
+        topk(1,
+          group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+          or
+          0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+        )


### PR DESCRIPTION
Recent `minor_min` bump to 4.15.11 for some reason did not propagate to 4.16.0-rc.0 ([Slack convo with ART](https://redhat-internal.slack.com/archives/CB95J6R4N/p1715163952815869) so we need to extend, but we can limit the risks to edges from <=4.15.10
