### PR TITLE
blocked-edges/4.14.36-ARODNSWrongBootSequence: Extend to 4.14.36

### DIFF
--- a/blocked-edges/4.14.36-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.36-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.14.36
+from: 4[.]13[.].*
+url: https://access.redhat.com/solutions/7074686
+name: ARODNSWrongBootSequence
+message: |-
+  Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_operator_conditions{_id="",name="aro"})
+        or
+        0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
Pretty much blindly, and the ARO folks can update whenever they want to declare this fixed.