### PR TITLE
WIP: SDN-5377: blocked-edges/4.14.*-OVNTransitSwitchSubset: Declare 4.13-to-4.14 risk

### DIFF
--- a/blocked-edges/4.14.0-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.0-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.0
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.1-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.1-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.1
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.10-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.10-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.10
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.11-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.11-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.11
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.12-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.12-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.12
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.13-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.13-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.13
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.14-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.14-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.14
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.15-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.15-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.15
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.16-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.16-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.16
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.17-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.17-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.17
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.18-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.18-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.18
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.19-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.19-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.19
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.2-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.2-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.2
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.20-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.20-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.20
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.21-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.21-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.21
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.22-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.22-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.22
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.23-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.23-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.23
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.24-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.24-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.24
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.25-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.25-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.25
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.26-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.26-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.26
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.27-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.27-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.27
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.28-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.28-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.28
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.29-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.29-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.29
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.3-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.3-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.3
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.30-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.30-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.30
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.31-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.31-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.31
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.32-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.32-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.32
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.33-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.33-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.33
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.34-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.34-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.34
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.35-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.35-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.35
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.36-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.36-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.36
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.37-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.37-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.37
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.38-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.38-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.38
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.4-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.4-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.4
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.5-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.5-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.5
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.6-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.6-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.6
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.7-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.7-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.7
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.8-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.8-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.8
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )

--- a/blocked-edges/4.14.9-OVNTransitSwitchSubset.yaml
+++ b/blocked-edges/4.14.9-OVNTransitSwitchSubset.yaml
@@ -1,0 +1,16 @@
+to: 4.14.9
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/OCPBUGS-42713
+url: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
+name: OVNTransitSwitchSubset
+message: |-
+  4.13 OVN clusters whose clusterNetwork uses 100.88.0.0/16 may experience network disruption until their internalJoinSubnet or internalTransitSwitchSubnet is moved to a distinct subnet.
+matchingRules:
+- type: PromQL
+  promql:
+    promql:
+      (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+        or on ()
+        0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+      )


### PR DESCRIPTION
The risk is briefly covered in the linked [release note][0] [since 2024-09-18][1].

I'm setting `autoExtend`, because unless some future 4.13.z addresses this (unlikely, with [4.13.z going end-of-life on 2014-11-27][2]), or a future 4.14.z addresses this, we'll likely have to continue to carry it forward to every 4.13-to-4.14 update we ever support.  This will make life more difficult for customers who traditionally wait until there's an update we recommend unconditionally.  All OVN cluster administrators on 4.13 will need to read through the risk message and linked docs, and decide for themselves whether they are comfortable accepting the risk and updating to 4.14.

Generated by writing the 4.14.0 risk by hand, and then copying out to all existing 4.14.z update targets with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14[.][0-9]*$' | grep -v 4.14.0 | while read VERSION; do sed "s/4.14.0/${VERSION}/" blocked-edges/4.14.0-OVNTransitSwitchSubset.yaml > "blocked-edges/${VERSION}-OVNTransitSwitchSubset.yaml"; done
```

[0]: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-OVN-IC-IP-range
[1]: https://github.com/openshift/openshift-docs/pull/81666#event-14307870553
[2]: https://access.redhat.com/support/policy/updates/openshift#dates