### PR TITLE
blocked-edges/4.13.41-CephCapDropPanic: Fixed in 4.13.42

### DIFF
--- a/blocked-edges/4.13.41-CephCapDropPanic.yaml
+++ b/blocked-edges/4.13.41-CephCapDropPanic.yaml
@@ -1,6 +1,7 @@
 to: 4.13.41
 # 4.12 before 4.12.54 and 4.13 before 4.13.36
 from: 4[.](12[.](5[0-3]|[1-4]?[0-9])|13[.](3[0-5]|[0-2]?[0-9]))[+].*
+fixedIn: 4.13.42
 url: https://issues.redhat.com/browse/COS-2781
 name: CephCapDropPanic
 message: Nodes in clusters running workloads that mount Ceph volumes may experience kernel panics due to a CephFS client bug.


### PR DESCRIPTION
[4.13.42][1] has:

> Red Hat Enterprise Linux CoreOS upgraded from 413.92.202404232117-0 to 413.92.202405132113-0 ([diff][2])

[that diff][2] (internal only, sorry external folks) has:

> Package (NEVR)	413.92.202404232117-0	413.92.202405132113-0
> ...
> kernel	kernel-0-5.14.0-284.64.1.el9_2-x86_64	kernel-0-5.14.0-284.66.1.el9_2-x86_64

66 is [RHSA-2024:2845][4], which is linked from [RHEL-33001][3] tracking the Ceph fix.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.13.42
[2]: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/diff.html?arch=x86_64&first_release=413.92.202404232117-0&first_stream=prod%2Fstreams%2F4.13-9.2&second_release=413.92.202405132113-0&second_stream=prod%2Fstreams%2F4.13-9.2
[3]: https://issues.redhat.com/browse/RHEL-33001?focusedId=24730409&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24730409
[4]: https://access.redhat.com/errata/RHSA-2024:2845