### PR TITLE
COS-1942: blocked-edges/4.12.0-rc.7-AWSOldBootImage: Fixed in 4.12.0-rc.8

### DIFF
--- a/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
+++ b/blocked-edges/4.12.0-rc.7-AWSOldBootImage.yaml
@@ -1,5 +1,6 @@
 to: 4.12.0-rc.7
 from: 4[.]11[.].*
+fixedIn: 4.12.0-rc.8
 url: https://issues.redhat.com/browse/COS-1942
 name: AWSOldBootImages
 message: |-


### PR DESCRIPTION
With e1e5822ba1 ( #6268), the stabilization bot is looking at these again, and is concerned about this risk:

    * FAILED AWSOldBootImages affects 4.12.0-rc.7.  Either declare a fix version or extend the risk to 4.12.0-rc.8.

Checking to see when [the MCO fix][1] landed:

```console
$ for X in 4.12.0-rc.7 4.12.0-rc.8 4.12.0; do echo -n "${X} "; oc adm release info --commits "quay.io/openshift-release-dev/ocp-release:${X}-x86_64" | grep machine-config-operator; done
4.12.0-rc.7   machine-config-operator                        https://github.com/openshift/machine-config-operator                        b29dceb12638f3d7f30f339729344de69824a09b
4.12.0-rc.8   machine-config-operator                        https://github.com/openshift/machine-config-operator                        2b3eba74dd9e4371f35ab41dbda02642f60707ec
4.12.0   machine-config-operator                        https://github.com/openshift/machine-config-operator                        2b3eba74dd9e4371f35ab41dbda02642f60707ec
```

So rc.8 has the same MCO commit as 4.12.0, and we didn't declare the risk for 4.12.0, so it must have been fixed in rc.8 too.

[1]: https://issues.redhat.com/browse/OCPBUGS-5384