### PR TITLE
Update AROMissingInternalLBSAN edges with reference to OCPBUGS

### DIFF
--- a/blocked-edges/4.19.0-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.0-AROMissingInternalLBSAN.yaml
@@ -3,7 +3,7 @@ from: 4.18.*
 url: https://access.redhat.com/solutions/7128495
 name: AROMissingInternalLBSAN
 message: |-
-  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.19.1-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.1-AROMissingInternalLBSAN.yaml
@@ -3,7 +3,7 @@ from: 4.18.*
 url: https://access.redhat.com/solutions/7128495
 name: AROMissingInternalLBSAN
 message: |-
-  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.19.2-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.2-AROMissingInternalLBSAN.yaml
@@ -3,7 +3,7 @@ from: 4.18.*
 url: https://access.redhat.com/solutions/7128495
 name: AROMissingInternalLBSAN
 message: |-
-  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.19.4-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.4-AROMissingInternalLBSAN.yaml
@@ -3,7 +3,7 @@ from: 4.18.*
 url: https://access.redhat.com/solutions/7128495
 name: AROMissingInternalLBSAN
 message: |-
-  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
 matchingRules:
 - type: PromQL
   promql:

--- a/blocked-edges/4.19.5-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.5-AROMissingInternalLBSAN.yaml
@@ -3,7 +3,7 @@ from: 4.18.*
 url: https://access.redhat.com/solutions/7128495
 name: AROMissingInternalLBSAN
 message: |-
-  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
 matchingRules:
 - type: PromQL
   promql:


### PR DESCRIPTION
Now that https://issues.redhat.com/browse/OCPBUGS-59780 exists to track this issue, adding a reference in the description text for the blocked edges for AROMissingInternalLBSAN