### PR TITLE
AUTH-517: blocked-edges/4.15.14-ServiceAccountsOAuth: Not fixed

### DIFF
--- a/blocked-edges/4.15.14-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.14-ServiceAccountsOAuth.yaml
@@ -1,0 +1,14 @@
+to: 4.15.14
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/AUTH-517
+name: ServiceAccountsOAuth
+message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk(1,
+        0 * group by (deployment) (kube_deployment_spec_replicas{_id="",namespace="openshift-image-registry",deployment="image-registry"} > 0)
+        or
+        group(kube_deployment_spec_replicas{_id=""})
+      )


### PR DESCRIPTION
[OCPBUGS-33210][1] is still POST.

Generated with:

```console
$ sed 's/4[.]15[.]13/4.15.14/' blocked-edges/4.15.13-ServiceAccountsOAuth.yaml
```

[1]: https://issues.redhat.com/browse/OCPBUGS-33210