### PR TITLE
AUTH-550: Set up OAuthServerDownIfSpaceInIDPName for 4.16 -> 4.17 paths

### DIFF
--- a/blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.0-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.0-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.0
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.1-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.1-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.1
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.2-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.2-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.2
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.3-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.3-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.3
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.5-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.5-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.5
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.0-rc.6-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.6-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.0-rc.6
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.1-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.1-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.1
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.2-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.2-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.2
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,0 +1,8 @@
+to: 4.17.3
+from: 4[.]16[.].*
+url: https://issues.redhat.com/browse/AUTH-550
+name: OAuthServerDownIfSpaceInIDPName
+message: |-
+  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Manual edited `blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml`
and generated others by

```bash
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.17&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]17' | sort -V | grep -v '^4.17.0$' | grep -v '^4.17.0-ec' | while read VERSION; do sed "s/4.17.0/${VERSION}/" blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml > "blocked-edges/${VERSION}-OAuthServerDownIfSpaceInIDPName.yaml"; done
```