### PR TITLE
COS-3357: blocked-edges/4.19.4-OldBootImagesComposeFSvsGrubProbe: Fixed in 4.19.5

### DIFF
--- a/blocked-edges/4.19.4-OldBootImagesComposeFSvsGrubProbe.yaml
+++ b/blocked-edges/4.19.4-OldBootImagesComposeFSvsGrubProbe.yaml
@@ -1,5 +1,6 @@
 to: 4.19.4
 from: 4[.]18[.].*
+fixedIn: 4.19.5
 url: https://issues.redhat.com/browse/COS-3357
 name: OldBootImagesComposeFSvsGrubProbe
 message: Upgrade to 4.19 will fail due to a boot image incompatibility issue if a cluster was born in 4.2 or earlier.


### PR DESCRIPTION
[RHCOS 9.6.20250710-0 picked up the fixes, including bootupd-0.2.27-4.el9_6.x86_64][1].  And [4.19.5 is based on the later 9.6.20250715-0, which also includes 0.2.27-4.el9_6][2].

[1]: https://issues.redhat.com/browse/OCPBUGS-52485?focusedId=27601346&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27601346
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.5