### PR TITLE
RUN-3446: blocked-edges/4.18.23-CrunConflictsWithNVIDIA: Fixed in 4.18.24

### DIFF
--- a/blocked-edges/4.18.23-CrunConflictsWithNVIDIA.yaml
+++ b/blocked-edges/4.18.23-CrunConflictsWithNVIDIA.yaml
@@ -1,5 +1,6 @@
 to: 4.18.23
 from: .*
+fixedIn: 4.18.24
 url: https://issues.redhat.com/browse/RUN-3446
 name: CrunConflictsWithNVIDIA
 message: Some crun 1.23 releases conflict with the NVIDIA GPU Operator over eBPF, causing issues with GPU workloads.


### PR DESCRIPTION
[4.18.24][1] contains [OCPBUGS-60663][2], with [the 418.94.202508261658-0 to 418.94.202509100653-0 RHCOS bump][3] bringing in [a `container-selinux-2.237.0-1.rhaos4.18.el9` build][4] picking up a carry of containers/container-selinux#390.

[1]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.18.24
[2]: https://issues.redhat.com/browse/OCPBUGS-60663
[3]: https://releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/diff.html?arch=x86_64&first_release=418.94.202508261658-0&first_stream=prod%2Fstreams%2F4.18-9.4&second_release=418.94.202509100653-0&second_stream=prod%2Fstreams%2F4.18-9.4
[4]: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3833814