### PR TITLE
internal-channels/candidate: Tombstone 4.20.0-ec.1

### DIFF
--- a/internal-channels/candidate.yaml
+++ b/internal-channels/candidate.yaml
@@ -105,6 +105,8 @@ tombstones:
 - 4.12.62
 # 4.17.13: Late rejection of an early kernel
 - 4.17.13
+# 4.20.0-ec.1 included a self-reference in its .metadata.previous section
+- 4.20.0-ec.1
 versions:
 - 4.5.0-0.hotfix-2020-08-24-185832
 - 4.5.0-0.hotfix-2020-11-28-021842


### PR DESCRIPTION
We don't want this self-referential update in public channels:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.20.0-ec.1-x86_64 -o json | jq -c '{digest, previous: .metadata.previous}'
{"digest":"sha256:b7acb7ffbaf23be6fd4d06ce10e68ef1209c131211f50af67316d718145410a9","previous":["4.19.0-rc.4","4.20.0-ec.1"]}
```