### PR TITLE
CNTRLPLANE-1407: blocked-edges: Declare HyperShiftProxyScheme

### DIFF
--- a/blocked-edges/4.18.22-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.18.22-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.18.22
+from: ^4[.](17[.].*|18[.](1?[0-9]|2[0-1]))[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.18.23-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.18.23-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.18.23
+from: ^4[.](17[.].*|18[.](1?[0-9]|2[0-1]))[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.10-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.10-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.10
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.11-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.11-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.11
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.4-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.4-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.4
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.5-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.5-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.5
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.6-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.6-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.6
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.7-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.7-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.7
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.8-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.8-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.8
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.9-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.9-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.9
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
Generated by writing the 4.18.22 and 4.19.4 risks by hand, and then copying them out to later releases with:

```console
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.18&arch=amd64' | jq -r '.nodes[] | .version' | sort -V | grep -A100 '^4[.]18[.]22$' | grep -v '^4[.]18[.]22$' | while read VERSION; do sed "s/4.18.22/${VERSION}/" blocked-edges/4.18.22-HyperShiftProxyScheme.yaml > "blocked-edges/${VERSION}-HyperShiftProxyScheme.yaml"; done
$ curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.19&arch=amd64' | jq -r '.nodes[] | .version' | sort -V | grep -A100 '^4[.]19[.]4$' | grep -v '^4[.]19[.]4$' | while read VERSION; do sed "s/4.19.4/${VERSION}/" blocked-edges/4.19.4-HyperShiftProxyScheme.yaml > "blocked-edges/${VERSION}-HyperShiftProxyScheme.yaml"; done
```