### PR TITLE
add a known risk for 4.18.0-ec.3

### DIFF
--- a/blocked-edges/4.18.0-ec.3-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-ec.3-CMOSuddenStrictConfigValidation.yaml
@@ -1,0 +1,13 @@
+to: 4.18.0-ec.3
+# 4.17 ECs and RCs + 4.17.[0-4] + 4.18.0-ec.[0-2]
+from: ^4[.](17[.](0.*|[1-4])|18[.]0-ec[0-2])$
+url: https://issues.redhat.com/browse/OCPBUGS-42671
+name: CMOSuddenStrictConfigValidation
+message: |-
+  The Cluster Monitoring Operator (CMO) now validates the content of its ConfigMaps more strictly.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` while updating to a version with strict validation if any of the ConfigMaps contain invalid configurations.
+
+  The error messages should be clear enough to help identify and correct any eventual issues.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.0-ec.4-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-ec.4-CMOSuddenStrictConfigValidation.yaml
@@ -1,0 +1,12 @@
+to: 4.18.0-ec.4
+from: ^4[.]18[.]0-ec[0-2]$
+url: https://issues.redhat.com/browse/OCPBUGS-42671
+name: CMOSuddenStrictConfigValidation
+message: |-
+  The Cluster Monitoring Operator (CMO) now validates the content of its ConfigMaps more strictly.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` while updating to a version with strict validation if any of the ConfigMaps contain invalid configurations.
+
+  The error messages should be clear enough to help identify and correct any eventual issues.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.0-rc.0-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-rc.0-CMOSuddenStrictConfigValidation.yaml
@@ -1,0 +1,12 @@
+to: 4.18.0-rc.0
+from: ^4[.]18[.]0-ec[0-2]$
+url: https://issues.redhat.com/browse/OCPBUGS-42671
+name: CMOSuddenStrictConfigValidation
+message: |-
+  The Cluster Monitoring Operator (CMO) now validates the content of its ConfigMaps more strictly.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` while updating to a version with strict validation if any of the ConfigMaps contain invalid configurations.
+
+  The error messages should be clear enough to help identify and correct any eventual issues.
+matchingRules:
+- type: Always


### PR DESCRIPTION
4.18.0-ec.3 shipped the strict CMO config validation https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.18.0-ec.3 and **was built before** 4.17.5 where the "make CMO Upgradeable=false to ensure configurations pass strict validation before the 4.18 upgrade" was shipped https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.17.5