### PR TITLE
CNTRLPLANE-1110: Issue `HCPServiceHealthCheckDisruption` for 4.18 -> 4.19.[0-4]

### DIFF
--- a/blocked-edges/4.19.0-HCPServiceHealthCheckDisruption.yaml
+++ b/blocked-edges/4.19.0-HCPServiceHealthCheckDisruption.yaml
@@ -3,7 +3,7 @@ from: 4.18[.].*
 url: https://issues.redhat.com/browse/CNTRLPLANE-1110
 name: HCPServiceHealthCheckDisruption
 message: |-
-  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update the control plane, the Services of type
+  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update a node pool, the Services of type
   LoadBalancer may experience temporary availability disruption because health checks are not set up properly to monitor
   Node readiness state.
 matchingRules:
@@ -15,9 +15,8 @@ matchingRules:
           or
           0 * group by (_id, invoker) (cluster_installer{_id=""})
         )
-        and on (_id) (
-          group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
-        )
-        or on (_id) (
-          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        * on (_id) group_left (type) (
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
         )

--- a/blocked-edges/4.19.1-HCPServiceHealthCheckDisruption.yaml
+++ b/blocked-edges/4.19.1-HCPServiceHealthCheckDisruption.yaml
@@ -3,7 +3,7 @@ from: 4.18[.].*
 url: https://issues.redhat.com/browse/CNTRLPLANE-1110
 name: HCPServiceHealthCheckDisruption
 message: |-
-  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update the control plane, the Services of type
+  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update a node pool, the Services of type
   LoadBalancer may experience temporary availability disruption because health checks are not set up properly to monitor
   Node readiness state.
 matchingRules:
@@ -15,9 +15,8 @@ matchingRules:
           or
           0 * group by (_id, invoker) (cluster_installer{_id=""})
         )
-        and on (_id) (
-          group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
-        )
-        or on (_id) (
-          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        * on (_id) group_left (type) (
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
         )

--- a/blocked-edges/4.19.2-HCPServiceHealthCheckDisruption.yaml
+++ b/blocked-edges/4.19.2-HCPServiceHealthCheckDisruption.yaml
@@ -3,7 +3,7 @@ from: 4.18[.].*
 url: https://issues.redhat.com/browse/CNTRLPLANE-1110
 name: HCPServiceHealthCheckDisruption
 message: |-
-  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update the control plane, the Services of type
+  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update a node pool, the Services of type
   LoadBalancer may experience temporary availability disruption because health checks are not set up properly to monitor
   Node readiness state.
 matchingRules:
@@ -15,9 +15,8 @@ matchingRules:
           or
           0 * group by (_id, invoker) (cluster_installer{_id=""})
         )
-        and on (_id) (
-          group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
-        )
-        or on (_id) (
-          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        * on (_id) group_left (type) (
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
         )

--- a/blocked-edges/4.19.3-HCPServiceHealthCheckDisruption.yaml
+++ b/blocked-edges/4.19.3-HCPServiceHealthCheckDisruption.yaml
@@ -3,7 +3,7 @@ from: 4.18[.].*
 url: https://issues.redhat.com/browse/CNTRLPLANE-1110
 name: HCPServiceHealthCheckDisruption
 message: |-
-  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update the control plane, the Services of type
+  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update a node pool, the Services of type
   LoadBalancer may experience temporary availability disruption because health checks are not set up properly to monitor
   Node readiness state.
 matchingRules:
@@ -15,9 +15,8 @@ matchingRules:
           or
           0 * group by (_id, invoker) (cluster_installer{_id=""})
         )
-        and on (_id) (
-          group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
-        )
-        or on (_id) (
-          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        * on (_id) group_left (type) (
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
         )

--- a/blocked-edges/4.19.4-HCPServiceHealthCheckDisruption.yaml
+++ b/blocked-edges/4.19.4-HCPServiceHealthCheckDisruption.yaml
@@ -4,7 +4,7 @@ fixedIn: 4.19.5
 url: https://issues.redhat.com/browse/CNTRLPLANE-1110
 name: HCPServiceHealthCheckDisruption
 message: |-
-  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update the control plane, the Services of type
+  When Hosted Control Plane (HCP/HyperShift) clusters running on AWS update a node pool, the Services of type
   LoadBalancer may experience temporary availability disruption because health checks are not set up properly to monitor
   Node readiness state.
 matchingRules:
@@ -16,9 +16,8 @@ matchingRules:
           or
           0 * group by (_id, invoker) (cluster_installer{_id=""})
         )
-        and on (_id) (
-          group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
-        )
-        or on (_id) (
-          0 * group by (type) (cluster_infrastructure_provider{_id=""})
+        * on (_id) group_left (type) (
+          group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+          or
+          0 * group by (_id, type) (cluster_infrastructure_provider{_id=""})
         )


### PR DESCRIPTION
Set up a known issue for HyperShift hosted clusters on AWS. PromQL was taken and adapted from earlier `HCPMetallbCNOCannotDeployFRRK8S` and `AWSCustomDomainNodesNotReady`

I do not have a suitable HCP cluster at hand but I tested the PromQL structurally on a standalone AWS cluster:

```
(
  group by (_id, invoker) (cluster_installer{_id="",invoker="user"})
  or
  0 * group by (_id, invoker) (cluster_installer{_id=""})
)
and on (_id) (
  group by (type) (cluster_infrastructure_provider{_id="",type="AWS"})
)
or on (_id) (
  0 * group by (type) (cluster_infrastructure_provider{_id=""})
)
```
