### PR TITLE
Block edges for ARO clusters with systemd dependency loops

### DIFF
--- a/blocked-edges/4.13.46-AROSystemDLooping.yaml
+++ b/blocked-edges/4.13.46-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.13.46
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.14.33-AROSystemDLooping.yaml
+++ b/blocked-edges/4.14.33-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.14.33
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.14.34-AROSystemDLooping.yaml
+++ b/blocked-edges/4.14.34-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.14.34
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.15.22-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.22-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.15.22
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.15.23-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.23-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.15.23
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.15.24-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.24-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.15.24
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.15.25-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.25-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.15.25
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.16.3-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.3-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.16.3
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.16.4-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.4-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.16.4
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.16.5-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.5-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.16.5
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.16.6-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.6-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.16.6
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )

--- a/blocked-edges/4.16.7-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.7-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.16.7
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      (
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/OCPBUGS-37534

Investigation is still ongoing to determine full impact for born in versions. Currently, ARO SRE is seeing 100% failure rate into versions with this code change listed above.