### PR TITLE
`CMOSuddenStrictConfigValidation`: Extend to 4.18 RC1, bump 4.18 `z_min` to EC3

### DIFF
--- a/blocked-edges/4.18.0-rc.1-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-rc.1-CMOSuddenStrictConfigValidation.yaml
@@ -1,0 +1,12 @@
+to: 4.18.0-rc.1
+from: ^4[.]18[.]0-ec[.][0-2][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-42671
+name: CMOSuddenStrictConfigValidation
+message: |-
+    The Cluster Monitoring Operator (CMO) now validates the content of its ConfigMaps more strictly.
+
+    This may result in the operator being marked as `Degraded` and `Unavailable` while updating to a version with strict validation if any of the ConfigMaps contain invalid configurations.
+
+    The error messages should be clear enough to help identify and correct any eventual issues.
+matchingRules:
+- type: Always

--- a/build-suggestions/4.18.yaml
+++ b/build-suggestions/4.18.yaml
@@ -2,6 +2,6 @@ default:
   minor_min: 4.17.5
   minor_max: 4.17.9999
   minor_block_list: []
-  z_min: 4.18.0-ec.0
+  z_min: 4.18.0-ec.3
   z_max: 4.18.9999
   z_block_list: []


### PR DESCRIPTION
**`CMOSuddenStrictConfigValidation`: Extend to 4.18.0-rc.1**

RC1 still has edges from early ECs 0-2 without the validation, so is exposed:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.18.0-rc.1-x86_64 | grep Upgrades
  Upgrades: 4.17.5, 4.17.6, 4.17.7, 4.17.8, 4.18.0-ec.0, 4.18.0-ec.1, 4.18.0-ec.2, 4.18.0-ec.3, 4.18.0-ec.4, 4.18.0-rc.0
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
A followup commit will bump the `z_min` in 4.18 build suggestions which will allow us to `fixedIn` the next RC, likely RC2

---

**build-suggestions/4.18: bump `z_min` to 4.18.0-ec.3**

Bumping to EC3 will prevent the next RC (likely RC2) to have edges from early ECs, upgrades from which are affected by `CMOSuddenStrictConfigValidation`. The bump will allow us to declare that risk as fixed in that RC, because it will have no affected edges.

---

~~**`CMOSuddenStrictConfigValidation`: Fixed in 4.18.0-rc.2**~~

~~Assumes an earlier commit bumps 4.18 `z_min` to `4.18.0-ec.3` or later~~

EDIT: Dropped from the PR, will happen once we actually have RC2 and validate that it does not have paths from exposed versions.
