### PR TITLE
NO-JIRA: Add dhurta to cincinnati-graph-data-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,6 +6,7 @@ aliases:
     - LalatenduMohanty
     - PratikMahajan
     - petr-muller
+    - Davoska
   sre-approvers:
     - bennerv
     - cblecker


### PR DESCRIPTION
Add David Hurta (me) to the `cincinnati-graph-data-approvers` group.