### PR TITLE
OSASINFRA-3500: blocked-edges: Declare OpenStackAvailabilityZoneOutOfRange

### DIFF
--- a/blocked-edges/4.14.29-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.14.29-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.14.29
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.14.30-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.14.30-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.14.30
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.15-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.15.15-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.15.15
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.16-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.15.16-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.15.16
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.17-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.15.17-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.15.17
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.18-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.15.18-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.15.18
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-ec.6-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-ec.6-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-ec.6
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-rc.0-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.0-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.0
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-rc.1-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.1-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.1
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-rc.2-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.2-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.2
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-rc.3-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.3-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.3
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.0-rc.4-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.4-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.4
+from: .*
+url: https://issues.redhat.com/browse/OSASINFRA-3500
+name: OpenStackAvailabilityZoneOutOfRange
+message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, type) (cluster_infrastructure_provider{_id="",type="OpenStack"})
+      or on (_id)
+      0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})


### PR DESCRIPTION
Regressions [landed][1] [in 4.16.0-ec.6][2], [4.15.15][3] and [4.14.29][3]. Generated by creating the 4.14.29 risk and copying it around with:

```console
$ for V in 4.14.30 4.15.{15,16,17,18} 4.16.0-{ec.6,rc.{0,1,2,3,4}}; do sed 's/4.14.29/${V}/' blocked-edges/4.14.29-OpenStackAvailabilityZoneOutOfRange.yaml > "blocked-edges/${V}-OpenStackAvailabilityZoneOutOfRange.yaml"; done
```

I've gone with `from: .*`, because I expect a fix to move back quickly, but we can revise to allow updates within affected releases (e.g. 4.15.15 -> 5.15.16) in follow up work, if we want those flowing while we wait for the fix.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.16.0-ec.6
[2]: https://issues.redhat.com/browse/OCPBUGS-30951
[3]: https://issues.redhat.com/browse/OSASINFRA-3500