### PR TITLE
MCO-1834: Add fixedIn into 4.19.7 claim

### DIFF
--- a/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
+++ b/blocked-edges/4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml
@@ -1,5 +1,6 @@
 to: 4.19.7
 from: 4[.]18[.].*
+fixedIn: 4.19.9
 url: https://issues.redhat.com/browse/MCO-1834
 name: InvalidArchitectureValueOfMachinesetsAnnotation
 message: |


### PR DESCRIPTION
We have `fixedIn: 4.19.9` claimed in [4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml](https://github.com/openshift/cincinnati-graph-data/blob/132af517dcb93bc01b9a86094048a976d47fcf76/blocked-edges/4.19.8-InvalidArchitectureValueOfMachinesetsAnnotation.yaml#L3) but still [the alert](https://redhat-internal.slack.com/archives/C02MX20TV24/p1755813703332979) is fired.

It looks like a corner case for `hack/stabilization-changes.py`:
- `4.19.8` is missing in the `Fast-4.19` channel as it is a [tombstone](https://github.com/openshift/cincinnati-graph-data/pull/7780). 
- The bug is fixed in the release `4.19.9` right next to `4.19.8`.

Before we figure out how to fix the Python script, we expect adding `fixedIn: 4.19.9` into `4.19.7-InvalidArchitectureValueOfMachinesetsAnnotation.yaml` to comfort the alert.