### PR TITLE
Declare `ReconciledPlatformSCC` for 4.13.{17,18} -> 4.14.0

### DIFF
--- a/blocked-edges/4.14.0-ReconciledPlatformSCC.yaml
+++ b/blocked-edges/4.14.0-ReconciledPlatformSCC.yaml
@@ -1,0 +1,9 @@
+to: 4.14.0
+from: 4[.]13[.](17|18)[+].*
+fixedIn: 4.14.1
+url: https://access.redhat.com/solutions/7033949
+name: ReconciledPlatformSCC
+message: |-
+  User changes of platform SecurityContextConstraints (SCCs) would be removed in 4.14, we recommend to update from a more recent 4.13 version that contains appropriate warnings and gates.
+matchingRules:
+- type: Always


### PR DESCRIPTION
4.14.0 is the only 4.14 with updates from 4.13 versions without a CVO gate that sets `Upgradeable=False` when it detect user-modified platform SCCs (OCPBUGS-19465). We want to steer 4.13 clusters to pass this gate, so lets set up an `Always` risk to discourage folks from taking these two exposed edges.

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.14.1-x86_64 | grep Upgrades
  Upgrades: 4.13.19, 4.14.0-ec.0, 4.14.0-ec.1, 4.14.0-ec.2, 4.14.0-ec.3, 4.14.0-ec.4, 4.14.0-rc.0, 4.14.0-rc.1, 4.14.0-rc.2, 4.14.0-rc.3, 4.14.0-rc.4, 4.14.0-rc.5, 4.14.0-rc.6, 4.14.0-rc.7, 4.14.0

$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.14.0-x86_64 | grep Upgrades
  Upgrades: 4.13.17, 4.13.18, 4.13.19, 4.14.0-ec.0, 4.14.0-ec.1, 4.14.0-ec.2, 4.14.0-ec.3, 4.14.0-ec.4, 4.14.0-rc.0, 4.14.0-rc.1, 4.14.0-rc.2, 4.14.0-rc.3, 4.14.0-rc.4, 4.14.0-rc.5, 4.14.0-rc.6, 4.14.0-rc.7
```
