### PR TITLE
Block edges to 4.19 for ARO clusters 

### DIFF
--- a/blocked-edges/4.19.0-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.0-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.0
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.1-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.1-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.1
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.2-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.2-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.2
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.3-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.3-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.3
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.4-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.4-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.4
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.5-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.5-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.5
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-20086
https://access.redhat.com/solutions/7128495

Blocks all upgrades to 4.19 for ARO clusters. New Machines in 4.19 ARO clusters fail to come up due to a missing Internal LB IP missing in the SAN of the cert issued by MCO. 