### PR TITLE
Block 4.14 due to bad boot order

### DIFF
--- a/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.0
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.0
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.1
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.1
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.10
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.10
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.11
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.11
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.12
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.12
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.13
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.13
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.14
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.14
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.15
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.15
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.16
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.16
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.17
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.17
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.18
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.18
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.19
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.19
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.2
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.2
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.20
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.20
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.21
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.21
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.22
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.22
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.23
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.23
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.24
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.24
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.25
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.25
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.26
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.26
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.27
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.27
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.28-ARODNSWrongBootSequence.yaml.yaml
+++ b/blocked-edges/4.14.28-ARODNSWrongBootSequence.yaml.yaml
@@ -1,0 +1,13 @@
+to: 4.14.28
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.14.29-ARODNSWrongBootSequence.yaml.yaml
+++ b/blocked-edges/4.14.29-ARODNSWrongBootSequence.yaml.yaml
@@ -1,0 +1,13 @@
+to: 4.14.29
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.3
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.3
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.4
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.4
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.5
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.5
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.6
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.6
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.7
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.7
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.8
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )

--- a/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.8
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,15 @@
+to: 4.14.9
+from: .*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)
+      )

--- a/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
@@ -1,15 +1,13 @@
 to: 4.14.9
-from: .*
+from: 4[.]13[.].*
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-
-  Disconnected clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
 - type: PromQL
   promql:
     promql: |
-      (
         group(cluster_operator_conditions{name="aro"})
         or
         0 * group(cluster_operator_conditions)
-      )


### PR DESCRIPTION
Adds conditional edges to the ARO Service for 4.14 versions. Because Systemd Boot Order puts ARO DNSMasq too late.