### PR TITLE
CNTRLPLANE-1407: blocked-edges/*-HyperShiftProxyScheme: Extend to 4.18.24 and 4.19.12

### DIFF
--- a/blocked-edges/4.18.24-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.18.24-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.18.24
+from: ^4[.](17[.].*|18[.](1?[0-9]|2[0-1]))[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.19.12-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.12-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.12
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
[OCPBUGS-61567][1] and [OCPBUGS-61568][2] are both still `New`.

[1]: https://issues.redhat.com/browse/OCPBUGS-61567
[2]: https://issues.redhat.com/browse/OCPBUGS-61568