### PR TITLE
SDN-5485: `OVNLocalnetWithNoSubnets`: ->4.17.[0-6] with virtualization

### DIFF
--- a/blocked-edges/4.17.0-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.0-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.0
+from: ^4[.]16[.].*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.1-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.1-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.1
+from: ^4[.]16[.].*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.2-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.2-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.2
+from: ^4[.]16[.]0.*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.3-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.3-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.3
+from: ^4[.]16[.]0.*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.4-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.4-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.4
+from: ^4[.]16[.]0.*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.5-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.5-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,22 @@
+to: 4.17.5
+from: ^4[.]16[.]0.*
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )

--- a/blocked-edges/4.17.6-OVNLocalnetWithNoSubnets.yaml
+++ b/blocked-edges/4.17.6-OVNLocalnetWithNoSubnets.yaml
@@ -1,0 +1,23 @@
+to: 4.17.6
+from: ^4[.]16[.]0.*
+fixedIn: 4.17.7
+url: https://issues.redhat.com/browse/SDN-5485
+name: OVNLocalnetWithNoSubnets
+message: |-
+  Clusters with localnet topology networks with no subnets defined (configuration typical for OpenShift Virtualization)
+  would fail to update and create new workloads.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        (
+          group by (_id, resource) (max_over_time(apiserver_storage_objects{_id="",resource="network-attachment-definitions.k8s.cni.cncf.io"}[1h]) > 0)
+          or on (_id)
+          0 * label_replace(group by (_id) (max_over_time(apiserver_storage_objects{_id=""}[1h])), "resource", "no-network_attachment-definitions", "resource", ".*")
+        )
+        * on (_id) group_left (name)
+        (
+          group by (_id, name) (csv_succeeded{_id="", name=~"kubevirt-hyperconverged-operator[.].*"})
+          or on (_id)
+          0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "not hyperconverged", "name", ".*")
+        )


### PR DESCRIPTION
Address [SDN-5485](https://issues.redhat.com//browse/SDN-5485) / OCPBUGS-43454 which affects 4.17 until 4.17.7 where it is fixed. We have not managed to identify a precise technical PromQL to identify clusters with the exact problematic networking configuration so I am proposing to use a coarse approximation of what clusters are *likely* (based on the information available) to have such config (OpenShift Virtualization installations identified by the hyperconverged-cluster-operator CSV presence, and which at the same time have at least one `network-attachment-definitions.k8s.cni.cncf.io` resource instance.

Given the impact of the bug when hit (failure to create new workloads), it is better to steer the group of potentially affected clusters towards already available 4.17.7, even if we are not able to produce a sufficiently targeted PromQL for the actual network configuration.
