### PR TITLE
CORENET-6114: Set up OVNEgressIPFailure to block paths to 4.18

### DIFF
--- a/blocked-edges/4.18.1-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.1-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.1
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.10-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.10-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.10
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.11-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.11-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.11
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.12-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.12-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.12
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.13-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.13-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.13
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.14-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.14-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.14
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.15-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.15-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.15
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.16-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.16-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.16
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.17-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.17-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.17
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.2-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.2-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.2
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.3-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.3-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.3
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.4-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.4-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.4
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.5-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.5-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.5
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.6-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.6-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.6
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.7-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.7-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.7
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.8-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.8-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.8
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})

--- a/blocked-edges/4.18.9-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.9-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.9
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})


### PR DESCRIPTION
```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18' | sort -V | grep -v '^4.18.1$' | grep -v '^4.18.0-ec' | grep -v '^4.18.0-rc' | while read VERSION; do sed "s/4.18.1/${VERSION}/" blocked-edges/4.18.1-OVNEgressIPFailure.yaml > "blocked-edges/${VERSION}-OVNEgressIPFailure.yaml"; done
```

/hold

Wait a bit for [CORENET-6114](https://issues.redhat.com//browse/CORENET-6114) to be polished up