### PR TITLE
OCPNODE-3119: Restrict `from:` on `MCOContainerRuntimeConfigStaleFinalizer`

### DIFF
--- a/blocked-edges/4.17.11-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.11-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.11
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.12-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.12-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.12
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.13-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.13-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.13
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.14-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.14-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.14
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.15-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.15-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.15
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.16-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.16-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.16
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.17-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.17-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.17
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.18-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.18-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.18
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.19-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.19-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.19
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.20-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.20-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.20
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.21-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.21-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.21
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.22-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.22-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.22
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.23-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.23-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.23
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer
 message: Machine Config Operator may enter Degraded state during the update on clusters with a ContainerRuntimeConfig that has a stale finalizer referring to a MachineConfig object that no longer exists. Such clusters will not be able to finish updating without manually cleaning such stale finalizers.

--- a/blocked-edges/4.17.24-MCOContainerRuntimeConfigStaleFinalizer.yaml
+++ b/blocked-edges/4.17.24-MCOContainerRuntimeConfigStaleFinalizer.yaml
@@ -1,5 +1,5 @@
 to: 4.17.24
-from: .*
+from: 4[.]((16[.][0-9]+)|17[.]([0-9]|10))[+].*
 fixedIn: 4.17.25
 url: https://issues.redhat.com/browse/OCPNODE-3119
 name: MCOContainerRuntimeConfigStaleFinalizer


### PR DESCRIPTION
Only updates from any 4.16 and 4.17 below 4.17.10 are affected, no need to bother 4.17 clusters that either already or never encountered the bug.
