### PR TITLE
Reconcile stabilization-bot warnings

### DIFF
--- a/blocked-edges/4.18.0-rc.10-PreRelease.yaml
+++ b/blocked-edges/4.18.0-rc.10-PreRelease.yaml
@@ -1,8 +1,8 @@
 to: 4.18.0-rc.10
 from: .*
+fixedIn: 4.18.1
 url: https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html
 name: PreRelease
-message: |-
-  This is a prerelease version, and you should update to 4.18.1 or later releases, even if that means updating to a newer 4.17 first.
+message: This is a prerelease version, and you should update to 4.18.1 or later releases, even if that means updating to a newer 4.17 first.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.19.0-ec.2-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.19.0-ec.2-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,5 +1,4 @@
-to: 4.19.0-ec.1
-# 4.18 before 4.18.0-rc.4 OR 4.19.0-ec.0
+to: 4.19.0-ec.2
 from: 4[.](18[.]0-(ec[.].*|rc[.][0-3])|19[.]0-ec[.]0)
 url: https://issues.redhat.com/browse/MCO-1585
 name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO

--- a/blocked-edges/4.19.0-ec.3-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
+++ b/blocked-edges/4.19.0-ec.3-LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO.yaml
@@ -1,6 +1,6 @@
-to: 4.19.0-ec.1
-# 4.18 before 4.18.0-rc.4 OR 4.19.0-ec.0
+to: 4.19.0-ec.3
 from: 4[.](18[.]0-(ec[.].*|rc[.][0-3])|19[.]0-ec[.]0)
+fixedIn: 4.19.0-ec.4
 url: https://issues.redhat.com/browse/MCO-1585
 name: LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO
 message: Some clusters with some KubeletConfigs or ContainerRuntimeConfigs will have issues updating MachineConfigPools.


### PR DESCRIPTION
> @ota-monitor: Cincinnati stabilization:
> * FAILED PreRelease affects 4.18.0-rc.10.  Either declare a fix version or extend the risk to 4.18.1.
> * FAILED LabeledMachineConfigAndContainerRuntimeConfigBlocksMCO affects 4.19.0-ec.1 and is not fixed until 4.19.0-ec.4.  Extend the risk to 4.19.0-ec.2.

Unsure why these started to appear now, seems enabled by https://github.com/openshift/cincinnati-graph-data/pull/7239

I am not sure why https://github.com/openshift/cincinnati-graph-data/pull/7020 did not add files for ec2 and ec3 when it knew the fix is in ec4 but there is no harm in filling the blanks.
