### PR TITLE
AUTH-517: Declare `ServiceAccountsOAuth` for cluster with disabled registry

### DIFF
--- a/blocked-edges/4.15.0-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.0-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.0
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.10-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.10-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.10
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.11-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.11-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.11
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.12-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.12-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.12
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.2-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.2-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.2
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.3-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.3-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.3
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.5-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.5-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.5
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.6-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.6-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.6
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.7-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.7-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.7
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.8-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.8-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.8
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )

--- a/blocked-edges/4.15.9-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.9-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.9
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )


### PR DESCRIPTION
~~PromQL works as expected on enabled capability, disabled capability, and defensively, on clusters that are somehow not aware a capability:~~

Trevor suggested we pivot to checking the presence of scaled-up image registry deployment:

cluster runs 2 replicas of registry
first is "no such deployment" -> 1
second is "scaled beyond threshold" -> 0
third is "scaled below threshold" -> 1

For production PromQL we just check the threshold is 0, not 2

![image](https://github.com/openshift/cincinnati-graph-data/assets/712614/cbdf27bb-daf9-4850-a7e8-f354245287f6)
