### PR TITLE
VSphereStorageMountIssues: vSphere -> VSphere in promql

### DIFF
--- a/blocked-edges/4.19.0-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-VSphereStorageMountIssues.yaml
@@ -7,6 +7,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-ec.0-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-ec.0-VSphereStorageMountIssues.yaml
@@ -7,6 +7,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.4-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.4-VSphereStorageMountIssues.yaml
@@ -7,6 +7,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.0-rc.5-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.0-rc.5-VSphereStorageMountIssues.yaml
@@ -7,6 +7,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.1-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.1-VSphereStorageMountIssues.yaml
@@ -7,6 +7,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)

--- a/blocked-edges/4.19.2-VSphereStorageMountIssues.yaml
+++ b/blocked-edges/4.19.2-VSphereStorageMountIssues.yaml
@@ -8,6 +8,6 @@ matchingRules:
   - type: PromQL
     promql:
       promql: |
-        group(cluster_infrastructure_provider{type=~"vSphere|None"})
+        group(cluster_infrastructure_provider{type=~"VSphere|None"})
         or
         0 * group(cluster_infrastructure_provider)


### PR DESCRIPTION
It uses both `vSphere` and `VSphere` in https://github.com/openshift/cincinnati-graph-data/pull/7380

Other places with `cluster_infrastructure_provider` seems using `VSphere` all the time.