### PR TITLE
SDN-5477: blocked-edges/4.14.40-OVNlibreswan: "is IPsec enabled?" PromQL

### DIFF
--- a/blocked-edges/4.14.40-OVNlibreswan.yaml
+++ b/blocked-edges/4.14.40-OVNlibreswan.yaml
@@ -7,6 +7,14 @@ matchingRules:
 - type: PromQL
   promql:
     promql: |
-      group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-      or on ()
+      group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled (4.14)", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled (4.14)", "", ""))
+      or on (_id) 
+      group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled (4.13)", "", "") == 1)
+      or on (_id)
+      0 * group by (ipsec) (label_replace(max_over_time(ovnkube_master_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled (4.13)", "", ""))
+      or on (_id)
+      -1 * group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
Checking [4.13 OVN CI][1] in [PromeCIeus][2]:

```
group by (__name__) ({__name__=~".*ipsec.*"})
```

only turns up `ovnkube_master_ipsec_enabled`, which we'd used previously, e.g. in 279798919e (#5334).  But checking [4.14 OVN CI][3], that same `__name__` search turns up:

* `openshift:openshift_network_operator_ipsec_state:info`,
* `openshift_network_operator_ipsec_state`, and
* `ovnkube_controller_ipsec_enabled`,

but not 4.13's `ovnkube_master_ipsec_enabled`.  The PromQL I'm adding here looks for the 4.14 `ovnkube_controller_ipsec_enabled`, if it can't find that it falls back to the 4.13 `ovnkube_master_ipsec_enabled`, and if it can't find that it falls back to the Kube-API standard `apiserver_storage_objects` we'd been using before for "am I OVN or not?".

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.13-e2e-azure-ovn-upgrade/1851915878388469760
[2]: https://promecieus.dptools.openshift.org/
[3]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-serial/1851940515621113856