### PR TITLE
NHE-1171: SRIOVFailedToConfigureVF: Include 4.16.7

### DIFF
--- a/blocked-edges/4.16.7-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.16.7-SRIOVFailedToConfigureVF.yaml
@@ -1,0 +1,13 @@
+to: 4.16.7
+from: ^4[.](15[.]([1]?[0-9]|2[0-4])|16[.][0-6])[+].*$
+url: https://issues.redhat.com/browse/NHE-1171
+name: SRIOVFailedToConfigureVF
+message: |-
+  On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"sriov-network-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
Corresponding impact statement https://issues.redhat.com/browse/NHE-1171

[OCPBUGS-38089](https://issues.redhat.com/browse/OCPBUGS-38089) tracks the backport for the 4.16.z version.

The 4.16.7 payload is affected.