### PR TITLE
EarlyAPICertRotation: : unify the message

### DIFF
--- a/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
+++ b/blocked-edges/4.15.0-rc.0-EarlyAPICertRotation.yaml
@@ -2,7 +2,7 @@ to: 4.15.0-rc.0
 from: 4[.]14[.].*
 url: https://issues.redhat.com/browse/API-1687
 name: EarlyAPICertRotation
-message: Clusters born in 4.7 and earlier or older than one month will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
+message: Clusters born in 4.7 and earlier will trigger an api-int certificate authority rollout, and bugs in that rollout may break kubelet access to the Kubernetes API service.
 matchingRules:
   - type: PromQL
     promql:


### PR DESCRIPTION
Feels like it is missed in https://github.com/openshift/cincinnati-graph-data/pull/4864/files#diff-3f70c11efe92a235472ac9ba86a5642685ff0ed6c255fa4a6f286d0c90953c43R5