### PR TITLE
Update ARODNSWrongBootSequence edges blocking

### DIFF
--- a/blocked-edges/4.13.25-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.25-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.25
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.26-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.26-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.26
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.27-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.27-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.27
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.28-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.28-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.28
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.29-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.29-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.29
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.30-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.30-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.30
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.31-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.31-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.31
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.33-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.33-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.33
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.34-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.34-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.34
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.35-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.35-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.35
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.36-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.36-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.36
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.37-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.37-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.37
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.38-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.38-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.38
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.39-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.39-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.39
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.40-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.40-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.40
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.41-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.41-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.41
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.42-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.42-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.42
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.43-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.43-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.43
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.44-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.44-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.13.44
 from: 4[.]12[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.45-ARODNSWrongBootSequence.yaml
@@ -1,7 +1,6 @@
 to: 4.13.45
 from: 4[.]12[.].*
-fixedIn: 4.13.46
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -9,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.13.46-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.46-ARODNSWrongBootSequence.yaml
@@ -1,4 +1,4 @@
-to: 4.13.32
+to: 4.13.46
 from: 4[.]12[.].*
 url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence

--- a/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.0-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.0
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.1-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.1
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.10-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.10
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.11-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.11
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.12-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.12
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.13-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.13
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.14-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.14
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.15-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.15
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.16-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.16
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.17-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.17
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.18-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.18
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.19-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.19
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.2-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.2
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.20-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.20
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.21-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.21
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.22-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.22
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.23-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.23
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.24-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.24
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.25-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.25
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.26-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.26
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.27-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.27
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.28-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.28-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.28
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.29-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.29-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.29
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{_id="",name="aro"})
         or
-        0 * group(cluster_operator_conditions)
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.3-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.3
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.30-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.30-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.30
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{_id="",name="aro"})
         or
-        0 * group(cluster_operator_conditions)
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.31-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.31-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.31
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{_id="",name="aro"})
         or
-        0 * group(cluster_operator_conditions)
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.32-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.32-ARODNSWrongBootSequence.yaml
@@ -1,7 +1,6 @@
 to: 4.14.32
 from: 4[.]13[.].*
-fixedIn: 4.14.33
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -9,6 +8,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_operator_conditions{name="aro"})
+        group(cluster_operator_conditions{_id="",name="aro"})
         or
-        0 * group(cluster_operator_conditions)
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.33-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.33-ARODNSWrongBootSequence.yaml
@@ -1,13 +1,13 @@
-to: 4.13.32
-from: 4[.]12[.].*
+to: 4.14.33
+from: 4[.]13[.].*
 url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(cluster_operator_conditions{_id="",name="aro"})
-      or
-      0 * group(cluster_operator_conditions{_id=""})
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.34-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.34-ARODNSWrongBootSequence.yaml
@@ -1,13 +1,13 @@
-to: 4.13.32
-from: 4[.]12[.].*
+to: 4.14.34
+from: 4[.]13[.].*
 url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
 matchingRules:
-- type: PromQL
-  promql:
-    promql: |
-      group(cluster_operator_conditions{_id="",name="aro"})
-      or
-      0 * group(cluster_operator_conditions{_id=""})
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.4-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.4
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.5-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.5
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.6-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.6
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.7-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.7
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.8-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.8
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.9-ARODNSWrongBootSequence.yaml
@@ -1,6 +1,6 @@
 to: 4.14.9
 from: 4[.]13[.].*
-url: https://issues.redhat.com/browse/OCPBUGS-35300
+url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: |-
   Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
@@ -8,6 +8,6 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-        group(cluster_operator_conditions{name="aro"})
-        or
-        0 * group(cluster_operator_conditions)
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
Adds new effected for ARO edges to the original bug. The believe fix has shown to not work and adds a new issue. Original PR was #5390