### PR TITLE
CORENET-6196: blocked-edges/4.19.7: Extend AROMissingInternalLBSAN and IPsecLargeClusterConnectivity

### DIFF
--- a/blocked-edges/4.19.7-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.7-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,12 @@
+to: 4.19.7
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})

--- a/blocked-edges/4.19.7-IPsecLargeClusterConnectivity.yaml
+++ b/blocked-edges/4.19.7-IPsecLargeClusterConnectivity.yaml
@@ -1,0 +1,18 @@
+to: 4.19.7
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/CORENET-6196
+name: IPsecLargeClusterConnectivity
+message: Large clusters with enabled IPsec might experience intermittent loss of pod-to-pod connectivity. This prevents some pods on certain nodes from reaching services on other nodes, resulting in connection timeouts.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "enabled", "", "") == 1)
+        or on (_id)
+        0 * group by (ipsec) (label_replace(max_over_time(ovnkube_controller_ipsec_enabled{_id=""}[1h]), "ipsec", "disabled", "", "") == 0)
+      ) and on (_id) (
+        group by (resource) (max_over_time(apiserver_storage_objects{_id="",resource="nodes"}[1h]) > 120)
+      )
+      or on (_id)
+      0 * group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
[OCPBUGS-59978][1] has merged into the 4.19, but too late to have made [4.19.7][2].
[OCPBUGS-55453][3] is still New.

[1]: https://issues.redhat.com/browse/OCPBUGS-59978
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.7
[3]: https://issues.redhat.com/browse/OCPBUGS-55453