### PR TITLE
NHE-1171: Declare SRIOVFailedToConfigureVF risk

### DIFF
--- a/blocked-edges/4.14.34-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.14.34-SRIOVFailedToConfigureVF.yaml
@@ -1,0 +1,13 @@
+to: 4.14.34
+from: ^4[.](13[.].*|14[.]([12]?[0-9]|3[0-3]))[+].*$
+url: https://issues.redhat.com/browse/NHE-1171
+name: SRIOVFailedToConfigureVF
+message: |-
+  On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"sriov-network-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})

--- a/blocked-edges/4.15.25-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.15.25-SRIOVFailedToConfigureVF.yaml
@@ -1,0 +1,13 @@
+to: 4.15.25
+from: ^4[.](14[.]([12]?[0-9]|3[0-3])|15[.]([1]?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/NHE-1171
+name: SRIOVFailedToConfigureVF
+message: |-
+  On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"sriov-network-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
The corresponding impact statement: https://issues.redhat.com/browse/NHE-1171

Versions affected at the moment:
- 4.14.34+
- 4.15.25+

Created `4.14.34-SRIOVFailedToConfigureVF.yaml` manually.

Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]\(3[5-9]\|4[0-9]\)$' | while read VERSION; do sed "s/4.14.34/${VERSION}/" blocked-edges/4.14.34-SRIOVFailedToConfigureVF.yaml > "blocked-edges/${VERSION}-SRIOVFailedToConfigureVF.yaml"; done
```

Created `4.15.25-SRIOVFailedToConfigureVF.yaml` manually.

Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]\(2[6-9]\|3[0-9]\)$' | while read VERSION; do sed "s/4.15.25/${VERSION}/" blocked-edges/4.15.25-SRIOVFailedToConfigureVF.yaml > "blocked-edges/${VERSION}-SRIOVFailedToConfigureVF.yaml"; done
```