### PR TITLE
`ARODNSWrongBootSequence`: Fix in 4.13.26

### DIFF
--- a/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
@@ -1,5 +1,6 @@
 to: 4.13.45
 from: 4[.]12[.].*
+fixedIn: 4.13.46
 url: https://issues.redhat.com/browse/OCPBUGS-35300
 name: ARODNSWrongBootSequence
 message: |-


### PR DESCRIPTION
[OCPBUGS-37160](https://issues.redhat.com/browse/OCPBUGS-37160) is fixed in https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.13.46
