### PR TITLE
NE-1689: Declare `IngressDegradedOnRouterReloads` for <4.14.23

### DIFF
--- a/blocked-edges/4.14.0-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.0-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.1-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.1-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.10-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.10-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.10
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.11-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.11-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.11
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.12-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.12-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.12
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.13-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.13-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.13
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.14-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.14-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.14
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.15-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.15-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.15
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.16-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.16-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.16
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.17-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.17-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.17
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.18-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.18-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.18
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.19-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.19-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.19
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.2-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.2-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.20-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.20-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.20
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.21-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.21-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.21
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.22-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.22-IngressDegradedOnRouterReloads.yaml
@@ -1,5 +1,6 @@
 to: 4.14.22
 from: 4[.]13[.].*
+fixedIn: 4.14.23
 url: https://issues.redhat.com/browse/NE-1689
 name: IngressDegradedOnRouterReloads
 message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.

--- a/blocked-edges/4.14.22-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.22-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.22
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.3-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.3-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.4-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.4-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.5-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.5-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.6-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.6-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.7-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.7-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.8-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.8-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.8
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.9-IngressDegradedOnRouterReloads.yaml
+++ b/blocked-edges/4.14.9-IngressDegradedOnRouterReloads.yaml
@@ -1,0 +1,7 @@
+to: 4.14.9
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/NE-1689
+name: IngressDegradedOnRouterReloads
+message: Incoming HTTP requests to services exposed by Routes may fail while routers reload their configuration, especially when made with Apache HTTPClient versions before 5.0. The problem is more likely to occur in clusters with higher number of Routes and corresponding endpoints.
+matchingRules:
+- type: Always


### PR DESCRIPTION
OTA consensus was to declare this risk once a fixed version in present in the stable channel, which was expedited for 4.14.23 and it went to stable via https://github.com/openshift/cincinnati-graph-data/pull/5214

I was thinking of maybe making this a conditional risk based on the count of Routes in the cluster, but without knowing a good threshold I would be just speculating. We have a fixed 4.14.23, lets steer folks towards it.
