### PR TITLE
MCO-1257: blocked-edges/4.13.46-AzureSystemDLooping: Declare Azure-scoped risk

### DIFF
--- a/blocked-edges/4.13.46-AzureSystemDLooping.yaml
+++ b/blocked-edges/4.13.46-AzureSystemDLooping.yaml
@@ -1,0 +1,21 @@
+to: 4.13.46
+from: .*
+url: https://issues.redhat.com/browse/MCO-1257
+name: AzureSystemDLooping
+message: |-
+  Azure clusters created on 4.(y<12) or 4.12.(z<54) are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing CRI-O and the kublet to never start on nodes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.](([0-9]|1[01])[.][0-9]*|12[.]([1-4]?[0-9]|5[0-3]))"}),"born_before_4_12_54", "yes, born in 4.11 or 4.12.53 or earlier", "", "")
+        or on ()
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.](([0-9]|1[01])[.][0-9]*|12[.]([1-4]?[0-9]|5[0-3]))"}),"born_before_4_12_54", "no, born in 4.12.54 or 4.13 or later", "", "")
+      )
+      * on () group_left (type)
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or on ()
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )


### PR DESCRIPTION
There is already an ARO-scoped AROSystemDLooping risk which has been evolving:

* 2183f0c284 (#5683).
* 2ef3ccd02f (#5693).
* 25b37ba861 (#5721).

But we hadn't seen that impact in 4.12.recent to 4.13.recent non-ARO Azure CI.  As we continued to test, the 4.12.54 [OCPBUGS-30823][1] change seems to be what's protecting clusters installed with 4.12.recent.  And [OCPBUGS-38295][2] is taking a fix back to 4.13.z that will allow the machine-config daemon to update units without spooking systemd with dependency cycles while the units are being updated.

[1]: https://issues.redhat.com/browse/OCPBUGS-30823
[2]: https://issues.redhat.com/browse/OCPBUGS-38295