### PR TITLE
block edges from all 4.18 to 4.19 with vsphere provider storage issues

### DIFF
--- a/blocked-edges/4.19.0-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.0-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.0-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.0
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.1-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.1-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.2-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.2-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.2
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.3-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.3-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.3
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.4-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.4-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.4
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.5-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.5-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-ec.5
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.0-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.0-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.0
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.1-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.1-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.2-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.2-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.2
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.3-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.3-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.3
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.4-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.4-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.4
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.5-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.5-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.0-rc.5
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.1-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.1-VSphereStorageMountIssues.yaml
@@ -1,0 +1,12 @@
+to: 4.19.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/STOR-2486
+name: VSphereStorageMountIssues
+message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        or
+        0 * group(cluster_infrastructure_provider)


### PR DESCRIPTION
Clusters running on the vSphere platform with the vSphere CSI driver mounting VSAN Files volumes whenever VSAN is not fully patched and up to date.
Nodes cannot mount NFS volumes from VSAN files provider.
Blocking all the affected edges