### PR TITLE
Extend OVNEgressIPFailure to 4.18.18

### DIFF
--- a/blocked-edges/4.18.18-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.18-OVNEgressIPFailure.yaml
@@ -1,0 +1,13 @@
+to: 4.18.18
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: |-
+  EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+      or
+      0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/C02MX20TV24/p1750433340854259

https://issues.redhat.com/browse/OCPBUGS-57179 is still unresolved at the moment (June 20 2025).

```console
$ cp blocked-edges/4.18.17-OVNEgressIPFailure.yaml blocked-edges/4.18.18-OVNEgressIPFailure.yaml
```

Then replaced `to` in the new file.