### PR TITLE
CNF-17689: Set up `MetallbBgpBfdFrrRpm` for 4.18.{10,11}

### DIFF
--- a/blocked-edges/4.18.10-MetallbBgpBfdFrrRpm.yaml
+++ b/blocked-edges/4.18.10-MetallbBgpBfdFrrRpm.yaml
@@ -1,0 +1,15 @@
+to: 4.18.10
+from: .*
+url: https://issues.redhat.com/browse/CNF-17689
+name: MetallbBgpBfdFrrRpm
+message: |-
+  Clusters using MetalLB BFD capabilities alongside BGP can fail to establish BGP peering, reducing the availability of LoadBalancer services exposed by MetalLB, or even making them unreachable
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (_id, name) (csv_succeeded{_id="", name=~"metallb-operator[.].*"})
+        or on (_id)
+        0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "metallb operator not installed", "name", ".*")
+      )

--- a/blocked-edges/4.18.11-MetallbBgpBfdFrrRpm.yaml
+++ b/blocked-edges/4.18.11-MetallbBgpBfdFrrRpm.yaml
@@ -1,0 +1,16 @@
+to: 4.18.11
+fixedIn: 4.18.12
+from: .*
+url: https://issues.redhat.com/browse/CNF-17689
+name: MetallbBgpBfdFrrRpm
+message: |-
+  Clusters using MetalLB BFD capabilities alongside BGP can fail to establish BGP peering, reducing the availability of LoadBalancer services exposed by MetalLB, or even making them unreachable
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (_id, name) (csv_succeeded{_id="", name=~"metallb-operator[.].*"})
+        or on (_id)
+        0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "metallb operator not installed", "name", ".*")
+      )


### PR DESCRIPTION
Clusters with `metallb-operator` CSV installed should be warned about updating to 4.18.10 and 4.18.11, because these OCP payloads ship a `metallb` image (which serves as the OLM operators operand) with a FRR RPM that causes issues for clusters using BFD and BGP.

I do not have a cluster at hand with metallb installed, but testing CSV presence is an established practice for matching an installed OLM operator, and I have tested the PromQL on ota-stage, just substituted the metallb-operator name for one of the CSVs installed there. I used https://github.com/metallb/metallb-operator/blob/main/bundle/manifests/metallb-operator.clusterserviceversion.yaml#L446C9-L446C25 as a source for what the CSV name is,

```
     (
        group by (_id, name) (csv_succeeded{_id="", name=~"metallb-operator[.].*"})
        or on (_id)
        0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "metallb operator not installed", "name", ".*")
      )
```
