### PR TITLE
OCPBUGS-55193: channels/stable-*: Remove 4.14.z feeders from stable channels

### DIFF
--- a/channels/stable-4.14.yaml
+++ b/channels/stable-4.14.yaml
@@ -1,7 +1,3 @@
-feeder:
-  delay: PT0H
-  filter: 4[.](13|14)[.][0-9].*
-  name: stable
 name: stable-4.14
 versions:
 - 4.12.0

--- a/channels/stable-4.15.yaml
+++ b/channels/stable-4.15.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4[.](14|15)[.][0-9].*
+  filter: 4[.]15[.][0-9].*
   name: stable
 name: stable-4.15
 versions:

--- a/channels/stable-4.16.yaml
+++ b/channels/stable-4.16.yaml
@@ -1,6 +1,6 @@
 feeder:
   delay: PT0H
-  filter: 4[.](14|15|16)[.][0-9].*
+  filter: 4[.](15|16)[.][0-9].*
   name: stable
 name: stable-4.16
 versions:


### PR DESCRIPTION
Like a56b5405 (#6584), but for 4.14, because [4.14 left its Maintenance phase and entered its EUS phase on 2025-05-01][1]:

```console
$ curl -s 'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4' | jq -r '.data[].versions[] | select(.name == "4.14").phases[] | .date + " " + .name'
2023-10-31T00:00:00.000Z General availability
2024-05-27T00:00:00.000Z Full support
2025-05-01T00:00:00.000Z Maintenance support
2025-10-31T00:00:00.000Z Extended update support
2026-10-31T00:00:00.000Z Extended update support Term 2
N/A Extended life phase
```

The most recent 4.14.z is 4.14.51, and it entered stable and related on 354234b97d (#7200), as expected for a release that went GA and entered fast channels before the Maintenance cutoff in 90aff68115 (#7161).  The next 4.14.z to be built will include [OCPBUGS-55193][2], which will default it to the `eus-4.14` channel, so it does not need to enter `stable-*` channels.

[1]: https://access.redhat.com/support/policy/updates/openshift#dates
[2]: https://issues.redhat.com/browse/OCPBUGS-55193