### PR TITLE
OCPBUGS-33984: build-suggestions/4.16: Set minor_min to 4.15.17

### DIFF
--- a/build-suggestions/4.16.yaml
+++ b/build-suggestions/4.16.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.15.11
+  minor_min: 4.15.17
   minor_max: 4.15.9999
   minor_block_list: []
   z_min: 4.16.0-ec.1


### PR DESCRIPTION
[4.15.17][1] has [OCPBUGS-33984][2], and we want that in front of every admin taking a 4.15 cluster to a supported 4.16 release.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.17
[2]: https://issues.redhat.com/browse/OCPBUGS-33984