### PR TITLE
MCO-1257: blocked-edges/4.13.46-*SystemDLooping: 4.13.48 fixes the looping

### DIFF
--- a/blocked-edges/4.13.46-AROSystemDLooping.yaml
+++ b/blocked-edges/4.13.46-AROSystemDLooping.yaml
@@ -1,5 +1,6 @@
 to: 4.13.46
 from: .*
+fixedIn: 4.13.48
 url: https://access.redhat.com/solutions/7082093
 name: AROSystemDLooping
 message: |-


### PR DESCRIPTION
[4.13.48][1] includes [OCPBUGS-38295][2], which avoids confusing systemd while multiple units are being adjusted.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.13.48
[2]: https://issues.redhat.com/browse/OCPBUGS-38295