### PR TITLE
OCPNODE-3074: Declare `CRIOLayerCompressionPulls` for 4.18.1..6

### DIFF
--- a/blocked-edges/4.18.1-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.1-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,8 @@
+to: 4.18.1
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: |-
+  The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.2-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.2-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,7 @@
+to: 4.18.2
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.3-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.3-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,7 @@
+to: 4.18.3
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.4-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.4-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,7 @@
+to: 4.18.4
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.5-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.5-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,7 @@
+to: 4.18.5
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.6-CRIOLayerCompressionPulls.yaml
+++ b/blocked-edges/4.18.6-CRIOLayerCompressionPulls.yaml
@@ -1,0 +1,8 @@
+to: 4.18.6
+from: .*
+fixedIn: 4.18.7
+url: https://issues.redhat.com/browse/OCPNODE-3074
+name: CRIOLayerCompressionPulls
+message: The CRI-O container runtime may fail to pull images with certain layer compression characteristics
+matchingRules:
+- type: Always


### PR DESCRIPTION
Fixed versions are already available, we are just steering clusters away from the affected ones.
