### PR TITLE
CORENET-5630: blocked-edges/4.15.48-OVNIPsecPausedMCPConnectivity: Fixed in 4.15.49

### DIFF
--- a/blocked-edges/4.15.48-OVNIPsecPausedMCPConnectivity.yaml
+++ b/blocked-edges/4.15.48-OVNIPsecPausedMCPConnectivity.yaml
@@ -1,5 +1,6 @@
 to: 4.15.48
 from: 4[.]14[.].*
+fixedIn: 4.15.49
 url: https://issues.redhat.com/browse/CORENET-5630
 name: OVNIPsecPausedMCPConnectivity
 message: OVN clusters with enabled IPsec may lose SDN connectivity during updates when a worker MCP is paused.


### PR DESCRIPTION
[4.15.49][1] contains [OCPBUGS-36688][2] and [OCPBUGS-43099][3], picking up openshift/machine-config-operator#4937 and openshift/cluster-network-operator#2658.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.15.49
[2]: https://issues.redhat.com/browse/OCPBUGS-36688
[3]: https://issues.redhat.com/browse/OCPBUGS-43099
