### PR TITLE
Extend `OVNIPsecConnectivity` risk to 4.15.37

### DIFF
--- a/blocked-edges/4.15.37-OVNIPsecConnectivity.yaml
+++ b/blocked-edges/4.15.37-OVNIPsecConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.15.37
+from: 4[.]14[.].*
+url: https://issues.redhat.com/browse/SDN-5422
+name: OVNIPsecConnectivity
+message: OVN clusters with enabled IPsec may lose pod to pod communication between a set of nodes which may impact overall functionality of the cluster and even cause production outage.
+matchingRules:
+    - type: PromQL
+      promql:
+        promql: |
+            (
+              group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+              or on (_id)
+              0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+            ) and on (_id) (
+              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+            )
+            or on (_id)
+            0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
The underlying bug https://issues.redhat.com/browse/OCPBUGS-41823 of https://issues.redhat.com/browse/SDN-5422 is currently not fixed (with the "ASSIGNED" state). Thus we extend the risk to 4.15.37.


Follow up https://redhat-internal.slack.com/archives/C02MX20TV24/p1730130810267269

```bash
$ go run ./cmd/graph-extend-or-fix --do extend --graph-repository-path ~/repo/openshift/cincinnati-graph-data --jira-bearer-token-file ~/.jira-token --last 4.15.36 --new 4.15.37 --risk OVNIPsecConnectivity
INFO[0000] Obtaining (likely) impact statement card SDN-5422 and process its linked bugs
SDN-5422 OCPBUGS-41823 OCPBUGS-43323 OCPBUGS-43498
INFO[0002] Found 3 bug cards
OCPBUGS-43323                   ON_QA           [Docs] IPsec upgrade from 4.14 to 4.15 pods losing connectivity
OCPBUGS-43498           4.18.0  New             Pin rhcos ipsec libreswan package to 4.5-1.el9 for 4.15 and above
OCPBUGS-41823   x               ASSIGNED        After upgrading a full ipsec cluster to 4.15.25 pods on nodes will lose the ability to communicate with other pods on different nodes intermittently
INFO[0002] Extending `OVNIPsecConnectivity` risk to 4.15.37

$ git remote -v | head -n 1
origin  https://github.com/petr-muller/ota.git (fetch)
```