### PR TITLE
Start to use hack/requirements.txt

### DIFF
--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,1 +1,2 @@
-PyGithub==1.52
+PyGithub >= 1.55
+PyYAML >= 5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-PyGithub >= 1.55
-PyYAML >= 5.4.0


### PR DESCRIPTION
There are two of them in the repo:
- requirements.txt
- hack/requirements.txt

`hack/requirements.txt` is preferred because it is where the python scripts stay and the file is not part of the grapha-data consumed by Cincinnati.