### PR TITLE
SDN-5055: Set up `OVNMulticastPacketLoss` for 4.16

### DIFF
--- a/blocked-edges/4.16.0-rc.0-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.0-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.0
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.1-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.1-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.1
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.2-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.2-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.2
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.3-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.3-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.3
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.4-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.4-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.4
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.5-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.5-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.5
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.16.0-rc.6-OVNMulticastPacketLoss.yaml
+++ b/blocked-edges/4.16.0-rc.6-OVNMulticastPacketLoss.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0-rc.6
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/SDN-5055
+name: OVNMulticastPacketLoss
+message: Multicast communication fails when multicast receiver and clients run on the same node in clusters that use OVN networking. Clusters that do not use multicast communication are not affected.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
I have created rc0 manually and copied the rest with:

```
for rc in (seq 1 6)
        cp 4.16.0-rc.0-OVNMulticastPacketLoss.yaml 4.16.0-rc.$rc-OVNMulticastPacketLoss.yaml
        sed -i "s|4.16.0-rc.0|4.16.0-rc.$rc|" 4.16.0-rc.$rc-OVNMulticastPacketLoss.yaml
end
```

I have copied the OVN detection from some past OVN risks:

https://github.com/openshift/cincinnati-graph-data/blob/1d7976cc21c2ba338355d15a3afb1a35d5d0a252/blocked-edges/4.14.9-OVNInterConnectTransitionIPsec.yaml#L14C1-L16C70

But I'm not sure why the past risk are using a `-1` in that PromQL. I have tested the PromQL and it seems to behave as expected without the negative multiplication?

### Build02 which is now OVN

![image](https://github.com/openshift/cincinnati-graph-data/assets/712614/96d10265-0637-4a0d-9ecc-99073607aff9)

### ota-stage which is not OVN

![image](https://github.com/openshift/cincinnati-graph-data/assets/712614/04bb2819-1109-4cce-a6e4-dcd182c1e6f1)
