### PR TITLE
`ServiceAccountContentionSecretCreation`: Fixed in 4.16.4

### DIFF
--- a/blocked-edges/4.16.3-ServiceAccountContentionSecretCreation.yaml
+++ b/blocked-edges/4.16.3-ServiceAccountContentionSecretCreation.yaml
@@ -1,5 +1,6 @@
 to: 4.16.3
 from: 4[.]15[.].*
+fixedIn: 4.16.4
 url: https://issues.redhat.com/browse/API-1819
 name: ServiceAccountContentionSecretCreation
 message: |-


### PR DESCRIPTION
OCBUGS-36862 listed as fixed in https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.16.4
