### PR TITLE
CNTRLPLANE-256: blocked-edges/4.17-HostedClusterIsProgressingStuckCondition: Declare risk

### DIFF
--- a/blocked-edges/4.17.16-HostedClusterIsProgressingStuckCondition.yaml
+++ b/blocked-edges/4.17.16-HostedClusterIsProgressingStuckCondition.yaml
@@ -1,0 +1,13 @@
+to: 4.17.16
+from: .*
+name: HostedClusterIsProgressingStuckCondition
+url: https://issues.redhat.com/browse/CNTRLPLANE-256
+message: |-
+  The Hosted Cluster is properly deployed but still incorrectly shows the condition: HostedCluster is deploying, upgrading, or reconfiguring, which is blocking the cluster deployment completion.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.17.17-HostedClusterIsProgressingStuckCondition.yaml
+++ b/blocked-edges/4.17.17-HostedClusterIsProgressingStuckCondition.yaml
@@ -1,0 +1,13 @@
+to: 4.17.17
+from: .*
+name: HostedClusterIsProgressingStuckCondition
+url: https://issues.redhat.com/browse/CNTRLPLANE-256
+message: |-
+  The Hosted Cluster is properly deployed but still incorrectly shows the condition: HostedCluster is deploying, upgrading, or reconfiguring, which is blocking the cluster deployment completion.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.17.18-HostedClusterIsProgressingStuckCondition.yaml
+++ b/blocked-edges/4.17.18-HostedClusterIsProgressingStuckCondition.yaml
@@ -1,0 +1,13 @@
+to: 4.17.18
+from: .*
+name: HostedClusterIsProgressingStuckCondition
+url: https://issues.redhat.com/browse/CNTRLPLANE-256
+message: |-
+  The Hosted Cluster is properly deployed but still incorrectly shows the condition: HostedCluster is deploying, upgrading, or reconfiguring, which is blocking the cluster deployment completion.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.17.19-HostedClusterIsProgressingStuckCondition.yaml
+++ b/blocked-edges/4.17.19-HostedClusterIsProgressingStuckCondition.yaml
@@ -1,0 +1,13 @@
+to: 4.17.19
+from: .*
+name: HostedClusterIsProgressingStuckCondition
+url: https://issues.redhat.com/browse/CNTRLPLANE-256
+message: |-
+  The Hosted Cluster is properly deployed but still incorrectly shows the condition: HostedCluster is deploying, upgrading, or reconfiguring, which is blocking the cluster deployment completion.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
Generated by writing the 4.17.16 risk by hand, and then copying it out to the other releases files and changing the file version. Blocking upgrades from all OCP releases to `4.17.16`, `4.17.17`, `4.17.18` and `4.17.19`.

The Issue was introduced by these Jira bugs:
- [OCPBUGS-44927](https://issues.redhat.com//browse/OCPBUGS-44927)
  - https://github.com/openshift/hypershift/pull/5238
- [OCPBUGS-48487](https://issues.redhat.com//browse/OCPBUGS-48487), [OCPBUGS-48488](https://issues.redhat.com//browse/OCPBUGS-48488), [OCPBUGS-48490](https://issues.redhat.com//browse/OCPBUGS-48490)
  - https://github.com/openshift/hypershift/pull/5402
---
- Release 4.19 and 4.18 already contains the fix by:
  - 4.18: https://github.com/openshift/hypershift/pull/5513
  - 4.19: https://github.com/openshift/hypershift/pull/5487
- Release 4.17.20 will contain the fix by: https://github.com/openshift/hypershift/pull/5712
- Releases under 4.17 will not receive the patches which introduced the issue, so I declare them as `not affected`