### PR TITLE
OCPBUGS-55359: build-suggestions/4.19: Raise minor_min to 4.18.13

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.11
+  minor_min: 4.18.13
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0-ec.0


### PR DESCRIPTION
[4.18.13][1] includes [OCPBUGS-55359][2] and [OCPBUGS-53427][3], which we want clusters to be evaluating before they launch updates to 4.19.

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.18.13
[2]: https://issues.redhat.com/browse/OCPBUGS-55359
[3]: https://issues.redhat.com/browse/OCPBUGS-53427