### PR TITLE
NHE-1171: SRIOVFailedToConfigureVF: Extend to 4.15.26

### DIFF
--- a/blocked-edges/4.15.26-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.15.26-SRIOVFailedToConfigureVF.yaml
@@ -1,0 +1,13 @@
+to: 4.15.26
+from: ^4[.](14[.]([12]?[0-9]|3[0-3])|15[.]([1]?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/NHE-1171
+name: SRIOVFailedToConfigureVF
+message: |-
+  On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"sriov-network-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
The [OCPBUGS-38090](https://issues.redhat.com/browse/OCPBUGS-38090) issue tracks the backport for the 4.15.z version.

The bug is in the state `NEW` as of the moment. Thus, I am extending the risk to 4.15.26.