### PR TITLE
blocked-edges/4.15.18-OpenStackAvailabilityZoneOutOfRange: Fixed in 4.15.19

### DIFF
--- a/blocked-edges/4.15.18-OpenStackAvailabilityZoneOutOfRange.yaml
+++ b/blocked-edges/4.15.18-OpenStackAvailabilityZoneOutOfRange.yaml
@@ -1,5 +1,6 @@
 to: 4.15.18
 from: .*
+fixedIn: 4.15.19
 url: https://issues.redhat.com/browse/OSASINFRA-3500
 name: OpenStackAvailabilityZoneOutOfRange
 message: OpenStack clusters with more compute availability zones than storage availability zones can lose the ability to provision or deprovision Cinder CSI volumes.


### PR DESCRIPTION
[4.15.19][1] contains [OCPBUGS-34927][2].

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.19
[2]: https://issues.redhat.com/browse/OCPBUGS-34927