### PR TITLE
CORENET-6114: blocked-edges/4.18.21-OVNEgressIPFailure: Fixed in 4.18.22

### DIFF
--- a/blocked-edges/4.18.21-OVNEgressIPFailure.yaml
+++ b/blocked-edges/4.18.21-OVNEgressIPFailure.yaml
@@ -1,5 +1,6 @@
 to: 4.18.21
 from: 4[.]17[.].*
+fixedIn: 4.18.22
 url: https://issues.redhat.com/browse/CORENET-6114
 name: OVNEgressIPFailure
 message: EgressIP functionality may fail if the cluster has assigned EgressIPs.


### PR DESCRIPTION
[4.18.22][1] contains [OCPBUGS-59531][2].

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.18.22
[2]: https://issues.redhat.com/browse/OCPBUGS-59531