### PR TITLE
NO-JIRA: blocked-edges/4.18.0-rc.1-CMOSuddenStrictConfigValidation.yaml: Set the risk as fixed in rc.2

### DIFF
--- a/blocked-edges/4.18.0-rc.1-CMOSuddenStrictConfigValidation.yaml
+++ b/blocked-edges/4.18.0-rc.1-CMOSuddenStrictConfigValidation.yaml
@@ -1,5 +1,6 @@
 to: 4.18.0-rc.1
 from: ^4[.]18[.]0-ec[.][0-2][+].*$
+fixedIn: 4.18.0-rc.2
 url: https://issues.redhat.com/browse/OCPBUGS-42671
 name: CMOSuddenStrictConfigValidation
 message: |-


### PR DESCRIPTION
Upgrades from ECs 0-2 are affected due to the risk.

The https://github.com/openshift/cincinnati-graph-data/pull/6405 PR bumped `build-suggestions/4.18` `z_min` to 4.18.0-ec.3 to prevent the next RC to have edges from the early affected ECs.

Verifying that the 4.18.0-rc.2 does not have upgrade paths from the affected versions:

```
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.18.0-rc.2-x86_64 | grep "Release Metadata" -A 4
Release Metadata:
  Version:  4.18.0-rc.2
  Upgrades: 4.17.5, 4.17.6, 4.17.7, 4.17.8, 4.17.9, 4.18.0-ec.3, 4.18.0-ec.4, 4.18.0-rc.0, 4.18.0-rc.1
  Metadata:
    url: https://access.redhat.com/errata/RHEA-2024:6122
```

Upgrades from the affected ECs 0-2 are not present.