### PR TITLE
MCO-1834: Set up InvalidArchitectureValueOfMachinesetsAnnotation to block paths to 4.19

### DIFF
--- a/blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.0
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.1-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.1-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.1-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.1-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.1
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.2-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.2-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.2-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.2-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.2
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.3-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.3-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.3-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.3-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.3
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.4-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.4-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.4-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.4-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.4
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.5-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.5-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.5-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.5-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.5
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.6-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.6-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.6-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.6-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.6
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -6,4 +6,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+

--- a/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,9 @@
+to: 4.19.7
+from: 4[.]18[.].*
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,0 +1,10 @@
+to: 4.19.8
+from: 4[.]18[.].*
+fixedIn: 4.19.9
+url: https://issues.redhat.com/browse/MCO-1834
+name: InvalidArchitectureValueOfMachinesetsAnnotation
+message: |
+  Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
+  multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -7,4 +7,12 @@ message: |
   Degrade machine-config cluster operator blocks the cluster update if a GCP or AWS cluster has machinesets with 
   multiple labels embedded within their "capacity.cluster-autoscaler.kubernetes.io/labels" annotation.
 matchingRules:
-- type: Always
+- type: PromQL
+  promql:
+    promql: |
+      (
+        group by (type) (cluster_infrastructure_provider{_id="",type="AWS|GCP"})
+        or
+        0 * group by (type) (cluster_infrastructure_provider{_id=""})
+      )
+


### PR DESCRIPTION
Create `blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml` and generate the rest by:

```
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.19&arch=amd64' | jq -r '.nodes[] | .version' | grep '^4[.]19' | sort -V | grep -v 0-ec | grep -v 0-rc | tail -n +2 | sed '/4.19.9/,$d' | while read VERSION; do gsed "s/4.19.0/${VERSION}/" blocked-edges/4.19.0-InvalidArchitectureValueOfMachinesetsAnnotation.yaml > "blocked-edges/${VERSION}-InvalidArchitectureValueOfMachinesetsAnnotation.yaml"; done
```

Add `fixedIn: 4.19.9` into `blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml`

I think we may use PromQL to narrow down the damage range but with the fix shipped in `4.19.9` which landed in [Fast-4.19](https://github.com/openshift/cincinnati-graph-data/blob/807e85a92fcdf59d159ddd05a6245ad0db3e0b93/channels/fast-4.19.yaml#L37), it might be not that important (which is how I interpret @wking 's [msg](https://redhat-internal.slack.com/archives/CJ1J9C3V4/p1755497912093249)).