### PR TITLE
OTA-1310: Remove stable channel 4.12.z feeders

### DIFF
--- a/channels/stable-4.12.yaml
+++ b/channels/stable-4.12.yaml
@@ -1,7 +1,3 @@
-feeder:
-  delay: PT0H
-  filter: 4[.](11|12)[.][0-9].*
-  name: stable
 name: stable-4.12
 versions:
 - 4.11.0

--- a/channels/stable-4.13.yaml
+++ b/channels/stable-4.13.yaml
@@ -1,7 +1,3 @@
-feeder:
-  delay: PT0H
-  filter: 4[.](12|13)[.][0-9].*
-  name: stable
 name: stable-4.13
 versions:
 - 4.12.0

--- a/channels/stable-4.14.yaml
+++ b/channels/stable-4.14.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4[.](12|13|14)[.][0-9].*
+  filter: 4[.](13|14)[.][0-9].*
   name: stable
 name: stable-4.14
 versions:


### PR DESCRIPTION
4.12.z went EUS back in July, however we had a mandate to continue
plumbing them through to stable channels through January and that's
ended now. Since no additional 4.12.z go into stable-4.12, they shouldn't
go into stable-4.13 and stable-4.14 either. Those who continue with 4.12
should use eus channels which are tailored for that use.
