### PR TITLE
build-suggestions/4.18: Raise minor_min to 4.17.11

### DIFF
--- a/build-suggestions/4.18.yaml
+++ b/build-suggestions/4.18.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.17.5
+  minor_min: 4.17.11
   minor_max: 4.17.9999
   minor_block_list: []
   z_min: 4.18.0-ec.3


### PR DESCRIPTION
[4.17.11][1] includes [OCPBUGS-38292][2], and we want clusters to pick up that logic before updating to 4.18 in generally-available channels.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.17.11
[2]: https://issues.redhat.com/browse/OCPBUGS-38292