### PR TITLE
CORENET-6419: `NMStateServiceFailure`: Declare on 4.16 - 4.19

### DIFF
--- a/blocked-edges/4.16.46-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.16.46-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.16.46
+# 4.16 lower than 4.16.46 and any 4.15
+from: ^4[.](16[.]([0-9]|[1-3][0-9]|4[0-5])|15[.].*)[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.16.47-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.16.47-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.16.47
+# 4.16 lower than 4.16.46 and any 4.15
+from: ^4[.](16[.]([0-9]|[1-3][0-9]|4[0-5])|15[.].*)[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.16.48-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.16.48-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.16.48
+# 4.16 lower than 4.16.46 and any 4.15
+from: ^4[.](16[.]([0-9]|[1-3][0-9]|4[0-5])|15[.].*)[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.16.49-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.16.49-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.16.49
+# 4.16 lower than 4.16.46 and any 4.15
+from: ^4[.](16[.]([0-9]|[1-3][0-9]|4[0-5])|15[.].*)[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.17.38-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.17.38-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.17.38
+# 4.17 lower than 4.17.38 and 4.16 lower than 4.16.46
+from: ^4[.](17[.](([0-9]|[1-2][0-9]|3[0-7]))|16[.]([0-9]|[1-3][0-9]|4[0-5]))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.17.39-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.17.39-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.17.39
+# 4.17 lower than 4.17.38 and 4.16 lower than 4.16.46
+from: ^4[.](17[.](([0-9]|[1-2][0-9]|3[0-7]))|16[.]([0-9]|[1-3][0-9]|4[0-5]))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.17.40-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.17.40-NMStateServiceFailure.yaml
@@ -1,0 +1,16 @@
+to: 4.17.40
+# 4.17 lower than 4.17.38 and 4.16 lower than 4.16.46
+from: ^4[.](17[.](([0-9]|[1-2][0-9]|3[0-7]))|16[.]([0-9]|[1-3][0-9]|4[0-5]))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )
+

--- a/blocked-edges/4.18.22-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.18.22-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.18.22
+# 4.18 lower than 4.18.22 and 4.17 lower than 4.17.38
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|17[.](([0-9]|[1-2][0-9]|3[0-7])))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.18.23-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.18.23-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.18.23
+# 4.18 lower than 4.18.22 and 4.17 lower than 4.17.38
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|17[.](([0-9]|[1-2][0-9]|3[0-7])))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.18.24-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.18.24-NMStateServiceFailure.yaml
@@ -1,6 +1,7 @@
 to: 4.18.24
 # 4.18 lower than 4.18.22 and 4.17 lower than 4.17.38
 from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|17[.](([0-9]|[1-2][0-9]|3[0-7])))[+].*$
+fixedIn: 4.18.25
 url: https://issues.redhat.com/browse/CORENET-6419
 name: NMStateServiceFailure
 message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.

--- a/blocked-edges/4.18.24-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.18.24-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.18.24
+# 4.18 lower than 4.18.22 and 4.17 lower than 4.17.38
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|17[.](([0-9]|[1-2][0-9]|3[0-7])))[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.10-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.10-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.10
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.11-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.11-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.11
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.12-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.12-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.12
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.13-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.13-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.13
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.13-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.13-NMStateServiceFailure.yaml
@@ -1,6 +1,7 @@
 to: 4.19.13
 # 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
 from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+fixedIn: 4.19.14
 url: https://issues.redhat.com/browse/CORENET-6419
 name: NMStateServiceFailure
 message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.

--- a/blocked-edges/4.19.8-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.8-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.8
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )

--- a/blocked-edges/4.19.9-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.19.9-NMStateServiceFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.19.9
+# 4.18 lower than 4.18.22 and 4.19 lower than 4.19.8
+from: ^4[.](18[.]([0-9]|1[0-9]|2[0-1])|19[.][0-7])[+].*$
+url: https://issues.redhat.com/browse/CORENET-6419
+name: NMStateServiceFailure
+message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      topk by (_id) (1,
+        group by (_id, type) (cluster_infrastructure_provider{_id="",type=~"None|BareMetal"})
+        or
+        0 * group by (_id, type) (cluster_infrastructure_provider{_id="",type!~"None|BareMetal"})
+      )


### PR DESCRIPTION
Baremetal clusters that use NMState to create br-ex instead of configure-ovs. That means it is also specific to clusters running OVNKubernetes as the CNI.

- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare on 4.19.(8-13)**
- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare fixed in 4.19.14**
- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare on 4.18.(22-24)**
- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare fixed in 4.18.25**
- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare on 4.17.(38-40)**
- **[CORENET-6419](https://issues.redhat.com//browse/CORENET-6419): `NMStateServiceFailure`: Declare on 4.16.(46-49)**
