### PR TITLE
CORENET-5832: Set up OVNWithMultipleClusterNetworks to block paths to 4.18

### DIFF
--- a/blocked-edges/4.18.1-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.1-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.1
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.2-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.2-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.2
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.3-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.3-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.3
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.4-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.4-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.4
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.5-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.5-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.5
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.6-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.6-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.6
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.7-OVNWithMultipleClusterNetworks.yaml
+++ b/blocked-edges/4.18.7-OVNWithMultipleClusterNetworks.yaml
@@ -1,0 +1,12 @@
+to: 4.18.7
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-5832
+name: OVNWithMultipleClusterNetworks
+message: |-
+  The cluster upgrade cannot be complete and new pods cannot be created successfully if the cluster network configuration is with:
+
+  * "OVNKubernetes" type, and 
+
+  * multiple IP address pools in the same IP family, e.g., IPv4 or IPv6 in the cluster's network.
+matchingRules:
+- type: Always


### PR DESCRIPTION
The command to extend the risks from `blocked-edges/4.18.1-OVNWithMultipleClusterNetworks.yam`:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18' | sort -V | grep -v '^4.18.1$' | grep -v '^4.18.0-ec' | grep -v '^4.18.0-rc' | while read VERSION; do sed "s/4.18.1/${VERSION}/" blocked-edges/4.18.1-OVNWithMultipleClusterNetworks.yaml > "blocked-edges/${VERSION}-OVNWithMultipleClusterNetworks.yaml"; done
```