### PR TITLE
`OVNEgressIPFailure`: Extend to 4.18.20

### DIFF
--- a/blocked-edges/4.18.20-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.20-OVNEgressIPFailure.yaml
@@ -1,0 +1,12 @@
+to: 4.18.20
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6114
+name: OVNEgressIPFailure
+message: EgressIP functionality may fail if the cluster has assigned EgressIPs.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+        group(ovnkube_clustermanager_num_egress_ips{_id=""} > 0)
+        or
+        0 * group(ovnkube_clustermanager_num_egress_ips{_id=""})


### PR DESCRIPTION
OCPBUGS-57179 targeting 4.20 is still in POST
