### PR TITLE
SDN-4871: blocked-edges/4.14.*-OVNInterConnectTransitionIPsec: Declare risk

### DIFF
--- a/blocked-edges/4.14.0-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-ec.0-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-ec.0-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-ec.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-ec.1-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-ec.1-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-ec.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-ec.2-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-ec.2-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-ec.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-ec.3-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-ec.3-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-ec.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-ec.4-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-ec.4-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-ec.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.0-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.0-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.0
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.1-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.1-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.2-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.2-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.3-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.3-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.4-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.4-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.5-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.5-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.6-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.6-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.0-rc.7-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.0-rc.7-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0-rc.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.1-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.1-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.1
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.10-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.10-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.10
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.11-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.11-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.11
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.12-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.12-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.12
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.13-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.13-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.13
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.14-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.14-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.14
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.15-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.15-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.15
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.16-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.16-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.16
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.17-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.17-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.17
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.18-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.18-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.18
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.19-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.19-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.19
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.2-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.2-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.2
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.20-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.20-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.20
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.21-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.21-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.21
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.22-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.22-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.22
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.23-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.23-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.23
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.24-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.24-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.24
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.25-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.25-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.25
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.26-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.26-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.26
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.27-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.27-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.27
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.28-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.28-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.28
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.3-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.3-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.3
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.4-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.4-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.4
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.5-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.5-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.5
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.6-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.6-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.6
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.7-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.7-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.7
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.8-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.8-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.8
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.14.9-OVNInterConnectTransitionIPsec.yaml
+++ b/blocked-edges/4.14.9-OVNInterConnectTransitionIPsec.yaml
@@ -1,0 +1,16 @@
+to: 4.14.9
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/SDN-4871
+name: OVNInterConnectTransitionIPsec
+message: OVN clusters with IPsec enabled may have a window during the update to 4.14 where pod-to-node and node-to-node traffic is not encrypted.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
The PromQL is:

* If we know IPsec is enabled, we're exposed, or...
* If we know IPsec is not enabled, we're not exposed, or...
* If are OVN, but aren't sure if IPsec is enabled (e.g. `ovnkube_master_ipsec_enabled` scraping is failing), we might be exposed.  [-1 will cause an evaluation failure][1].  Or...
* If we know we are not OVN, we are not exposed, or...
* If we aren't sure we're on OVN (e.g. `apiserver_storage_objects` scraping is failing), we might be exposed.  [Returning no time series will cause an evaluation failure][1].

The `label_replace` makes it easier to tell when we're in the "we know IPsec is not enabled" case.

The `max_over_time` avoids hiccuping if metrics are interrupted; see 5e4480fa76 (#4763).

I'm also adding `_id=""` to the queries as a pattern to support HyperShift and other systems that could query the cluster's data out of a PromQL engine that stored data for multiple clusters.  More context in 5cb2e93728 (#3591).

Generated by creating the 4.14.0 file by hand and copying it out to the other 4.14 releases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]' | grep -v '^4[.]14[.]0$' | while read VERSION; do sed "s/4.14.0/${VERSION}/" blocked-edges/4.14.0-OVNInterConnectTransitionIPsec.yaml > "blocked-edges/${VERSION}-OVNInterConnectTransitionIPsec.yaml"; done
```

[1]: https://github.com/openshift/enhancements/blob/4668a0825c59739dfafd2ae661c16cf30f540946/enhancements/update/targeted-update-edge-blocking.md?plain=1#L119