### PR TITLE
MCO-1702: Declare RHELFailedRebootMissingService Risk

### DIFF
--- a/blocked-edges/4.16.38-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.16.38-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.16.38
+from: ^4[.](15[.].*|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.39-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.16.39-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.16.39
+from: ^4[.](15[.].*|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.40-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.16.40-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.16.40
+from: ^4[.](15[.].*|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.16.41-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.16.41-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.16.41
+from: ^4[.](15[.].*|16[.]([1-2]?[0-9]|3[0-7]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.22-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.22-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.22
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.23-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.23-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.23
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.24-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.24-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.24
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.25-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.25-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.25
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.26-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.26-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.26
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.27-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.27-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.27
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.28-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.28-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.28
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.29-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.29-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.29
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.30-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.30-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.30
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.17.31-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.17.31-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.17.31
+from: ^4[.](16[.]([1-2]?[0-9]|3[0-7])|17[.]([1]?[0-9]|2[0-1]))[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.10-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.10-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.10
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.11-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.11-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.11
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.12-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.12-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.12
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.13-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.13-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.13
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.14-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.14-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.14
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.15-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.15-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.15
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.6-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.6-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.6
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.7-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.7-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.7
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.8-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.8-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.8
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )

--- a/blocked-edges/4.18.9-RHELFailedRebootMissingService.yaml
+++ b/blocked-edges/4.18.9-RHELFailedRebootMissingService.yaml
@@ -1,0 +1,14 @@
+to: 4.18.9
+from: ^4[.](17[.]([1]?[0-9]|2[0-1])|18[.][0-5])[+].*$
+url: https://issues.redhat.com/browse/MCO-1702
+name: RHELFailedRebootMissingService
+message: RHEL worker nodes will fail to reboot during a node update due to a missing service.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        group by (label_node_openshift_io_os_id) (kube_node_labels{_id="",label_node_openshift_io_os_id="rhel"})
+        or
+        0 * group by (label_node_openshift_io_os_id) (kube_node_labels{_id=""})
+      )


### PR DESCRIPTION
The related impact statement: https://issues.redhat.com/browse/MCO-1702.

---

Created `blocked-edges/4.16.38-RHELFailedRebootMissingService.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.16&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]16[.]\(3[9-9]\|[4-9][0-9]\)$' | while read VERSION; do sed "s/4.16.38/${VERSION}/" blocked-edges/4.16.38-RHELFailedRebootMissingService.yaml > "blocked-edges/${VERSION}-RHELFailedRebootMissingService.yaml"; done
```

---

Created `blocked-edges/4.17.22-RHELFailedRebootMissingService.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.17&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]17[.]\(2[3-9]\|[3-9][0-9]\)$' | while read VERSION; do sed "s/4.17.22/${VERSION}/" blocked-edges/4.1
7.22-RHELFailedRebootMissingService.yaml > "blocked-edges/${VERSION}-RHELFailedRebootMissingService.yaml"; done
```

---

Created `blocked-edges/4.18.6-RHELFailedRebootMissingService.yaml` manually

Run:

```sh
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18[.]\([7-9]\|[1-9][0-9]\)$' | while read VERSION; do sed "s/4.18.6/${VERSION}/" blocked-edges/4.18.
6-RHELFailedRebootMissingService.yaml > "blocked-edges/${VERSION}-RHELFailedRebootMissingService.yaml"; done
```
