### PR TITLE
blocked-edges/4.16.0-rc.9-PreRelease: Fixed in 4.16.0

### DIFF
--- a/blocked-edges/4.16.0-rc.9-PreRelease.yaml
+++ b/blocked-edges/4.16.0-rc.9-PreRelease.yaml
@@ -1,5 +1,6 @@
 to: 4.16.0-rc.9
 from: .*
+fixedIn: 4.16.0
 url: https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html
 name: PreRelease
 message: |-


### PR DESCRIPTION
4.16.0 is the Generally Available release, as described in the message.  Declaring this addresses:

```
  * FAILED PreRelease affects 4.16.0-rc.9.  Either declare a fix version or extend the risk to 4.16.0.
```

as `hack/stabilization-changes.py` adapts to 4d3beb6476 (#6412).