### PR TITLE
COS-3068: Declare the `FCoEBootFromSANKernelDriverQedf` risk and mark it as fixed in 4.16.27 and 4.17.9

### DIFF
--- a/blocked-edges/4.16.25-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.16.25-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,0 +1,8 @@
+to: 4.16.25
+from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/COS-3068
+name: FCoEBootFromSANKernelDriverQedf
+message: |-
+  Nodes in clusters that utilize FCoE boot from SAN on devices that use the qedf kernel driver will fail to boot after updating.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.26-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.16.26-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,5 +1,6 @@
 to: 4.16.26
 from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+fixedIn: 4.16.27
 url: https://issues.redhat.com/browse/COS-3068
 name: FCoEBootFromSANKernelDriverQedf
 message: |-

--- a/blocked-edges/4.16.26-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.16.26-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,0 +1,8 @@
+to: 4.16.26
+from: ^4[.](15[.].*|16[.](1?[0-9]|2[0-4]))[+].*$
+url: https://issues.redhat.com/browse/COS-3068
+name: FCoEBootFromSANKernelDriverQedf
+message: |-
+  Nodes in clusters that utilize FCoE boot from SAN on devices that use the qedf kernel driver will fail to boot after updating.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.7-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.17.7-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,0 +1,8 @@
+to: 4.17.7
+from: ^4[.](16[.](1?[0-9]|2[0-4])|17[.][0-6])[+].*$
+url: https://issues.redhat.com/browse/COS-3068
+name: FCoEBootFromSANKernelDriverQedf
+message: |-
+  Nodes in clusters that utilize FCoE boot from SAN on devices that use the qedf kernel driver will fail to boot after updating.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.8-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.17.8-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,5 +1,6 @@
 to: 4.17.8
 from: ^4[.](16[.](1?[0-9]|2[0-4])|17[.][0-6])[+].*$
+fixedIn: 4.17.9
 url: https://issues.redhat.com/browse/COS-3068
 name: FCoEBootFromSANKernelDriverQedf
 message: |-

--- a/blocked-edges/4.17.8-FCoEBootFromSANKernelDriverQedf.yaml
+++ b/blocked-edges/4.17.8-FCoEBootFromSANKernelDriverQedf.yaml
@@ -1,0 +1,8 @@
+to: 4.17.8
+from: ^4[.](16[.](1?[0-9]|2[0-4])|17[.][0-6])[+].*$
+url: https://issues.redhat.com/browse/COS-3068
+name: FCoEBootFromSANKernelDriverQedf
+message: |-
+  Nodes in clusters that utilize FCoE boot from SAN on devices that use the qedf kernel driver will fail to boot after updating.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Declare `FCoEBootFromSANKernelDriverQedf` risk

Impact statement: https://issues.redhat.com/browse/COS-3068

Created manually.

---

Set `FCoEBootFromSANKernelDriverQedf` risk as fixed in 4.16.27 and 4.17.9
