### PR TITLE
MCO-1585: set up LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO to block affected upgrade paths

### DIFF
--- a/blocked-edges/4.14.47-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.14.47-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,7 @@
+to: 4.14.47
+from: .*
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.48-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.14.48-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,7 @@
+to: 4.14.48
+from: .*
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.49-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.14.49-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,7 @@
+to: 4.14.49
+from: .*
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.50-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.14.50-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.14.50
+from: .*
+fixedIn: 4.14.51
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.45-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.15.45-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.15.45
+# 4.14 before 4.14.47 OR 4.15.z with z<45
+from: 4[.](14[.](0.*|[123][0-9]|4[0-6]|[0-9])|15[.](0.*|[1-3][0-9]|4[0-4]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.46-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.15.46-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.15.46
+# 4.14 before 4.14.47 OR 4.15.z with z<45
+from: 4[.](14[.](0.*|[123][0-9]|4[0-6]|[0-9])|15[.](0.*|[1-3][0-9]|4[0-4]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.47-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.15.47-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.15.47
+# 4.14 before 4.14.47 OR 4.15.z with z<45
+from: 4[.](14[.](0.*|[123][0-9]|4[0-6]|[0-9])|15[.](0.*|[1-3][0-9]|4[0-4]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.15.48-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.15.48-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,9 @@
+to: 4.15.48
+# 4.14 before 4.14.47 OR 4.15.z with z<45
+from: 4[.](14[.](0.*|[123][0-9]|4[0-6]|[0-9])|15[.](0.*|[1-3][0-9]|4[0-4]|[0-9]))
+fixedIn: 4.15.49
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.31-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.31-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.31
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.32-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.32-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.32
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.33-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.33-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.33
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.34-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.34-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.34
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.35-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.35-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.35
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.36-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.36-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.16.36
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.16.37-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.16.37-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,9 @@
+to: 4.16.37
+# 4.15 before 4.15.45 OR 4.16.z with z<31
+from: 4[.](15[.](0.*|[1-3][0-9]|4[0-4]|[0-9])|16[.](0.*|[12][0-9]|30|[0-9]))
+fixedIn: 4.16.38
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.12-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.12-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.12
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.13-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.13-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.13
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.14-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.14-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.14
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.15-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.15-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.15
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.16-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.16-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.16
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.17-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.17-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.17
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.18-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.18-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.18
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.19-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.19-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.19
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.20-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.20-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.20
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.21-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.21-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.17.21
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.17.22-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.17.22-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,9 @@
+to: 4.17.22
+# 4.16 before 4.16.31 OR 4.17.z with z<12
+from: 4[.](16[.](0.*|[12][0-9]|30|[0-9])|17[.](0.*|1[01]|[0-9]))
+url: https://issues.redhat.com/browse/MCO-1585
+fixedIn: 4.17.23
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.1-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.18.1-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.18.1
+# 4.17 before 4.17.12 OR 4.18.z with z<0-rc4
+from: 4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.2-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.18.2-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.18.2
+# 4.17 before 4.17.12 OR 4.18.z with z<0-rc4
+from: 4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.3-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.18.3-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.18.3
+# 4.17 before 4.17.12 OR 4.18.z with z<0-rc4
+from: 4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.4-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.18.4-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,8 @@
+to: 4.18.4
+# 4.17 before 4.17.12 OR 4.18.z with z<0-rc4
+from: 4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.5-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.18.5-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,9 @@
+to: 4.18.5
+# 4.17 before 4.17.12 OR 4.18.z with z<0-rc4
+from: 4[.](17[.](1[01]|0-.*|[0-9])|18.0-(ec[.].*|rc[.][0-3]))
+fixedIn: 4.18.6
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.0-ec.1-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.19.0-ec.1-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,0 +1,9 @@
+to: 4.19.0-ec.1
+# 4.18 before 4.18.0-rc.4 OR 4.19.0-ec.0
+from: 4[.](18[.]0-(ec[.].*|rc[.][0-3])|19[.]0-ec[.]0)
+fixedIn: 4.19.0-ec.4
+url: https://issues.redhat.com/browse/MCO-1585
+name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
+message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.
+matchingRules:
+- type: Always


### PR DESCRIPTION
fixedIn:
[OCPBUGS-52213](https://issues.redhat.com/browse/OCPBUGS-52213)
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-dev-preview/release/4.19.0-ec.4

[OCPBUGS-53110](https://issues.redhat.com/browse/OCPBUGS-53110)
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.18.6

[OCPBUGS-53186](https://issues.redhat.com/browse/OCPBUGS-53186)
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.17.23

OCPBUGS-53434
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.16.38

OCPBUGS-54176
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.49

OCPBUGS-54228
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.51

```
### extend 4.18
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18' | xargs semver | sed '1,/4.18.0-rc.4/d' | grep -v 4.18.0-rc |  sed -n '/4.18.6/q;p' | while read VERSION; do sed "s/4.18.0-rc.4/${VERSION}/" blocked-edges/4.18.0-rc.4-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml > "blocked-edges/${VERSION}-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml"; done

### extend 4.17
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.17&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]17' | xargs semver | sed '1,/4.17.12/d' | sed -n '/4.17.23/q;p' | while read VERSION; do sed "s/4.17.12/${VERSION}/" blocked-edges/4.17.12-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml > "blocked-edges/${VERSION}-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml"; done

### extend 4.16
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16' | xargs semver | sed '1,/4.16.30/d' | sed -n '/4.16.38/q;p' | while read VERSION; do sed "s/4.16.31/${VERSION}/" blocked-edges/4.16.31-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml > "blocked-edges/${VERSION}-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml"; done

### extend 4.15
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15' | xargs semver | sed '1,/4.15.45/d' | sed -n '/4.15.49/q;p' | while read VERSION; do sed "s/4.15.45/${VERSION}/" blocked-edges/4.15.45-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml > "blocked-edges/${VERSION}-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml"; done

### extend 4.14
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.14&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]14' | xargs semver | sed '1,/4.14.46/d' | sed -n '/4.14.51/q;p' | while read VERSION; do sed "s/4.14.47/${VERSION}/" blocked-edges/4.14.47-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml > "blocked-edges/${VERSION}-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml"; done
```