### PR TITLE
OWNERS: Shift Lala to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - sre-approvers
 reviewers:
   - cincinnati-graph-data-approvers
+emeritus_approvers:
+  - LalatenduMohanty

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@
 aliases:
   cincinnati-graph-data-approvers:
     - wking
-    - LalatenduMohanty
     - PratikMahajan
     - petr-muller
     - DavidHurta


### PR DESCRIPTION
@LalatenduMohanty's mostly OLM-focused now, and while I'm still fine with him approving changes, he probably no longer wants to get pinged by GitHub to review new pulls.