### PR TITLE
Include examples of show-edges.py in command description

### DIFF
--- a/hack/show-edges.py
+++ b/hack/show-edges.py
@@ -389,10 +389,16 @@ def assert_path_to_minor(version, edges, blocked, target_major_minor):
 
 if __name__ == '__main__':
     import argparse
+    class HelpFormatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+        "Do not line-wrap description or epilog. Also include option defaults in the help message."
 
     parser = argparse.ArgumentParser(
-        description='Display edges for a particular channel and commit.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='''Display edges for a particular channel and commit.
+                    
+Examples:
+# show the edges from 4.14.51 in channel eus-4.16 with the information loaded from the Cincinnati instance managed by Red Hat in Production
+%(prog)s --cincinnati https://api.openshift.com/api/upgrades_info/graph --root-version 4.14.51 eus-4.16''',
+        formatter_class=HelpFormatter,
     )
     parser.add_argument(
         '--architecture',


### PR DESCRIPTION
To demenstrate:

```console
$ hack/show-edges.py -h
usage: show-edges.py [-h] [--architecture ARCHITECTURE] [--repository REPOSITORY] [--revision REVISION] [--root-version VERSION] [--cincinnati URI]
                     [--list-unable-to-reach-target-minor-version]
                     CHANNEL

Display edges for a particular channel and commit.

Examples:
show-edges.py --cincinnati https://api.openshift.com/api/upgrades_info/graph stable-4.16

positional arguments:
  CHANNEL               Cincinnati channel to load.
...
```

This is to avoid the panics in case the command gets lost in my bash history.