### PR TITLE
Add AROMissingInternalLBSAN to upgrades to 4.19.8

### DIFF
--- a/blocked-edges/4.19.8-AROMissingInternalLBSAN.yaml
+++ b/blocked-edges/4.19.8-AROMissingInternalLBSAN.yaml
@@ -1,0 +1,13 @@
+to: 4.19.0
+from: 4.18.*
+url: https://access.redhat.com/solutions/7128495
+name: AROMissingInternalLBSAN
+message: |-
+  ARO clusters on 4.19 experience issues creating new Machines due to missing the Internal LB SAN in the certificate provisioned by MCO. See https://issues.redhat.com/browse/OCPBUGS-59780
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group(cluster_operator_conditions{_id="",name="aro"})
+      or
+      0 * group(cluster_operator_conditions{_id=""})


### PR DESCRIPTION
https://issues.redhat.com//browse/OCPBUGS-59780
https://issues.redhat.com/browse/OCPBUGS-59978

The fix for this bug is pulled into 4.19.9, so upgrades to 4.19.8 need this risk added to prevent accidental upgrades to a version where this bug is still present. 