### PR TITLE
blocked-edges/4.14.35-ARODNSWrongBootSequence: Not fixed yet

### DIFF
--- a/blocked-edges/4.14.35-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.35-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.14.35
+from: 4[.]13[.].*
+url: https://access.redhat.com/solutions/7074686
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
The [OCPBUGS-35300][1] series [patched 4.14.33][2].  But the [OCPBUGS-37534][3] series [recently reverted that in 4.14][4].  But [4.14.35][5] has:

> Release 4.14.35 was created from registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-08-13-170824

which is too old to have the revert.  And doesn't seem like the revert would be grounds for declaring this fixed anyway.  I'll extend to unblock `candidate-*` membership, and the ARO folks can adjust if I'm misunderstanding.

[1]: https://issues.redhat.com/browse/OCPBUGS-35300
[2]: https://issues.redhat.com/browse/OCPBUGS-36593?focusedId=25141472&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25141472
[3]: https://issues.redhat.com/browse/OCPBUGS-37534
[4]: https://issues.redhat.com/browse/OCPBUGS-38371
[5]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.35