### PR TITLE
MCO-1257: Declare AzureDependencyLoopNotReady risk

### DIFF
--- a/blocked-edges/4.13.46-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.13.46-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.13.46
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.14.33-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.14.33-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.14.33
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.14.34-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.14.34-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.14.34
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.22-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.15.22-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.15.22
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.23-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.15.23-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.15.23
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.24-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.15.24-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.15.24
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.15.25-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.15.25-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.15.25
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.3-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.16.3-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.16.3
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.4-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.16.4-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.16.4
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.5-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.16.5-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.16.5
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})

--- a/blocked-edges/4.16.6-AzureDependencyLoopNotReady.yaml
+++ b/blocked-edges/4.16.6-AzureDependencyLoopNotReady.yaml
@@ -1,0 +1,13 @@
+to: 4.16.6
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureDependencyLoopNotReady
+message: |-
+  On Azure clusters, updated nodes will go to the NotReady state.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_infrastructure_provider{_id="",type="Azure"})
+      or
+      0 * group(cluster_infrastructure_provider{_id=""})


### PR DESCRIPTION
The corresponding impact statement: https://issues.redhat.com/browse/MCO-1257

Versions affected at the moment:
- 4.13.46+
- 4.14.33+
- 4.15.22+
- 4.16.3+

As the issues occur while updating to the affected versions, I have set the `from` field to contain all paths to the affected versions.

Created `4.13.46-AzureDependencyLoopNotReady.yaml` manually. Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.13&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]13[.]\(4[7-9]\|5[0-9]\)$' | while read VERSION; do sed "s/4.13.46/${VERSION}/" blocked-edges/4.13.46-AzureDependencyLoopNotReady.yaml > "blocked-edges/${VERSION}-AzureDependencyLoopNotReady"; done
```

Created `4.14.33-AzureDependencyLoopNotReady.yaml` manually. Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.]\(3[4-9]\|5[0-9]\)$' | while read VERSION; do sed "s/4.14.33/${VERSION}/" blocked-edges/4.14.33-AzureDependencyLoopNotReady.yaml > "blocked-edges/${VERSION}-AzureDependencyLoopNotReady.yaml"; done
```

Created `4.15.22-AzureDependencyLoopNotReady.yaml` manually. Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]\(2[3-9]\|3[0-9]\)$' | while read VERSION; do sed "s/4.15.22/${VERSION}/" blocked-edges/4.15.22-AzureDependencyLoopNotReady.yaml > "blocked-edges/${VERSION}-AzureDependencyLoopNotReady.yaml"; done
```

Created `4.16.3-AzureDependencyLoopNotReady.yaml` manually. Then run the following command for the next versions:
```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]\([4-9]\|1[0-9]\)$' | while read VERSION; do sed "s/4.16.3/${VERSION}/" blocked-edges/4.16.3-AzureDependencyLoopNotReady.yaml > "blocked-edges/${VERSION}-AzureDependencyLoopNotReady.yaml"; done
```