### PR TITLE
blocked-edges/4.14.39-ARODNSWrongBootSequence: Auto-extend to 4.14.39

### DIFF
--- a/blocked-edges/4.14.39-ARODNSWrongBootSequence.yaml
+++ b/blocked-edges/4.14.39-ARODNSWrongBootSequence.yaml
@@ -1,0 +1,13 @@
+to: 4.14.39
+from: 4[.]13[.].*
+autoExtend: https://issues.redhat.com/browse/ARO-9234
+url: https://access.redhat.com/solutions/7074686
+name: ARODNSWrongBootSequence
+message: Disconnected ARO clusters or clusters with a UDR 0.0.0.0/0 route definition that are blocking the ARO ACR and quay, are not be able to add or replace nodes after an upgrade
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            group(cluster_operator_conditions{_id="",name="aro"})
+            or
+            0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
Management deferred to https://issues.redhat.com/browse/ARO-9234
