### PR TITLE
blocked-edges/4.14.31-ARODNSWrongBootSequence: Not fixed yet

### DIFF
--- a/blocked-edges/4.14.31-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.31-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.14.31
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)


### PR DESCRIPTION
[OCPBUGS-35300][1] is still `New` for 4.17.

[1]: https://issues.redhat.com/browse/OCPBUGS-35300