### PR TITLE
MCO-1481: blocked-edges/4.18.0-rc.3-MachineConfigServerCARotation: Extend risk

### DIFF
--- a/blocked-edges/4.18.0-rc.3-MachineConfigServerCARotation.yaml
+++ b/blocked-edges/4.18.0-rc.3-MachineConfigServerCARotation.yaml
@@ -1,0 +1,8 @@
+to: 4.18.0-rc.3
+from: 4[.]18[.]0-ec[.]4[+].*
+url: https://issues.redhat.com/browse/MCO-1481
+name: MachineConfigServerCARotation
+message: |-
+  4.18.0-ec.4 adjusted machine-config server CA management.  The change was reverted in 4.18.0-rc.0, but clusters running 4.18.0-ec.4 need manual steps to be able to scale new Machines. 
+matchingRules:
+- type: Always


### PR DESCRIPTION
We'll declare it fixed by 4.18.1, or whatever we call the first post-GA 4.18 release.  Because at GA-time, we raise that z_min to the GA release:

```console
$ grep z_min hack/release-ga.sh
# Extract the smallest (we assume it is listed first) version from the stable channel (the GA version) and bump the z_min to that version
sed -i -e "s|z_min: .*|z_min: ${LATEST}|" "build-suggestions/${MAJOR_MINOR}.yaml"
```