### PR TITLE
blocked-edges/4.15.51-NonZonalAzureMachineSetScaling: Fixed in 4.15.52

### DIFF
--- a/blocked-edges/4.15.51-NonZonalAzureMachineSetScaling.yaml
+++ b/blocked-edges/4.15.51-NonZonalAzureMachineSetScaling.yaml
@@ -1,6 +1,6 @@
 to: 4.15.51
 from: ^4[.](14[.].*|15[.]([1-3]?[0-9]|4[0-7]))[+].*$
-
+fixedIn: 4.15.52
 url: https://issues.redhat.com/browse/OCPCLOUD-2975
 name: NonZonalAzureMachineSetScaling
 message: |-


### PR DESCRIPTION
[4.15.52][1] contains [OCPBUGS-56657][2].

[1]: https://multi.ocp.releases.ci.openshift.org/releasestream/4-stable-multi/release/4.15.52
[2]: https://issues.redhat.com/browse/OCPBUGS-56657