### PR TITLE
blocked-edges/4.15.26-AROSystemDLooping: Not fixed yet

### DIFF
--- a/blocked-edges/4.15.26-AROSystemDLooping.yaml
+++ b/blocked-edges/4.15.26-AROSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.15.26
+from: .*
+url: https://access.redhat.com/solutions/7082093
+name: AROSystemDLooping
+message: |-
+  ARO clusters created on 4.12.z and below are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing kublet and crio to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "yes, born in 4.12 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.]([0-9]|1[0-2])[.].*"}),"born_by_4_12", "no, born in 4.13 or later", "", "")
+      ) 
+      * on () group_left (name)
+      topk(1,
+        group by (name) (cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * topk(1, group by (name) (cluster_operator_conditions{_id=""}))
+      )


### PR DESCRIPTION
No machine-config changes [in 4.15.26][1].

[1]:https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.26