### PR TITLE
COS-3078: Declare `NUMAResourcesOperatorCrashLoopBackOff` risk

### DIFF
--- a/blocked-edges/4.16.25-NUMAResourcesOperatorCrashLoopBackOff.yaml
+++ b/blocked-edges/4.16.25-NUMAResourcesOperatorCrashLoopBackOff.yaml
@@ -1,0 +1,13 @@
+to: 4.16.25
+from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/COS-3078
+name: NUMAResourcesOperatorCrashLoopBackOff
+message: |-
+  Critical pods in the NUMA Resources Operator will start to CrashLoopBackOff due to new SELinux changes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"numaresources-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})

--- a/blocked-edges/4.16.26-NUMAResourcesOperatorCrashLoopBackOff.yaml
+++ b/blocked-edges/4.16.26-NUMAResourcesOperatorCrashLoopBackOff.yaml
@@ -1,5 +1,6 @@
 to: 4.16.26
 from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+fixedIn: 4.16.27
 url: https://issues.redhat.com/browse/COS-3078
 name: NUMAResourcesOperatorCrashLoopBackOff
 message: |-

--- a/blocked-edges/4.16.26-NUMAResourcesOperatorCrashLoopBackOff.yaml
+++ b/blocked-edges/4.16.26-NUMAResourcesOperatorCrashLoopBackOff.yaml
@@ -1,0 +1,13 @@
+to: 4.16.26
+from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/COS-3078
+name: NUMAResourcesOperatorCrashLoopBackOff
+message: |-
+  Critical pods in the NUMA Resources Operator will start to CrashLoopBackOff due to new SELinux changes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"numaresources-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})

--- a/blocked-edges/4.17.7-NUMAResourcesOperatorCrashLoopBackOff.yaml
+++ b/blocked-edges/4.17.7-NUMAResourcesOperatorCrashLoopBackOff.yaml
@@ -1,0 +1,13 @@
+to: 4.17.7
+from: ^4[.](16[.](1?[0-9]|2[0-4])|17[.][0-6])[+].*$
+url: https://issues.redhat.com/browse/COS-3078
+name: NUMAResourcesOperatorCrashLoopBackOff
+message: |-
+  Critical pods in the NUMA Resources Operator will start to CrashLoopBackOff due to new SELinux changes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"numaresources-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})

--- a/blocked-edges/4.17.8-NUMAResourcesOperatorCrashLoopBackOff.yaml
+++ b/blocked-edges/4.17.8-NUMAResourcesOperatorCrashLoopBackOff.yaml
@@ -1,0 +1,13 @@
+to: 4.17.8
+from: ^4[.](16[.](1?[0-9]|2[0-4])|17[.][0-6])[+].*$
+url: https://issues.redhat.com/browse/COS-3078
+name: NUMAResourcesOperatorCrashLoopBackOff
+message: |-
+  Critical pods in the NUMA Resources Operator will start to CrashLoopBackOff due to new SELinux changes.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(csv_succeeded{_id="", name=~"numaresources-operator[.].*"})
+      or
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
Impact statement: https://issues.redhat.com/browse/COS-3078

Steps done:
 - Created `blocked-edges/4.16.25-NUMAResourcesOperatorCrashLoopBackOff.yaml` manually
 - Run:
 ```shell
 $ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]\(2[6-9]\|[3-9][0-9]\)$' | while read VERSION; do sed "s/4.16.25/${VERSION}/" blocked-edges/4.16.25-NUMAResourcesOperatorCrashLoopBackOff.yaml > "blocked-edges/${VERSION}-NUMAResourcesOperatorCrashLoopBackOff.yaml"; done
 ```

 - Created `blocked-edges/4.17.7-NUMAResourcesOperatorCrashLoopBackOff.yaml` manually
 - Run:
 ```shell
 $ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.17&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]17[.]\([8-9]\|[1-9][0-9]\)$' | while read VERSION; do sed "s/4.17.7/${VERSION}/" blocked-edges/4.17.7-NUMAResourcesOperatorCrashLoopBackOff.yaml > "blocked-edges/${VERSION}-NUMAResourcesOperatorCrashLoopBackOff.yaml"; done
 ```

---

[4.16.26-NUMAResourcesOperatorCrashLoopBackOff: Set fixedIn 4.16.27](https://github.com/openshift/cincinnati-graph-data/pull/6444/commits/b7bf13d32d005aa23b983b8b5afbb9a380c0622f) 

Issue for the 4.16.z: https://issues.redhat.com/browse/OCPBUGS-45983
Issue has been added to advisory RHBA-2024:10973 (4.16.27)

```
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.16.27-x86_64
Name:           4.16.27
...
  Metadata:
    url: https://access.redhat.com/errata/RHBA-2024:10973
```