### PR TITLE
OCPNODE-3005: Bump 4.18 minor minimum version to 4.18.6

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.1
+  minor_min: 4.18.6
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0-ec.0


### PR DESCRIPTION
- Following PR sets the machine-config cluster operator's status condition of `Upgradeable` to `False` if a cluster is found to be on cgroupv1 
https://github.com/openshift/machine-config-operator/pull/4921 
- Every cluster has to pass through this change(which is in 4.18.6) before upgrading to 4.19 to make sure the cluster is migrated to cgroupv2