### PR TITLE
OCPCLOUD-3052: blocked-edges/4.19.*-NoCloudConfConfigMap: Declare new risk for 4.18 -> 4.19

### DIFF
--- a/blocked-edges/4.19.0-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.0-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.0
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.1-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.1-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.2-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.2-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.2
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.3-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.3-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.3
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.4-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.4-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.4
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.5-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.5-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.5
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.6-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.6-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.6
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )

--- a/blocked-edges/4.19.7-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.7-NoCloudConfConfigMap.yaml
@@ -1,0 +1,21 @@
+to: 4.19.7
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/OCPCLOUD-3052
+name: NoCloudConfConfigMap
+message: |-
+  Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      bottomk by (_id) (1,
+        0 * group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager",configmap="cloud-conf"})
+        or
+        group by (_id, namespace, configmap) (kube_configmap_info{_id="",namespace="openshift-cloud-controller-manager"})
+      )
+      * on (_id) group_left (type)
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type="AWS"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!="AWS"})
+      )


### PR DESCRIPTION
Generated by writing the 4.19.0 file by hand, and copying out with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.19&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]19[.][0-9]*$' | grep -v '4[.]19[.]0' | while read VERSION; do sed "s/4.19.0/${VERSION}/" blocked-edges/4.19.0-NoCloudConfConfigMap.yaml > "blocked-edges/${VERSION}-NoCloudConfConfigMap.yaml"; done
```