### PR TITLE
RUN-3446: blocked-edges/4.18.*-CrunConflictsWithNVIDIA: Declare risk

### DIFF
--- a/blocked-edges/4.18.22-CrunConflictsWithNVIDIA.yaml
+++ b/blocked-edges/4.18.22-CrunConflictsWithNVIDIA.yaml
@@ -1,0 +1,12 @@
+to: 4.18.22
+from: .*
+url: https://issues.redhat.com/browse/RUN-3446
+name: CrunConflictsWithNVIDIA
+message: Some crun 1.23 releases conflict with the NVIDIA GPU Operator over eBPF, causing issues with GPU workloads.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (name) (csv_succeeded{_id="", name=~"gpu-operator-certified[.].*"})
+      or on (_id)
+      0 * group(csv_count{_id=""})

--- a/blocked-edges/4.18.23-CrunConflictsWithNVIDIA.yaml
+++ b/blocked-edges/4.18.23-CrunConflictsWithNVIDIA.yaml
@@ -1,0 +1,12 @@
+to: 4.18.23
+from: .*
+url: https://issues.redhat.com/browse/RUN-3446
+name: CrunConflictsWithNVIDIA
+message: Some crun 1.23 releases conflict with the NVIDIA GPU Operator over eBPF, causing issues with GPU workloads.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (name) (csv_succeeded{_id="", name=~"gpu-operator-certified[.].*"})
+      or on (_id)
+      0 * group(csv_count{_id=""})


### PR DESCRIPTION
Still some uncertainty in the impact statement, and it would be nice to have NVIDIA and/or crun experts suggesting wording instead of my guessing.  But it's fairly clear that something is happening on these two releases, so get an initial warning out, and we can work on wordsmithing later.