### PR TITLE
SDN-5146: blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity: Fixed in 4.15.25

### DIFF
--- a/blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,5 +1,6 @@
 to: 4.15.24
 from: 4[.]14[.].*
+fixedIn: 4.15.25
 url: https://issues.redhat.com/browse/SDN-5146
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.


### PR DESCRIPTION
[4.15.25][1] includes [OCPBUGS-37205][2], which is Verified with that single pull request: openshift/cluster-network-operator#2439

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.15.25
[2]: https://issues.redhat.com/browse/OCPBUGS-37205
