### PR TITLE
AUTH-550: Set up OAuthServerDownIfSpaceInIDPName for 4.16 -> 4.17 paths (more cases)

### DIFF
--- a/blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.0-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.0-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.1-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.1-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.2-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.2-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.3-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.3-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.5-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.5-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.0-rc.6-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.0-rc.6-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.1-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.1-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.2-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.2-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
@@ -3,6 +3,10 @@ from: 4[.]16[.].*
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-
-  The OAuth server may crash-loop if there are two or more identity providers configured on the cluster with type htpasswd, keystone, ldap, or basic-authentication and at least one of their names contains a white space.
+  The OAuth server may crash-loop if either of the following conditions is met:
+
+  * At least two password-based IDPs have been configured in the OAuth configuration custom resource, and one of them contains a white space in its name. If the "kube:admin" user has not been removed from a cluster, then this already counts as an IDP. Currently, the supported password-based IDPs are HTPasswd, Keystone, LDAP, and BasicAuth.
+
+  * At least one OAuth IDP with a white space in its name has been configured. Currently, the supported OAuth IDPs are OpenID, GitHub, GitLab and Google.
 matchingRules:
 - type: Always


### PR DESCRIPTION
[OCPBUGS-44118](https://issues.redhat.com/browse/OCPBUGS-44118) has been filed and it identifies more affected clusters.

Both [OCPBUGS-43587](https://issues.redhat.com/browse/OCPBUGS-43587) and [OCPBUGS-44118](https://issues.redhat.com/browse/OCPBUGS-44118) shares the same symptom on the cluster, workaround, and fix.

So we use [AUTH-550](https://issues.redhat.com//browse/AUTH-550) as the assessment for both bugs.