### PR TITLE
MON-4093: Set 4.17.5 as the minor min for upgrades to 4.18.

### DIFF
--- a/build-suggestions/4.18.yaml
+++ b/build-suggestions/4.18.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.17.0
+  minor_min: 4.17.5
   minor_max: 4.17.9999
   minor_block_list: []
   z_min: 4.18.0-ec.0


### PR DESCRIPTION
In 4.17.5 ,CMO will block cluster upgrades if the configurations in openshift-monitoring/cluster-monitoring-config or openshift-user-workload-monitoring/user-workload-monitoring-config fail to meet stricter validation criteria. This is to prompt users to clean up their configurations by removing unsupported fields and resolving any misconfigurations. The goal is to prevent CMO from becoming degraded (and unavailable) during the upgrade to version 4.18.


- 4.17.5 does include https://issues.redhat.com/browse/OCPBUGS-43690 https://amd64.ocp.releases.ci.openshift.org/features/4.17.5?from=4.17.4


This is the needed change, maybe the PR should be recreated via a bot.