### PR TITLE
API-1819: blocked-edges/4.16.3-ServiceAccountContentionSecretCreation: Not fixed yet

### DIFF
--- a/blocked-edges/4.16.3-ServiceAccountContentionSecretCreation.yaml
+++ b/blocked-edges/4.16.3-ServiceAccountContentionSecretCreation.yaml
@@ -1,0 +1,8 @@
+to: 4.16.3
+from: 4[.]15[.].*
+url: https://issues.redhat.com/browse/API-1819
+name: ServiceAccountContentionSecretCreation
+message: |-
+  Controllers that remove annotations from ServiceAccounts can trigger Secret creation, and unbounded Secret growth may eventually destabilize etcd and cause Kube API server disruption.
+matchingRules:
+- type: Always


### PR DESCRIPTION
[OCPBUGS-36862][1] is `POST` for 4.16.

[1]: https://issues.redhat.com/browse/OCPBUGS-36862