### PR TITLE
`RHEL96Kernel331Panic`: Fixed in 4.19.9

### DIFF
--- a/blocked-edges/4.19.8-RHEL96Kernel331Panic.yaml
+++ b/blocked-edges/4.19.8-RHEL96Kernel331Panic.yaml
@@ -1,5 +1,6 @@
 to: 4.19.8
 from: 4[.].*
+fixedIn: 4.19.9
 url: https://issues.redhat.com/browse/COS-3503
 name: RHEL96Kernel331Panic
 message: |-


### PR DESCRIPTION
https://issues.redhat.com/browse/COS-3503 links to https://issues.redhat.com/browse/RHEL-108138 which claims:

```
Fixed in Build: kernel-5.14.0-570.35.1.el9_6
```

[4.19.9](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.9) lists `kernel-5.14.0-570.35.1.el9_6` in Node Image Info -> Package
