### PR TITLE
extend ARODNSWrongBootSequence and mark TechPreviewSignatureStoresInDefault as fixed

### DIFF
--- a/blocked-edges/4.14.32-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.32-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.14.32
+from: 4[.]13[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.17.0-ec.0-TechPreviewSignatureStoresInDefault.yaml
+++ b/blocked-edges/4.17.0-ec.0-TechPreviewSignatureStoresInDefault.yaml
@@ -1,5 +1,6 @@
 to: 4.17.0-ec.0
 from: .*
+fixedIn: 4.17.0-ec.1
 name: TechPreviewSignatureStoresInDefault
 url: https://issues.redhat.com/browse/OTA-1297
 message: Standalone clusters in the default feature set will fail to verify signatures when asked to update out to later releases.


### PR DESCRIPTION
1. **TechPreviewSignatureStoresInDefault** fixed in 4.17.0-ec.1

        **OCPBUGS-35236**: Revert: Add support for Custom Certificate Authorities
        for custom signature stores”
        https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.17.0-ec.1


2. **ARODNSWrongBootSequence** 
          OCPBUGS-35300 has merged in release 4.14 but missed 4.14.32
          https://github.com/openshift/machine-config-operator/pull/4456
          https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2024-07-05-145251?from=4.14.32
