### PR TITLE
blocked-edges/4.13.48-ARODNSWrongBootSequence: Not fixed yet

### DIFF
--- a/blocked-edges/4.13.48-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.48-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.13.48
+from: 4[.]12[.].*
+url: https://access.redhat.com/solutions/7074686
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
Just like #5737 extend this for the time being, review later once it's clearer when this gets declared fixed.