### PR TITLE
NO-ISSUE: build-suggestions/4.20: Raise minor_min to 4.19.22

### DIFF
--- a/blocked-edges/4.20.0-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.0-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.0
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.1-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.1-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.1
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.10-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.10-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.10
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.2-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.2-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.2
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.3-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.3-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.3
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.4-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.4-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.4
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.5-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.5-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.5
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.6-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.6-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.6
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.8-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.8-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.8
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.9-PrometheusReservedExternalLabelsInUse.yaml
+++ b/blocked-edges/4.20.9-PrometheusReservedExternalLabelsInUse.yaml
@@ -1,0 +1,12 @@
+to: 4.20.9
+from: ^4[.]19[.][0-21][+].*$
+url: https://issues.redhat.com/browse/OCPBUGS-67003
+name: PrometheusReservedExternalLabelsInUse
+message: |-
+  The Cluster Monitoring Operator (CMO) now enforces validation of reserved Prometheus external labels.
+
+  This may result in the operator being marked as `Degraded` and `Unavailable` when updating to a version with enforced validation, if reserved labels are in use.
+
+  The error messages should clearly indicate which external labels are invalid and need to be adjusted.
+matchingRules:
+- type: Always

--- a/build-suggestions/4.20.yaml
+++ b/build-suggestions/4.20.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.19.15
+  minor_min: 4.19.22
   minor_max: 4.19.9999
   minor_block_list: []
   z_min: 4.20.0


### PR DESCRIPTION
Needed for https://issues.redhat.com/browse/OCPBUGS-67003 so users adjust the config before upgrading.

4.19.22 contains the needed changes https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.19.22

blocked-edges: Add PrometheusReservedExternalLabelsInUse risk for 4.20.0-4.20.10, except 4.20.7 as not part of candidate-4.20
