### PR TITLE
`OVNIPsecPausedMCPConnectivity`: Extend to 4.15.24

### DIFF
--- a/blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,0 +1,20 @@
+to: 4.15.24
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5146
+name: OVNIPsecPausedMCPConnectivity
+message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            (
+              group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+              or on (_id)
+              0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+            ) and on (_id) (
+              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+              and on (_id)
+              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
+            )
+            or on (_id)
+            0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
Release controller says [4.15.24](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.24) was created from 4.15.0-0.nightly-2024-07-24-150754, the [fix](https://github.com/openshift/cluster-network-operator/pull/2439) for [OCPBUGS-37205](https://issues.redhat.com/browse/OCPBUGS-37205) was included in 4.15.0-0.nightly-2024-07-25-041013

=> extending to 4.15.24
