### PR TITLE
CNTRLPLANE-1407: blocked-edges/4.19.13-HyperShiftProxyScheme: Extend to 4.19.13

### DIFF
--- a/blocked-edges/4.19.13-HyperShiftProxyScheme.yaml
+++ b/blocked-edges/4.19.13-HyperShiftProxyScheme.yaml
@@ -1,0 +1,12 @@
+to: 4.19.13
+from: ^4[.](18[.](1?[0-9]|2[0-1])|19[.][0-3])[+].*$
+name: HyperShiftProxyScheme
+url: https://issues.redhat.com/browse/CNTRLPLANE-1407
+message: Hosted/HyperShift clusters where HostedCluster has a configured proxy needed for IDP or ingress canary probes may lose the ability to login.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or
+      0 * group by (_id, invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
The backport for 4.19 is in POST [[1]].

[1]: https://issues.redhat.com/browse/OCPBUGS-61567