### PR TITLE
CONSOLE-4632: Set up ConsoleEnabledTargetDownAlert to block paths to 4.1[789]

### DIFF
--- a/blocked-edges/4.17.29-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.29-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.17.29
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.17.30-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.30-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.17.30
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.17.31-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.31-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.17.31
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.17.32-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.32-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.17.32
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.17.33-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.33-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.17.33
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.17.34-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.17.34-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,10 @@
+to: 4.17.34
+from: ^4[.](16[.].*|17[.](2[0-8]|[1]?[0-9]))[+].*$
+fixedIn: 4.17.35
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.12-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.12-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.18.12
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.13-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.13-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.18.13
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.14-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.14-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.18.14
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.15-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.15-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.18.15
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.16-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.16-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,9 @@
+to: 4.18.16
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.18.17-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.18.17-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,10 @@
+to: 4.18.17
+from: ^4[.](17[.](2[0-8]|[1]?[0-9])|18[.](1[01]|[0-9]))[+].*$
+fixedIn: 4.18.18
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})

--- a/blocked-edges/4.19.0-ConsoleEnabledTargetDownAlert.yaml
+++ b/blocked-edges/4.19.0-ConsoleEnabledTargetDownAlert.yaml
@@ -1,0 +1,10 @@
+to: 4.19.0
+from: ^4[.]18[.](1[01]|[0-9])[+].*$
+fixedIn: 4.19.1
+url: https://issues.redhat.com/browse/CONSOLE-4632
+name: ConsoleEnabledTargetDownAlert
+message: The alert TargetDown is triggered if the capability Console is enabled on the cluster.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: max(cluster_version_capability{name="Console"})


### PR DESCRIPTION
Affected version:

- 4.19.0
- 4.18.12 / 4.18.13 / 4.18.14 / 4.18.15 / 4.18.16 / 4.18.17
- 4.17.29 / 4.17.30 / 4.17.31 / 4.17.32 / 4.17.33 / 4.17.34

Fixed in:

- 4.19.1
- 4.18.18
- 4.17.35

An example of cmd:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18' | sort -V | gsed "0,/4.18.12/d" | gsed '/4.18.17/q' | while read VERSION; do g\sed "s/4.18.12/${VERSION}/" blocked-edges/4.18.12-ConsoleEnabledTargetDownAlert.yaml > "blocked-edges/${VERSION}-ConsoleEnabledTargetDownAlert.yaml"; done
```

