### PR TITLE
SDN-5477: blocked-edges/4.14.40-OVNlibreswan: Fixed in 4.14.41

### DIFF
--- a/blocked-edges/4.14.40-OVNlibreswan.yaml
+++ b/blocked-edges/4.14.40-OVNlibreswan.yaml
@@ -1,5 +1,6 @@
 to: 4.14.40
 from: .*
+fixedIn: 4.14.41
 url: https://issues.redhat.com/browse/SDN-5477
 name: OVNlibreswan
 message: OVN clusters with IPsec enabled will regress on some libreswan CVEs.


### PR DESCRIPTION
[4.14.41][1] includes [OCPBUGS-44379][2].

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.41
[2]: https://issues.redhat.com/browse/OCPBUGS-44379