### PR TITLE
CORENET-6419: `NMStateServiceFailure`: Declare fixed in 4.17.41

### DIFF
--- a/blocked-edges/4.17.40-NMStateServiceFailure.yaml
+++ b/blocked-edges/4.17.40-NMStateServiceFailure.yaml
@@ -1,6 +1,7 @@
 to: 4.17.40
 # 4.17 lower than 4.17.38 and 4.16 lower than 4.16.46
 from: ^4[.](17[.](([0-9]|[1-2][0-9]|3[0-7]))|16[.]([0-9]|[1-3][0-9]|4[0-5]))[+].*$
+fixedIn: 4.17.41
 url: https://issues.redhat.com/browse/CORENET-6419
 name: NMStateServiceFailure
 message: The NMState service can fail on baremetal cluster nodes, causing node scaleups and re-deployment failures.


### PR DESCRIPTION
The 4.17.z bug is Verified [[1]].

4.17.41 changes list `OCPBUGS-61859: Override NMState service definition #5289` [[2]].

[1]: https://issues.redhat.com/browse/OCPBUGS-61859
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.17.41