### PR TITLE
Update AROSystemDLooping promql to have no errors

### DIFF
--- a/blocked-edges/4.13.46-AROSystemDLooping.yaml
+++ b/blocked-edges/4.13.46-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.14.33-AROSystemDLooping.yaml
+++ b/blocked-edges/4.14.33-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.14.34-AROSystemDLooping.yaml
+++ b/blocked-edges/4.14.34-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.15.22-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.22-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.15.23-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.23-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.15.24-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.24-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.15.25-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.25-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.16.3-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.3-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.16.4-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.4-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.16.5-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.5-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.16.6-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.6-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))

--- a/blocked-edges/4.16.7-AROSystemDLooping.yaml
+++ b/blocked-edges/4.16.7-AROSystemDLooping.yaml
@@ -14,7 +14,7 @@ matchingRules:
         label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
       ) 
       * on () group_left (name)
-      (
+      topk(1,
         group by (name) (cluster_operator_conditions{_id="",name="aro"})
         or
         0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))


### PR DESCRIPTION
Fixes small error seen in the promql in #5683 

Cluster born in 4.12 matching
![image](https://github.com/user-attachments/assets/30c6194f-b4bf-4a16-8304-dfa064ba7815)
