### PR TITLE
blocked-edges/4.13.25+-ARODNSWrongBootSequence: Declare risk

### DIFF
--- a/blocked-edges/4.13.25-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.25-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.25
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.26-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.26-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.26
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.27-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.27-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.27
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.28-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.28-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.28
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.29-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.29-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.29
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.30-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.30-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.30
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.31-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.31-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.31
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.32-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.32-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.32
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.33-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.33-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.33
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.34-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.34-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.34
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.35-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.35-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.35
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.36-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.36-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.36
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.37-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.37-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.37
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.38-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.38-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.38
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.39-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.39-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.39
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.40-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.40-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.40
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.41-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.41-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.41
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.42-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.42-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.42
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.43-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.43-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.43
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.44-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.44-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.44
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)

--- a/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.45
+from: 4[.]12[.].*
+url: https://issues.redhat.com/browse/OCPBUGS-35300
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(cluster_operator_conditions{name="aro"})
+        or
+        0 * group(cluster_operator_conditions)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-35300 remains an issue for clusters after 4.13.25.