### PR TITLE
MON-4270: Set 4.18.19 as the minor_min for 4.19 upgrade

### DIFF
--- a/build-suggestions/4.19.yaml
+++ b/build-suggestions/4.19.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.18.16
+  minor_min: 4.18.19
   minor_max: 4.18.9999
   minor_block_list: []
   z_min: 4.19.0


### PR DESCRIPTION
Using Alertmanager apiVersion v1 in openshift-monitoring/cluster-monitoring-config or openshift-user-workload-monitoring/user-workload-monitoring-config will cause (InvalidConfigXXX) as OCP 4.19 is using Prometheus V3 and Alertmanager apiVersions v1 is not supported in it. With the change included in 4.18.19, it will set CMO upgradable=false if apiVersion: v1 is detected in the config maps. Hence making it as minor_min version before upgrading to 4.19

cc @machine424 