### PR TITLE
API-1819: blocked-edges/4.16.*-ServiceAccountContentionSecretLeak: Declare risk

### DIFF
--- a/blocked-edges/4.16.0-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.0-rc.3-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-rc.3-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0-rc.3
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.0-rc.4-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-rc.4-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0-rc.4
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.0-rc.5-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-rc.5-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0-rc.5
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.0-rc.6-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-rc.6-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0-rc.6
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.0-rc.9-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.0-rc.9-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.0-rc.9
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.1-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.1-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.1
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.2-ServiceAccountContentionSecretLeak.yaml
+++ b/blocked-edges/4.16.2-ServiceAccountContentionSecretLeak.yaml
@@ -1,0 +1,8 @@
+to: 4.16.2
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretLeak
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret leaks, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always


### PR DESCRIPTION
The regression came in via [OCPBUGS-33600][1], landing [in rc.3][2].  I wrote the 4.16.0 risk by hand, and copied it out to the other 4.16 (by excluding Engineering Candidates and the first few Release Candidates) with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]' | grep -v '^4[.]16[.]0$\|-ec[.]\|-rc[.][0-2]' | while read VERSION; do sed "s/4.16.0/${VERSION}/" blocked-edges/4.16.0-ServiceAccountContentionSecretLeak.yaml > "blocked-edges/${VERSION}-ServiceAccountContentionSecretLeak.yaml"; done
```

0cc6e3c475 (#5490)'s `PreRelease` risks mean we don't need to bother with "but what about clusters on rc.0 updating into 4.16.0?" unless we want to protect clusters that are already (and still) running those very-prerelease versions.  I'm not worrying about them for now.

[1]: https://issues.redhat.com/browse/OCPBUGS-33600
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.16.0-rc.3