### PR TITLE
Make release-stable-minor.sh runnable on MacOS

### DIFF
--- a/hack/release-stable-minor.sh
+++ b/hack/release-stable-minor.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -55,9 +55,10 @@ fi
 
 FILTER="${MAJOR}[.](${PREVIOUS_MINORS}|${MINOR})[.][0-9].*"
 
+SED_CMD=${SED_CMD:-"sed"}
 echo "${CHANNELS}" | while read CHANNEL
 do
-	sed -i "s/filter: .*/filter: ${FILTER}/" "channels/${CHANNEL}-${MAJOR_MINOR}.yaml"
+	"${SED_CMD}" -i "s/filter: .*/filter: ${FILTER}/" "channels/${CHANNEL}-${MAJOR_MINOR}.yaml"
 done
 
 unset GITHUB_TOKEN


### PR DESCRIPTION
To follow up https://github.com/openshift/cincinnati-graph-data/pull/7037#issuecomment-2783965749

With this PR,
- the sed command can be overridden by "${SED_CM}"
- the script is more portable with #!/usr/bin/env As a Shebang [1].

After this PR: we can run the script on MacOS by the following
command:

```console
$ bash --version
GNU bash, version 5.2.37(1)-release (aarch64-apple-darwin24.2.0)
...

$ SED_CMD=gsed hack/release-stable-minor.sh 4.18
4.18 is an EUS release, will update stable and eus channels
Running stabilization-changes.py: iteration 1
Running stabilization-changes.py: iteration 2
Running stabilization-changes.py: iteration 3
Running stabilization-changes.py: iteration 4
See /var/folders/xp/g5y5gl3525g7c3fvfc75lkk40000gn/T/tmp.XaIEPThXo4 for stabilization-changes.py output if needed
```

[1]. https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html