### PR TITLE
OCPNODE-3119: Declare `MCOContainerRuntimeConfigStaleFinalizer` for 4.17.11..24

### DIFF
--- a/blocked-edges/4.17.11-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.11-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.11
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.12-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.12-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.12
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.13-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.13-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.13
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.14-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.14-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.14
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.15-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.15-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.15
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.16-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.16-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.16
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.17-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.17-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.17
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.18-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.18-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.18
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.19-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.19-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.19
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.20-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.20-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.20
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.21-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.21-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.21
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.22-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.22-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.22
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.23-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.23-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,12 @@
+to: 4.17.23
+from: .*
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))

--- a/blocked-edges/4.17.24-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.24-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,0 +1,13 @@
+to: 4.17.24
+from: .*
+fixedIn: 4.17.25
+url: https://issues.redhat.com/browse/OCPNODE-3119
+name: MCOContainerRuntimeConfigStaleFinalizer
+message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(max_over_time(apiserver_storage_objects{resource="containerruntimeconfigs.machineconfiguration.openshift.io"}[1h]) > 0)
+      or
+      0 * group(max_over_time(apiserver_storage_objects[1h]))


### PR DESCRIPTION
- [OCPBUGS-52188](https://issues.redhat.com/browse/OCPBUGS-52188) is fixed in [4.17.25](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.17.25)
- PromQL approximating affected clusters to "Clusters with ContainerRuntimeConfig resources" which may be very coarse but should not be a big deal because fixed 4.17 versions are already available.

/hold
PR created but [OCPNODE-3119](https://issues.redhat.com/browse/OCPNODE-3119) still needs final confirmations and description cleanup
