### PR TITLE
Backfill 4.14.0 risks from 4.14.1 and remove 4.14.0 drop

### DIFF
--- a/blocked-edges/4.14.0-AWSECRLegacyCredProvider.yaml
+++ b/blocked-edges/4.14.0-AWSECRLegacyCredProvider.yaml
@@ -1,0 +1,20 @@
+to: 4.14.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2434
+name: AWSECRLegacyCredProvider
+message: AWS clusters that use AmazonEC2ContainerRegistryReadOnly node policies to access ECR are unable to pull images from ECR after updating to exposed 4.14.z.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            topk(1,
+              cluster_infrastructure_provider{_id="",type="AWS"}
+              or
+              0 * cluster_infrastructure_provider{_id=""}
+            )
+            * on () group_left (namespace, pod, container, image)
+            topk(1,
+              kube_pod_container_info{_id="",image=~".*(?:[.]dkr[.]ecr(?:-fips)?[.].*[.]amazonaws[.]com(?:[.]cn)?|[.]dkr[.]ecr[.]us-isob?-east-1[.](?:c2s[.]ic|sc2s[.]sgov)[.]gov)[/@:].*"}
+              or on ()
+              0 * topk(1, kube_pod_container_info{_id=""})
+            )

--- a/blocked-edges/4.14.0-AzureDefaultVMType.yaml
+++ b/blocked-edges/4.14.0-AzureDefaultVMType.yaml
@@ -1,0 +1,28 @@
+to: 4.14.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-2409
+name: AzureDefaultVMType
+message: Azure clusters created by openshift-installer prior to 4.9 are unable to add load balancers to new machines after updating to exposed 4.14.z.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            topk(1,
+              group by (name) (cluster_operator_conditions{_id="",name="aro"})
+              or
+              (
+                0 * group(cluster_operator_conditions{_id=""})
+                + on () group_left (born_by_4_9)
+                topk(1,
+                  label_replace(group(cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.8 or earlier", "", "")
+                  or
+                  label_replace(0 * group(cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+                )
+              )
+            )
+            * on () group_left (type)
+            topk(1,
+              cluster_infrastructure_provider{_id="",type="Azure"}
+              or
+              0 * cluster_infrastructure_provider{_id=""}
+            )

--- a/blocked-edges/4.14.0-AzureRegistryImagePreservation.yaml
+++ b/blocked-edges/4.14.0-AzureRegistryImagePreservation.yaml
@@ -1,0 +1,22 @@
+to: 4.14.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/IR-461
+name: AzureRegistryImagePreservation
+message: In Azure clusters, the in-cluster image registry may fail to preserve images on update.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            topk(1,
+              group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+              or
+              0 * group by (type) (cluster_infrastructure_provider{_id=""})
+            )
+            * on () group_left (name, operation, method)
+            topk(1,
+              group by (name) (cluster_operator_conditions{_id="",name="aro"})
+              or
+              group by (operation) (max by (operation) (max_over_time(imageregistry_request_duration_seconds_count{_id=""}[1h])))
+              or
+              0 * group by (method) (max by (method) (imageregistry_http_request_duration_seconds_count{_id=""}))
+            )

--- a/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
+++ b/blocked-edges/4.14.0-ConsoleImplicitlyEnabled.yaml
@@ -1,0 +1,11 @@
+to: 4.14.0
+from: 4[.](13[.].*|14[.]0-(ec[.].*|rc[.][01]))
+fixedIn: 4.14.2
+url: https://issues.redhat.com/browse/OTA-1031
+name: ConsoleImplicitlyEnabled
+message: Clusters with the Console capability disabled will have it implicitly enabled by updating to the target release, and once enabled, capabilities cannot be disabled.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            1 - max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.14.0.yaml
+++ b/blocked-edges/4.14.0.yaml
@@ -1,5 +1,0 @@
-to: 4.14.0
-from: 4[.]13[.]1[789]
-fixedIn: 4.14.1
-# We want folks to pick up 4.13.19's https://issues.redhat.com/browse/OCPBUGS-19472 to avoid being surprised by SecurityContextConstraint stomping
-# Also AzureDefaultVMType and AWSECRLegacyCredProvider, but we cannot declare that as a conditional risk from 4.13.19 to 4.14.0 because of https://issues.redhat.com/browse/OTA-1043


### PR DESCRIPTION
Generated with https://github.com/petr-muller/ota/tree/main/cmd/graph-extend-or-fix by basically extending backwards:
```console
for risk in AWSCustomDomainNodesNotReady AWSECRLegacyCredProvider AzureDefaultVMType AzureRegistryImagePreservation ConsoleImplicitlyEnabled IngressDegradedOnRouterReloads
    go run ./cmd/graph-extend-or-fix/... --jira-endpoint=https://issues.redhat.com/ --jira-bearer-token-file=$HOME/Temporary/jira-upgradeblocker-token --graph-repository-path=/home/pmuller/Projects/RH/github.com/openshift/cincinnati-graph-data --risk=$risk --last=4.14.1 --new=4.14.0 --do=extend
end
```

I have not included the formatting changes in AWSCustomDomainNodesNotReady and IngressDegradedOnRouterReloads that already existed on 4.14.0

Initially we wanted to silently drop the 4.14.0 release from the graph but because of [OTA-1043](https://issues.redhat.com/browse/OTA-1043) it is hard to keep it that way, because we usually automate adding new 4.14 risks over individual patch updates and forget to avoid adding one for 4.14.0. This way we struggle to keep the drop in effect (see https://github.com/openshift/cincinnati-graph-data/pull/4339 and https://github.com/openshift/cincinnati-graph-data/pull/4301), so we decided to give up and just bury 4.14.0 in conditional risks.
