### PR TITLE
SDN-5422: Set up OVNIPsecConnectivity for 4.14 -> 4.15 paths

### DIFF
--- a/blocked-edges/4.15.0-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.0-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.0
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.1-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.1-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.1
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.10-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.10-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.10
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.11-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.11-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.11
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.12-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.12-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.12
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.13-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.13-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.13
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.14-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.14-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.14
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.15-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.15-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.15
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.16-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.16-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.16
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.17-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.17-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.17
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.18-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.18-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.18
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.19-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.19-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.19
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.2-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.2-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.2
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.20-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.20-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.20
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.21-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.21-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.21
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.22-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.22-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.22
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.23-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.23-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.23
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.24-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.24-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.24
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.25-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.25-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.25
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.26-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.26-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.26
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.27-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.27-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.27
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.3-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.3-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.3
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.4-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.4-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.4
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.5-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.5-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.5
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.6-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.6-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.6
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.7-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.7-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.7
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.8-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.8-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.8
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.9-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.9-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.9
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
Stole the query from https://github.com/openshift/cincinnati-graph-data/pull/5588 and removed the part for "multiple worker MachineConfigPools".

OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.

Created a 4.15.0 file manually then created the rest with:

```bash
for patch in $(seq 1 27); do
  cp blocked-edges/4.15.0-OVNIPsecConnectivity.yaml blocked-edges/4.15.$patch-OVNIPsecConnectivity.yaml
  gsed -i "s|to: 4.15.0|to: 4.15.$patch|" blocked-edges/4.15.$patch-OVNIPsecConnectivity.yaml
done
```