### PR TITLE
blocked-edges/4.15.27-SRIOVFailedToConfigureVF: Not fixed yet

### DIFF
--- a/blocked-edges/4.15.27-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.15.27-SRIOVFailedToConfigureVF.yaml
@@ -1,0 +1,13 @@
+to: 4.15.27
+from: ^4[.](14[.]([12]?[0-9]|3[0-3])|15[.]([1]?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/NHE-1171
+name: SRIOVFailedToConfigureVF
+message: |-
+  On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"sriov-network-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
Only metadata changes changes in [4.15.27][1].

[1]:https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.27