### PR TITLE
AUTH-517: blocked-edges/4.15.14-ServiceAccountsOAuth: Fixed in 4.15.15

### DIFF
--- a/blocked-edges/4.15.14-ServiceAccountsOAuth.yaml
+++ b/blocked-edges/4.15.14-ServiceAccountsOAuth.yaml
@@ -1,5 +1,6 @@
 to: 4.15.14
 from: 4[.]14[.].*
+fixedIn: 4.15.15
 url: https://issues.redhat.com/browse/AUTH-517
 name: ServiceAccountsOAuth
 message: ServiceAccounts cannot be used as OAuth2 clients in clusters where internal image registry is disabled.


### PR DESCRIPTION
[4.15.15][1] contains both non-library [OCPBUGS-33210][2] pulls, and OCPBUGS-33210 is `Verified` to show that's sufficient.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.15
[2]: https://issues.redhat.com/browse/OCPBUGS-33210