### PR TITLE
NoCloudConfConfigMap is fixed in 4.19.10

### DIFF
--- a/blocked-edges/4.19.9-NoCloudConfConfigMap.yaml
+++ b/blocked-edges/4.19.9-NoCloudConfConfigMap.yaml
@@ -1,5 +1,6 @@
 to: 4.19.9
 from: 4[.]18[.].*
+fixedIn: 4.19.10
 url: https://issues.redhat.com/browse/OCPCLOUD-3052
 name: NoCloudConfConfigMap
 message: Upgrade to 4.19 will complete due to an absent cloud-conf ConfigMap in AWS clusters born in 4.13 or earlier.


### PR DESCRIPTION
The fixed of OCPBUGS-60950 is shipped in [4.19.10](https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.10).