### PR TITLE
`CMOSuddenStrictConfigValidation`: Fix regexes

### DIFF
--- a/blocked-edges/4.18.0-ec.3-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-ec.3-CMOSuddenStrictConfigValidation.yaml
@@ -1,6 +1,6 @@
 to: 4.18.0-ec.3
 # 4.17 ECs and RCs + 4.17.[0-4] + 4.18.0-ec.[0-2]
-from: ^4[.](17[.](0.*|[1-4])|18[.]0-ec[0-2])$
+from: ^4[.](17[.](0.*|[1-4])|18[.]0-ec[.][0-2])[+].*$
 url: https://issues.redhat.com/browse/OCPBUGS-42671
 name: CMOSuddenStrictConfigValidation
 message: |-

--- a/blocked-edges/4.18.0-ec.4-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-ec.4-CMOSuddenStrictConfigValidation.yaml
@@ -1,5 +1,5 @@
 to: 4.18.0-ec.4
-from: ^4[.]18[.]0-ec[0-2]$
+from: ^4[.]18[.]0-ec[.][0-2][+].*$
 url: https://issues.redhat.com/browse/OCPBUGS-42671
 name: CMOSuddenStrictConfigValidation
 message: |-

--- a/blocked-edges/4.18.0-rc.0-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-rc.0-CMOSuddenStrictConfigValidation.yaml
@@ -1,5 +1,5 @@
 to: 4.18.0-rc.0
-from: ^4[.]18[.]0-ec[0-2]$
+from: ^4[.]18[.]0-ec[.][0-2][+].*$
 url: https://issues.redhat.com/browse/OCPBUGS-42671
 name: CMOSuddenStrictConfigValidation
 message: |-


### PR DESCRIPTION
- ECs and RC numbers are dot-separated
- regexes need to capture [architecture suffixes](https://github.com/openshift/cincinnati-graph-data?tab=readme-ov-file#block-edges)

I was a bit trigger happy when reviewing https://github.com/openshift/cincinnati-graph-data/pull/6331

/cc @wking @machine424 