### PR TITLE
`VSphereStorageMountIssues`: Fixed in 4.19.3

### DIFF
--- a/blocked-edges/4.19.2-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.2-VSphereStorageMountIssues.yaml
@@ -1,5 +1,6 @@
 to: 4.19.2
 from: 4[.]18[.].*
+fixedIn: 4.19.3
 url: https://issues.redhat.com/browse/STOR-2486
 name: VSphereStorageMountIssues
 message: vSphere customers using vSAN file volumes can't mount vSphere shared volumes and NFS volumes which server do not set NFS4ERR_ATTRNOTSUPP


### PR DESCRIPTION
I do not see [OCPBUGS-55978](https://issues.redhat.com/browse/OCPBUGS-55978) in [4.19.3 on r-c](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.3) but the bug itself links to [RHBA-2025:10290](https://errata.engineering.redhat.com/advisory/151748).
