### PR TITLE
Bump 4.18 minor minimum version to 4.18.11

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.6
+  minor_min: 4.18.11
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0-ec.0


### PR DESCRIPTION
Machine config cluster operator's status condition message has been updated with a clearer explanation and a reference to the doc to switch the cgroupMode in OCP

Every cluster has to pass through this change before upgrading to 4.19 to make sure the cluster is migrated to cgroupv2 Ref: https://github.com/openshift/machine-config-operator/pull/4993