### PR TITLE
CNTRLPLANE-256: blocked-edges/4.17.19-HostedClusterIsProgressingStuckCondition: Fixed in 4.17.20

### DIFF
--- a/blocked-edges/4.17.19-HostedClusterIsProgressingStuckCondition.yaml
+++ b/blocked-edges/4.17.19-HostedClusterIsProgressingStuckCondition.yaml
@@ -1,5 +1,6 @@
 to: 4.17.19
 from: .*
+fixedIn: 4.17.20
 name: HostedClusterIsProgressingStuckCondition
 url: https://issues.redhat.com/browse/CNTRLPLANE-256
 message: |-


### PR DESCRIPTION
[4.17.20][1] includes [OCPBUGS-51339][2].

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.17.20
[2]: https://issues.redhat.com/browse/OCPBUGS-51339