### PR TITLE
MCO-1481: blocked-edges/4.18.0-rc.[78]-MachineConfigServerCARotation: Extend risk

### DIFF
--- a/blocked-edges/4.18.0-rc.7-MachineConfigServerCARotation.yaml
+++ b/blocked-edges/4.18.0-rc.7-MachineConfigServerCARotation.yaml
@@ -1,0 +1,8 @@
+to: 4.18.0-rc.7
+from: 4[.]18[.]0-ec[.]4[+].*
+url: https://issues.redhat.com/browse/MCO-1481
+name: MachineConfigServerCARotation
+message: |-
+  4.18.0-ec.4 adjusted machine-config server CA management.  The change was reverted in 4.18.0-rc.0, but clusters running 4.18.0-ec.4 need manual steps to be able to scale new Machines. 
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.0-rc.8-MachineConfigServerCARotation.yaml
+++ b/blocked-edges/4.18.0-rc.8-MachineConfigServerCARotation.yaml
@@ -1,0 +1,8 @@
+to: 4.18.0-rc.8
+from: 4[.]18[.]0-ec[.]4[+].*
+url: https://issues.redhat.com/browse/MCO-1481
+name: MachineConfigServerCARotation
+message: |-
+  4.18.0-ec.4 adjusted machine-config server CA management.  The change was reverted in 4.18.0-rc.0, but clusters running 4.18.0-ec.4 need manual steps to be able to scale new Machines. 
+matchingRules:
+- type: Always


### PR DESCRIPTION
As described in db99b0a215 (#6506), we're just carrying this along through the RCs, until we hit a post-GA release and raise `z_min` for new 4.18 release builds.