### PR TITLE
Fixes shipped

### DIFF
--- a/blocked-edges/4.13.46-AzureSystemDLooping.yaml
+++ b/blocked-edges/4.13.46-AzureSystemDLooping.yaml
@@ -2,6 +2,7 @@ to: 4.13.46
 from: .*
 url: https://issues.redhat.com/browse/MCO-1257
 name: AzureSystemDLooping
+fixedIn: 4.13.48
 message: |-
   Azure clusters created on 4.(y<12) or 4.12.(z<54) are experiencing a bug where systemd detects a dependency loop. Systemd deletes these dependencies causing CRI-O and the kublet to never start on nodes.
 matchingRules:

--- a/blocked-edges/4.14.34-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.14.34-SRIOVFailedToConfigureVF.yaml
@@ -2,6 +2,7 @@ to: 4.14.34
 from: ^4[.](13[.].*|14[.]([12]?[0-9]|3[0-3]))[+].*$
 url: https://issues.redhat.com/browse/NHE-1171
 name: SRIOVFailedToConfigureVF
+fixedIn: 4.14.35
 message: |-
   On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
 matchingRules:

--- a/blocked-edges/4.15.27-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.15.27-SRIOVFailedToConfigureVF.yaml
@@ -2,6 +2,7 @@ to: 4.15.27
 from: ^4[.](14[.]([12]?[0-9]|3[0-3])|15[.]([1]?[0-9]|2[0-4]))[+].*$
 url: https://issues.redhat.com/browse/NHE-1171
 name: SRIOVFailedToConfigureVF
+fixedIn: 4.15.28
 message: |-
   On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
 matchingRules:

--- a/blocked-edges/4.16.7-SRIOVFailedToConfigureVF.yaml
+++ b/blocked-edges/4.16.7-SRIOVFailedToConfigureVF.yaml
@@ -2,6 +2,7 @@ to: 4.16.7
 from: ^4[.](15[.]([1]?[0-9]|2[0-4])|16[.][0-6])[+].*$
 url: https://issues.redhat.com/browse/NHE-1171
 name: SRIOVFailedToConfigureVF
+fixedIn: 4.16.8
 message: |-
   On clusters with the SR-IOV Network Operator installed and configured, pods with a secondary interface of SRI-OV VF will fail to create a pod sandbox and thus will not function.
 matchingRules:

--- a/build-suggestions/4.17.yaml
+++ b/build-suggestions/4.17.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.16.0
+  minor_min: 4.16.8
   minor_max: 4.16.9999
   minor_block_list: []
   z_min: 4.17.0-ec.0


### PR DESCRIPTION
AzureSystemDLooping fixed in 4.13.48
SRIOVFailedToConfigureVF fixed in 4.14.35, 4.15.28, 4.16.8

Require 4.16.8 so that fixes for OCPBUGS-38182 are present before upgrading to 4.17.