### PR TITLE
OCPBUGS-54594: ARM64 nodes to apply a bootloader update at 4.18.11 or later

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.6
+  minor_min: 4.18.11
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0-ec.0


### PR DESCRIPTION
…update

Reference: https://issues.redhat.com/browse/OCPBUGS-54594