### PR TITLE
blocked-edges: fix typos in regexes

### DIFF
--- a/blocked-edges/4.15.0-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.0-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.0
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.10-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.10
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 fixedIn: 4.15.11
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState

--- a/blocked-edges/4.15.2-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.2-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.2
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.3-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.3-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.3
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.5-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.5-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.5
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.6-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.6-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.6
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.7-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.7-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.7
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.8-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.8-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.8
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.15.9-OLMOperatorsInFailedState.yaml
+++ b/blocked-edges/4.15.9-OLMOperatorsInFailedState.yaml
@@ -1,5 +1,5 @@
 to: 4.15.9
-from: 4[.]14[.]*
+from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/OPRUN-3267
 name: OLMOperatorsInFailedState
 message: |-

--- a/blocked-edges/4.16.0-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.0-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,5 +1,5 @@
 to: 4.16.0
-from: 4[.]15[.]*
+from: 4[.]15[.].*
 url: https://issues.redhat.com/browse/MCO-1212
 name: OldBootImagesMissingOSReleaseRHELVersion
 message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.16 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.

--- a/blocked-edges/4.16.1-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.1-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,5 +1,5 @@
 to: 4.16.1
-from: 4[.]15[.]*
+from: 4[.]15[.].*
 url: https://issues.redhat.com/browse/MCO-1212
 name: OldBootImagesMissingOSReleaseRHELVersion
 message: Machine boot images from 4.1 and 4.2 are not compatible with some 4.16 and later OpenShift releases, and machines created with them will fail to become nodes.  This risk does not apply if a cluster was installed as version 4.3 or later, or otherwise uses 4.3 or later boot images.

--- a/blocked-edges/4.16.2-OldBootImagesMissingOSReleaseRHELVersion.yaml
+++ b/blocked-edges/4.16.2-OldBootImagesMissingOSReleaseRHELVersion.yaml
@@ -1,5 +1,5 @@
 to: 4.16.2
-from: 4[.]15[.]*
+from: 4[.]15[.].*
 fixedIn: 4.16.3
 url: https://issues.redhat.com/browse/MCO-1212
 name: OldBootImagesMissingOSReleaseRHELVersion


### PR DESCRIPTION
Trevor noticed we sometimes have `4[.]X[.]*` instead of `4[.]X[.].*`. The former would capture multiple dots where our intent is to capture a single dot followed by anything (usually patch numbers). It happens to work because we match on substrings, but fixed regexes express our intent better and are more readable for everyone.

Edited with:

```
sed -E -i -e 's|4\[\.\]([0-9]*)\[\.\]\*|4[.]\1[.].*|' blocked-edges/*
```