### PR TITLE
OCPCLOUD-2975: Declare NonZonalAzureMachineSetScaling Risk

### DIFF
--- a/blocked-edges/4.15.48-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.15.48-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.15.48
+from: ^4[.](14[.].*|15[.]([1-3]?[0-9]|4[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.15.49-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.15.49-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.15.49
+from: ^4[.](14[.].*|15[.]([1-3]?[0-9]|4[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.15.50-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.15.50-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.15.50
+from: ^4[.](14[.].*|15[.]([1-3]?[0-9]|4[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.15.51-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.15.51-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.15.51
+from: ^4[.](14[.].*|15[.]([1-3]?[0-9]|4[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.16.38-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.16.38-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.16.38
+from: ^4[.](15[.]([1-3]?[0-9]|4[0-7])|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.16.39-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.16.39-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.16.39
+from: ^4[.](15[.]([1-3]?[0-9]|4[0-7])|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.16.40-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.16.40-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.16.40
+from: ^4[.](15[.]([1-3]?[0-9]|4[0-7])|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.17-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.17-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.17
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.18-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.18-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.18
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.19-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.19-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.19
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.20-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.20-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.20
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.21-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.21-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.21
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.22-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.22-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.22
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.23-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.23-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.23
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.24-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.24-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.24
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.25-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.25-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.25
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.26-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.26-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.26
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.27-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.27-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.27
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.28-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.28-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.28
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.29-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.29-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.29
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.30-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.30-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.30
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.1-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.1-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.1
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.10-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.10-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.10
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.11-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.11-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.11
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.12-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.12-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.12
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.13-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.13-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.13
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.14-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.14-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.14
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.2-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.2-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.2
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.3-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.3-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.3
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.4-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.4-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.4
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.5-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.5-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.5
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.6-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.6-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.6
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.7-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.7-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.7
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.8-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.8-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.8
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.9-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.9-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.9
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )


### PR DESCRIPTION
The related impact statement: https://issues.redhat.com/browse/OCPCLOUD-2975

---

Created `blocked-edges/4.15.48-NonZonalAzureMachineSetScaling.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.15&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]15[.]\(4[9]\|[5-9][0-9]\)$' | while read VERSION; do sed "s/4.15.48/${VERSION}/" blocked-edges/4.15.48-NonZonalAzureMachineSetScaling.yaml > "blocked-edges/${VERSION}-NonZonalAzureMachineSetScaling.yaml"; done
```

---

Created `blocked-edges/4.16.38-NonZonalAzureMachineSetScaling.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]\(3[9]\|[4-9][0
-9]\)$' | while read VERSION; do sed "s/4.16.38/${VERSION}/" blocked-edges/4.16.38-NonZonalAzureMachineSetScaling.yaml > "blocked-edges/${VERSION}-NonZonalAzureMachineSetScaling.yaml"; done
```

---

Created `blocked-edges/4.17.17-NonZonalAzureMachineSetScaling.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.17&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]17[.]\(1[8-9]\|[2-9]
[0-9]\)$' | while read VERSION; do sed "s/4.17.17/${VERSION}/" blocked-edges/4.17.17-NonZonalAzureMachineSetScaling.yaml > "blocked-edges/${VERSION}-NonZonalAzureMachineSetScaling.yaml"; done
```

---

Created `blocked-edges/4.18.1-NonZonalAzureMachineSetScaling.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18[.]\([2-9]\|[1-9][
0-9]\)$' | while read VERSION; do sed "s/4.18.1/${VERSION}/" blocked-edges/4.18.1-NonZonalAzureMachineSetScaling.yaml > "blocked-edges/${VERSION}-NonZonalAzureMachineSetScaling.yaml"; done
```