### PR TITLE
CORENET-5630: Extend OVNIPsecPausedMCPConnectivity to all 4.15.z

### DIFF
--- a/blocked-edges/4.15.0-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.0-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.0
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.10-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.10-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.10
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.11-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.11-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.11
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.12-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.12-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.12
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.13-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.13-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.13
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.14-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.14-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.14
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.15-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.15-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.15
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.16-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.16-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.16
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.17-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.17-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.17
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.18-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.18-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.18
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.19-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.19-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.19
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.2-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.2-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.2
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.20-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.20-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.20
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.21-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.21-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.21
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.22-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.22-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.22
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.23-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.23-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,20 +1,18 @@
 to: 4.15.23
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
-    - type: PromQL
-      promql:
-        promql: |
-            (
-              group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
-              or on (_id)
-              0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
-            ) and on (_id) (
-              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-              and on (_id)
-              group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
-            )
-            or on (_id)
-            0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.25-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.25-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.25
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.26-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.26-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.26
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.27-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.27-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.27
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.28-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.28-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.28
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.29-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.29-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.29
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.3-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.3-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.3
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.30-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.30-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.30
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.31-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.31-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.31
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.32-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.32-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.32
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.33-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.33-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.33
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.34-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.34-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.34
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.35-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.35-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.35
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.36-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.36-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.36
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.37-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.37-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.37
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.38-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.38-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.38
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.39-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.39-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.39
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.40-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.40-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.40
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.41-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.41-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.41
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.42-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.42-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.42
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.43-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.43-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.43
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.44-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.44-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.44
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.45-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.45-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.45
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.46-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.46-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.46
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.47-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.47-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.47
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.48-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.48-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,4 +1,4 @@
-to: 4.15.24
+to: 4.15.48
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity

--- a/blocked-edges/4.15.5-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.5-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.5
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.6-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.6-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.6
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.7-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.7-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.7
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.8-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.8-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.8
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.15.9-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.9-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,8 +1,8 @@
 to: 4.15.9
 from: 4[.]14[.].*
-url: https://issues.redhat.com/browse/SDN-5146
+url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
-message: OVN clusters with enabled IPsec with multiple worker MachineConfigPools may lose SDN connectivity during updates when at least one worker MCP is paused.
+message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.
 matchingRules:
 - type: PromQL
   promql:
@@ -13,8 +13,6 @@ matchingRules:
         0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
       ) and on (_id) (
         group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
-        and on (_id)
-        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="machineconfigpools.machineconfiguration.openshift.io"}[1h] ) > 2)
       )
       or on (_id)
       0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
* OVNIPsecConnectivity , [CORENET-5341](https://issues.redhat.com/browse/CORENET-5341), all IPSec, "restart IPsec pods", nominally [fixedIn: 4.15.42](https://github.com/openshift/cincinnati-graph-data/blob/master/blocked-edges/4.15.41-OVNIPsecConnectivity.yaml#L3).
* OVNIPsecPausedMCPConnectivity, [CORENET-4908](https://issues.redhat.com/browse/CORENET-4908), IPSec + multiple compute MachineConfigPools + at least one paused MachineConfigPool, "unpause the MCP", nominally [fixedIn: 4.15.25](https://github.com/openshift/cincinnati-graph-data/blob/1e2bde605b3932e57156425479df331233ccc110/blocked-edges/4.15.24-OVNIPsecPausedMCPConnectivity.yaml#L3).

[CORENET-5630](https://issues.redhat.com//browse/CORENET-5630), IPSec + at least one paused MachineConfigPool (but does not need multiple compute pools from OVNIPsecPausedMCPConnectivity), "unpause the MCP".  It impacts all 4.15 clusters and thus not a new regression since 4.15.25.

With this PR, we 
- removed `fixedIn` from OVNIPsecPausedMCPConnectivity, 
- removed  "with multiple worker MachineConfigPools" from OVNIPsecPausedMCPConnectivity's `message` to make it a more general risk,
- removed the "with multiple worker MachineConfigPools" part from the query which leads to the same query as OVNIPsecConnectivity up to [no PromQL to express MCP's pausedness](https://github.com/openshift/cincinnati-graph-data/pull/5588#discussion_r1684277525), and
- replace the `url` with [CORENET-5630](https://issues.redhat.com//browse/CORENET-5630).

In short, this PR extend OVNIPsecPausedMCPConnectivity to a more general risk to all 4.15.z clusters as
- [CORENET-5630](https://issues.redhat.com//browse/CORENET-5630) has impact a superset of cluster than [CORENET-4908](https://issues.redhat.com//browse/CORENET-4908), and
- [CORENET-5630](https://issues.redhat.com//browse/CORENET-5630) has the same remediation as [CORENET-4908](https://issues.redhat.com//browse/CORENET-4908).