### PR TITLE
CORENET-6189: Set up WhereaboutsControllerCreateContainerError to block paths to 4.18

### DIFF
--- a/blocked-edges/4.18.1-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.1-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.1
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.10-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.10-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.10
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.11-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.11-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.11
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.12-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.12-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.12
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.13-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.13-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.13
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.14-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.14-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.14
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.15-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.15-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.15
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.16-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.16-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.16
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.17-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.17-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.17
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.18-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.18-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.18
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.19-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.19-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.19
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.2-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.2-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.2
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.20-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.20-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.20
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.21-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.21-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.21
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.3-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.3-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.3
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.4-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.4-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.4
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.5-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.5-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.5
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.6-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.6-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.6
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.7-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.7-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.7
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.8-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.8-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.8
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.18.9-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.9-WhereaboutsControllerCreateContainerError.yaml
@@ -1,0 +1,8 @@
+to: 4.18.9
+from: 4[.]17[.].*
+url: https://issues.redhat.com/browse/CORENET-6189
+name: WhereaboutsControllerCreateContainerError
+message: |-
+  The cluster update cannot complete if the cluster uses the the whereabouts shim.
+matchingRules:
+- type: Always


### PR DESCRIPTION
Create `blocked-edges/4.18.1-WhereaboutsControllerCreateContainerError.yaml` (`4.18.0` is [not in the channel](https://github.com/openshift/cincinnati-graph-data/blob/ed47d4126c1c63dae5f42dcf7d9e0d39658699d0/channels/candidate-4.18.yaml#L114-L131)) and generate the rest by:

```
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]18' | sort -V | grep -v 0-ec | grep -v 0-rc | tail -n +2 | sed '/4.18.22/,$d' | while read VERSION; do gsed "s/4.18.1/${VERSION}/" blocked-edges/4.18.1-WhereaboutsControllerCreateContainerError.yaml > "blocked-edges/${VERSION}-WhereaboutsControllerCreateContainerError.yaml"; done
```

Add `fixedIn: 4.18.22` into `blocked-edges/4.18.21-WhereaboutsControllerCreateContainerError.yaml`