### PR TITLE
OCPCLOUD-2975: blocked-edges:*-NonZonalAzureMachineSetScaling: Extend to 4.16.41, 4.17.31, and 4.18.15

### DIFF
--- a/blocked-edges/4.16.41-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.16.41-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.16.41
+from: ^4[.](15[.]([1-3]?[0-9]|4[0-7])|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.17.31-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.17.31-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.17.31
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )

--- a/blocked-edges/4.18.15-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.18.15-NonZonalAzureMachineSetScaling.yaml
@@ -1,0 +1,16 @@
+to: 4.18.15
+from: ^4[.](17[.]([0-9]|1[0-6]))[+].*$
+
+url: https://issues.redhat.com/browse/OCPCLOUD-2975
+name: NonZonalAzureMachineSetScaling
+message: |-
+  Azure Clusters in non-zonal regions will fail at scaling MachineSets created in earlier versions.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="Azure"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )


### PR DESCRIPTION
[OCPBUGS-56380][1] is still `POST` for 4.20, so still waiting on fixes.

[1]: https://issues.redhat.com/browse/OCPBUGS-56380