### PR TITLE
HOSTEDCP-1849: blocked-edges/4.15-HyperShiftKubeAPIPort443: Declare risk

### DIFF
--- a/blocked-edges/4.15.17-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.17-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.17
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.18-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.18-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.18
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.19-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.19-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.19
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.20-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.20-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.20
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.21-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.21-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.21
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.22-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.22-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.22
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.23-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.23-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,12 @@
+to: 4.15.23
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.24-HyperShiftKubeAPIPort443.yaml
+++ b/blocked-edges/4.15.24-HyperShiftKubeAPIPort443.yaml
@@ -1,0 +1,13 @@
+to: 4.15.24
+from: ^4[.](14[.].*|15[.]([0-9]|1[0-6]))[+].*$
+fixedIn: 4.15.25
+name: HyperShiftKubeAPIPort443
+url: https://issues.redhat.com/browse/HOSTEDCP-1849
+message: Hosted/HyperShift clusters where HostedCluster spec.networking.apiServer.port is 443 can have trouble with Pods on compute Nodes connecting to the internal Kubernetes API service via the service IP.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
Generated by writing the 4.15.17 risk by hand, and then copying it out to the other exposed releases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]\(1[8-9]\|2[0-4]\)$' | while read VERSION; do sed "s/4.15.17/${VERSION}/" blocked-edges/4.15.17-HyperShiftKubeAPIPort443.yaml > "blocked-edges/${VERSION}-HyperShiftKubeAPIPort443.yaml"; done
```

After which I manually declared `fixedIn` for [4.15.25][3], which included [OCPBUGS-37695][4].

I did not need to declare 4.16 risks, because f8316da482f60 (2024-06-06, #5352) landed early enough that no exposed 4.16 bake in update-recommendations from unexposed 4.15.(z<17) releases.  For example:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64 | grep 'Created\|Upgrades'
Created:        2024-06-25T20:17:15Z
  Upgrades: 4.15.18, 4.16.0-ec.1, 4.16.0-ec.2, 4.16.0-ec.3, 4.16.0-ec.4, 4.16.0-ec.5, 4.16.0-ec.6, 4.16.0-rc.0, 4.16.0-rc.1, 4.16.0-rc.2, 4.16.0-rc.3, 4.16.0-rc.4, 4.16.0-rc.5, 4.16.0-rc.6, 4.16.0-rc.9
```

[3]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.15.25
[4]: https://issues.redhat.com/browse/OCPBUGS-37695