### PR TITLE
AUTH-550: blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName: Fixed in 4.17.4

### DIFF
--- a/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
+++ b/blocked-edges/4.17.3-OAuthServerDownIfSpaceInIDPName.yaml
@@ -1,5 +1,6 @@
 to: 4.17.3
 from: 4[.]16[.].*
+fixedIn: 4.17.4
 url: https://issues.redhat.com/browse/AUTH-550
 name: OAuthServerDownIfSpaceInIDPName
 message: |-


### PR DESCRIPTION
[4.17.4][1] has both [OCPBUGS-43587][2] and [OCPBUGS-44118][3].

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.17.4
[2]: https://issues.redhat.com/browse/OCPBUGS-43587
[3]: https://issues.redhat.com/browse/OCPBUGS-44118