### PR TITLE
`OpenStackAvailabilityZoneOutOfRange`: Fixed in 4.16.0-rc.5

### DIFF
--- a/blocked-edges/4.16.0-rc.4-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.16.0-rc.4-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,5 +1,6 @@
 to: 4.16.0-rc.4
 from: .*
+fixedIn: 4.16.0-rc.5
 url: https://issues.redhat.com/browse/OSASINFRA-3500
 name: OpenStackAvailabilityZoneOutOfRange
 message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.


### PR DESCRIPTION
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.16.0-rc.5 lists OCPBUGS-34882 as fixed.
