### PR TITLE
PatchesOlderRelease: unify the message

### DIFF
--- a/blocked-edges/4.11.36-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.11.36-PatchesOlderRelease.yaml
@@ -4,6 +4,6 @@ fixedIn: 4.11.37
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease
 message: |-
-  The 4.11.36 release only resolves an installation issue https://issues.redhat.com//browse/OCPBUGS-11663 , which does not affect already running clusters. 4.11.36 does not include fixes delivered in recent 4.11.z releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to 4.11.36 version for this reason.
+  The target release only resolves an installation issue (the https://issues.redhat.com/browse/OCPBUGS-11662 series), which does not affect already running clusters. It does not include fixes delivered in recent patch releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to the target version for this reason.
 matchingRules:
 - type: Always

--- a/blocked-edges/4.12.12-PatchesOlderRelease.yaml
+++ b/blocked-edges/4.12.12-PatchesOlderRelease.yaml
@@ -4,6 +4,6 @@ fixedIn: 4.12.13
 url: https://access.redhat.com/solutions/7007136
 name: PatchesOlderRelease
 message: |-
-  The 4.12.12 release only resolves an installation issue https://issues.redhat.com//browse/OCPBUGS-11662 , which does not affect already running clusters. 4.12.12 does not include fixes delivered in recent 4.11.z and 4.12.z releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to 4.12.12 version for this reason.
+  The target release only resolves an installation issue (the https://issues.redhat.com/browse/OCPBUGS-11662 series), which does not affect already running clusters. It does not include fixes delivered in recent patch releases and therefore upgrading from these versions would cause fixed bugs to reappear. Red Hat does not recommend upgrading clusters to the target version for this reason.
 matchingRules:
 - type: Always


### PR DESCRIPTION
I admit it is less clear than the existing version specific messages, but it delievers the main points:

- The underlying issue does not affect running clusters, and thus any cluster upgrade either.
- Previous fixed bugs may reappear and thus RH does not recommend upgrade to it.

