### PR TITLE
blocked-edges/4.13.7+: Declare OldBootImagesMissingOSReleaseRHELVersion 

### DIFF
--- a/blocked-edges/4.13.10-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.10-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.10
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.11-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.11-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.11
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.12-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.12-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.12
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.13-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.13-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.13
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.14-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.14-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.14
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.15-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.15-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.15
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.17-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.17-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.17
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.18-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.18-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.18
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.19-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.19-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.19
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.21-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.21-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.21
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.22-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.22-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.22
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.23-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.23-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.23
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.24-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.24-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.24
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.25-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.25-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.25
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.26-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.26-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.26
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.27-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.27-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.27
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.28-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.28-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.28
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.29-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.29-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.29
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.30-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.30-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.30
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.31-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.31-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.31
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.32-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.32-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.32
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.33-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.33-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.33
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.34-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.34-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.34
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.35-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.35-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.35
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.36-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.36-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.36
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.37-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.37-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.37
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.38-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.38-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.38
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.39-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.39-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.39
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.40-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.40-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.40
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.41-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.41-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.41
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.42-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.42-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.42
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.43-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.43-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.43
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.44-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.44-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.44
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.7-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.7-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.7
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.8-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.8-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.8
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.13.9-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.13.9-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.13.9
+from: 4[.]12[.].*|4[.]13[.][0-6][+].*$
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")


### PR DESCRIPTION
Machine boot images from 4.1 and 4.2 are not compatible with some 4.13 and later
OpenShift releases, and machines created with them will fail to become nodes.  This
risk does not apply if a cluster was installed as version 4.3 or later, or otherwise
uses 4.3 or later boot images.

clusters originally installed with OCP 4.1 and 4.2 and upgraded to 4.13.7+,
4.14 or later version are impacted.

Not declaring risks for 4.13.x -> 4.14.x because of z floor bumping.

Created 4.13.7 manually and copied risk for other edges
```shell 
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=fast-4.13' | jq -r '.nodes[].version' | grep '^4[.]13[.]' | grep -v '^4[.]13[.][0-7]$' | while read V; do sed "s/4[.]13[.]7/${V}/g" blocked-edges/4.13.7-OldBootImagesMissingOSReleaseRHELVersion.yaml > "blocked-edges/${V}-OldBootImagesMissingOSReleaseRHELVersion.yaml"; done
```