### PR TITLE
MCO-1481: blocked-edges/4.18.1-MachineConfigServerCARotation: Declare as fixed in 4.18.2

### DIFF
--- a/blocked-edges/4.18.1-MachineConfigServerCARotation.yaml
+++ b/blocked-edges/4.18.1-MachineConfigServerCARotation.yaml
@@ -1,5 +1,6 @@
 to: 4.18.1
 from: 4[.]18[.]0-ec[.]4[+].*
+fixedIn: 4.18.2
 url: https://issues.redhat.com/browse/MCO-1481
 name: MachineConfigServerCARotation
 message: |-


### PR DESCRIPTION
The risk affects updates from 4.18.0-ec.4 to later releases [[1]].

Upon the 4.18 GA release, we have bumped the `z_min` build suggestion in the `build-suggestions/4.18.yaml` file [[2]]. This means that the minimal version of the updates in the 4.18.z stream will be the 4.18.1 version for new releases.

Verifying that the new 4.18.2 release only includes the update from 4.18.1 in the 4.18.z stream (and not from the affected 4.18.0-ec.4 or other 4.18.z versions):

```sh
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.18.2-x86_64 | head -n 13
Name:           4.18.2
Digest:         sha256:46f9db00dac167897378825ea5f3cce0867743ac90498bbb61b0816daedd0d00
Created:        2025-02-27T23:04:23Z
OS/Arch:        linux/amd64
Manifests:      758
Metadata files: 2

Pull From: quay.io/openshift-release-dev/ocp-release@sha256:46f9db00dac167897378825ea5f3cce0867743ac90498bbb61b0816daedd0d00

Release Metadata:
  Version:  4.18.2
  Upgrades: 4.17.11, 4.17.12, 4.17.13, 4.17.14, 4.17.15, 4.17.16, 4.17.17, 4.17.18, 4.17.19, 4.18.1
  Metadata:
    url: https://access.redhat.com/errata/RHBA-2025:1904
```

As expected; marking the risk as fixed.

[1]: https://issues.redhat.com/browse/MCO-1481
[2]: https://github.com/openshift/cincinnati-graph-data/pull/6808