### PR TITLE
OCPBUGS-55638: OCPBUGS-55637: raise minor_min to 4.18.16

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.13
+  minor_min: 4.18.16
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0-ec.0


### PR DESCRIPTION
This includes admin-acks that handle [1] and [2], which we want cluster admins to evaluate before they update to 4.19.

[1]: https://issues.redhat.com//browse/OCPBUGS-55638
[2]: https://issues.redhat.com//browse/OCPBUGS-55637