### PR TITLE
OCPCLOUD-2582: blocked-edges/4.16.0-rc.0-CRIAuthPluginRHEL: Fixed in rc.1

### DIFF
--- a/blocked-edges/4.16.0-rc.0-CRIAuthPluginRHEL.yaml
+++ b/blocked-edges/4.16.0-rc.0-CRIAuthPluginRHEL.yaml
@@ -1,5 +1,6 @@
 to: 4.16.0-rc.0
 from: ^4[.]15[.]([0-9]|10)[+].*$
+fixedIn: 4.16.0-rc.1
 url: https://issues.redhat.com/browse/OCPCLOUD-2582
 name: CRIAuthPluginRHEL
 message: Azure and GCP clusters with RHEL nodes may fail to start the kubelet until the operating system has been updated.


### PR DESCRIPTION
rc.1 is built with the updated update sources:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.16.0-rc.1-x86_64 | grep Upgrade
  Upgrades: 4.15.11, 4.15.12, 4.15.13, 4.16.0-ec.1, 4.16.0-ec.2, 4.16.0-ec.3, 4.16.0-ec.4, 4.16.0-ec.5, 4.16.0-ec.6, 4.16.0-rc.0
```