### PR TITLE
MCO-1834: fixed in 4.18.22

### DIFF
--- a/blocked-edges/4.18.21-WhereaboutsControllerCreateContainerError.yaml
+++ b/blocked-edges/4.18.21-WhereaboutsControllerCreateContainerError.yaml
@@ -1,5 +1,6 @@
 to: 4.18.21
 from: 4[.]17[.].*
+fixedIn: 4.18.22
 url: https://issues.redhat.com/browse/CORENET-6189
 name: WhereaboutsControllerCreateContainerError
 message: |-


### PR DESCRIPTION
This is missed in https://github.com/openshift/cincinnati-graph-data/pull/7831

(I must have screwed `CMD+z` or something)

/cc @petr-muller 