### PR TITLE
OVNIPsecPausedMCPConnectivity extend to 4.15.23

### DIFF
--- a/blocked-edges/4.15.0-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.0-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.0
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.1-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.1-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.1
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.10-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.10-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.10
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.11-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.11-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.11
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.12-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.12-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.12
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.13-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.13-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.13
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.14-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.14-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.14
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.15-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.15-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.15
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.16-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.16-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.16
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.17-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.17-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.17
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.18-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.18-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.18
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.19-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.19-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.19
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.2-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.2-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.2
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.20-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.20-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.20
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.21-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.21-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.21
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.22-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.22-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.22
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.23-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.23-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,0 +1,20 @@
+to: 4.15.23
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5146
+name: OVNIPsecPausedMCPConnectivity
+message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            (
+              group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+              or on (_id)
+              0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+            ) and on (_id) (
+              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+              and on (_id)
+              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
+            )
+            or on (_id)
+            0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.3-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.3-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.3
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.4-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.4-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.4
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.5-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.5-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.5
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.6-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.6-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.6
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.7-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.7-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.7
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.8-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.8-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.8
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:

--- a/blocked-edges/4.15.9-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.9-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,6 +1,6 @@
 to: 4.15.9
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5145
+url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
 matchingRules:


### PR DESCRIPTION
**`OVNIPsecPausedMCPConnectivity`: Fix card name to [SDN-5146](https://issues.redhat.com//browse/SDN-5146)**

[SDN-5145](https://issues.redhat.com/browse/SDN-5145) is not the impact statement card, [SDN-5146](https://issues.redhat.com/browse/SDN-5146) is

---
**`OVNIPsecPausedMCPConnectivity`: Extend to 4.15.23**

[OCPBUGS-37205](https://issues.redhat.com/browse/OCPBUGS-37205) is still in POST

