### PR TITLE
MCO-1890: blocked-edges/4.19.1[23]-MachineConfigNodesV1AlphaControlPlaneLabels: Declare new risk

### DIFF
--- a/blocked-edges/4.19.12-MachineConfigNodesV1AlphaControlPlaneLabels.yaml
+++ b/blocked-edges/4.19.12-MachineConfigNodesV1AlphaControlPlaneLabels.yaml
@@ -1,0 +1,14 @@
+to: 4.19.12
+from: .*
+url: https://issues.redhat.com/browse/MCO-1890
+name: MachineConfigNodesV1AlphaControlPlaneLabels
+message: Standalone clusters born in 4.11 or earlier whose control-plane nodes lack the control-plane role may need that role added to update to the target release.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group by (role) (kube_node_role{_id="",role="control-plane"})
+      or on ()
+      1 * group by (role) (kube_node_role{_id="",role="master"})
+      or on ()
+      0 * topk(1, count by (role) (kube_node_role{_id=""}))

--- a/blocked-edges/4.19.13-MachineConfigNodesV1AlphaControlPlaneLabels.yaml
+++ b/blocked-edges/4.19.13-MachineConfigNodesV1AlphaControlPlaneLabels.yaml
@@ -1,0 +1,15 @@
+to: 4.19.13
+from: .*
+fixedIn: 4.19.14
+url: https://issues.redhat.com/browse/MCO-1890
+name: MachineConfigNodesV1AlphaControlPlaneLabels
+message: Standalone clusters born in 4.11 or earlier whose control-plane nodes lack the control-plane role may need that role added to update to the target release.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group by (role) (kube_node_role{_id="",role="control-plane"})
+      or on ()
+      1 * group by (role) (kube_node_role{_id="",role="master"})
+      or on ()
+      0 * topk(1, count by (role) (kube_node_role{_id=""}))


### PR DESCRIPTION
[Fixed in 4.19.14][1].  For the PromQL, the logic is:

* If you have any modern-role `control-plane` Nodes, you are not exposed (0), otherwise...
* ... if you have legacy-role `master` Nodes, you are exposed (1), otherwise...
* ... if the `kube_node_role` metric is working at all, you are not exposed (0), otherwise...
* ... we don't know if you are exposed or not (no response metric).

I'm preserving the `role` label in the output results to make it easier to understand how the PromQL functions if folks run it by hand.

[1]: https://issues.redhat.com/browse/OCPBUGS-62114?focusedId=28155286&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-28155286