### PR TITLE
Extend OldBootImagesComposeFSvsGrubProbe to 4.19.1

### DIFF
--- a/blocked-edges/4.19.1-OldBootImagesComposeFSvsGrubProbe.yaml
+++ b/blocked-edges/4.19.1-OldBootImagesComposeFSvsGrubProbe.yaml
@@ -1,0 +1,15 @@
+to: 4.19.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/COS-3357
+name: OldBootImagesComposeFSvsGrubProbe
+message: |-
+  Upgrade to 4.19 will fail due to a boot image incompatibility issue if a cluster was born in 4.2 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk(1,
+        label_replace(group by (version) (cluster_version{_id="",type="initial",version=~"4[.][0-9][.].*"}),"born_by_4_9", "yes, so possibly actually born in 4.2 or earlier", "", "")
+        or
+        label_replace(0 * group by (version) (cluster_version{_id="",type="initial",version!~"4[.][0-9][.].*"}),"born_by_4_9", "no, born in 4.10 or later", "", "")
+      )


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/C02MX20TV24/p1750433340854259

https://issues.redhat.com/browse/OCPBUGS-52485 is still not resolved at the moment (June 20, 2025).

```
$ cp blocked-edges/4.19.0-OldBootImagesComposeFSvsGrubProbe.yaml blocked-edges/4.19.1-OldBootImagesComposeFSvsGrubProbe.yaml
```
Then replaced `to` in the new file.