### PR TITLE
HOSTEDCP-1941: blocked-edges/*HyperShiftNodePoolSkewBinaryDownload: Declare new risk for 4.15.(z>=23) and 4.16.(z>=4)

### DIFF
--- a/blocked-edges/4.15.23-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.23-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.23
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.24-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.24-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.24
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.25-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.25-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.25
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.26-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.26-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.26
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.27-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.27-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.27
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.28-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.28-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.28
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.29-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.29-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.29
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.30-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.30-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.15.30
+from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.15.30-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.15.30-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,5 +1,6 @@
 to: 4.15.30
 from: ^4[.](14[.].*|15[.](1?[0-9]|2[0-2]))[+].*$
+fixedIn: 4.15.31
 name: HyperShiftNodePoolSkewBinaryDownload
 url: https://issues.redhat.com/browse/HOSTEDCP-1941
 message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).

--- a/blocked-edges/4.16.10-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.10-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,5 +1,6 @@
 to: 4.16.10
 from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+fixedIn: 4.16.11
 name: HyperShiftNodePoolSkewBinaryDownload
 url: https://issues.redhat.com/browse/HOSTEDCP-1941
 message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).

--- a/blocked-edges/4.16.10-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.10-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.10
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.4-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.4-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.4
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.5-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.5-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.5
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.6-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.6-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.6
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.7-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.7-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.7
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.8-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.8-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.8
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.16.9-HyperShiftNodePoolSkewBinaryDownload.yaml
+++ b/blocked-edges/4.16.9-HyperShiftNodePoolSkewBinaryDownload.yaml
@@ -1,0 +1,12 @@
+to: 4.16.9
+from: ^4[.](15[.](1?[0-9]|2[0-2])|16[.][0-3])[+].*$
+name: HyperShiftNodePoolSkewBinaryDownload
+url: https://issues.redhat.com/browse/HOSTEDCP-1941
+message: Hosted/HyperShift clusters where HostedCluster is on an exposed release can fail to create new nodes for NodePools on 4.14.(z<34) and 4.15.(z<23).
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
Generated by writing the 4.15.23 an 4.16.4 files by hand and copying them out with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]\(2[4-9]\|[3-9][0-9]\)$' | while read VERSION; do sed "s/4.15.23/${VERSION}/" blocked-edges/4.15.23-HyperShiftNodePoolSkewBinaryDownload.yaml > "blocked-edges/${VERSION}-HyperShiftNodePoolSkewBinaryDownload.yaml"; done
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]\([5-9]\|[1-9][0-9]\)$' | while read VERSION; do sed "s/4.16.4/${VERSION}/" blocked-edges/4.16.4-HyperShiftNodePoolSkewBinaryDownload.yaml > "blocked-edges/${VERSION}-HyperShiftNodePoolSkewBinaryDownload.yaml"; done
```

I'm not aware of PromQL for "what version NodePools are attached to this cluster?", but if that PromQL does exist, it would likely reduce the scope of matching clusters considerably.