### PR TITLE
MCO-1212: blocked-edges/4.16.{0,1,2}: Re-declare `OldBootImagesMissingOSReleaseRHELVersion`

### DIFF
--- a/blocked-edges/4.16.0-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.0-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.16.0
+from: 4[.]15[.]*
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.16 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.16.1-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.1-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,12 @@
+to: 4.16.1
+from: 4[.]15[.]*
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.16 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")

--- a/blocked-edges/4.16.2-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.2-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,0 +1,13 @@
+to: 4.16.2
+from: 4[.]15[.]*
+fixedIn: 4.16.3
+url: https://issues.redhat.com/browse/MCO-1212
+name: OldBootImagesMissingOSReleaseRHELVersion
+message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.16 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")


### PR DESCRIPTION
Originally declared for 4.13.7+ in https://github.com/openshift/cincinnati-graph-data/pull/5528 and then reverted in https://github.com/openshift/cincinnati-graph-data/pull/5539 because we discovered the versions are not actually affected. We confirmed the exposure for 4.16.* and the fix went into 4.16.3 ([OCPBUGS-36330](https://issues.redhat.com/browse/OCPBUGS-36330)) so declaring just for the three earlier versions.

Copied one file from the original #5528, manually adjusted for 4.16.0, then copied with

```
for patch in 1 2
    cp blocked-edges/4.16.0-OldBootImagesMissingOSReleaseRHELVersion.yaml blocked-edges/4.16.$patch-OldBootImagesMissingOSReleaseRHELVersion.yaml
    sed -i "s|to: 4.16.0|to: 4.16.$patch|" blocked-edges/4.16.$patch-OldBootImagesMissingOSReleaseRHELVersion.yaml
end
```

Finally added a `fixedIn: 4.16.3` to the 4.16.2 file.