### PR TITLE
blocked-edges/4.13.51-ARODNSWrongBootSequence: autoExtend on ARO-9234

### DIFF
--- a/blocked-edges/4.13.51-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.13.51-ARODNSWrongBootSequence.yaml
@@ -1,5 +1,6 @@
 to: 4.13.51
 from: 4[.]12[.].*
+autoExtend: https://issues.redhat.com/browse/ARO-9234
 url: https://access.redhat.com/solutions/7074686
 name: ARODNSWrongBootSequence
 message: Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade


### PR DESCRIPTION
I'd missed 4.13.51 in ef681855340b (#6044).