### PR TITLE
CNTRLPLANE-3074: blocked-edges/4.21.8-EtcdStorageVersion3Migration: Fixed in 4.21.9

### DIFF
--- a/blocked-edges/4.21.8-EtcdStorageVersion3Migration.yaml
+++ b/blocked-edges/4.21.8-EtcdStorageVersion3Migration.yaml
@@ -1,5 +1,6 @@
 to: 4.21.8
 from: 4[.]20[.]([0-9]|1[0-4])[+].*
+fixedIn: 4.21.9
 url: https://redhat.atlassian.net/browse/CNTRLPLANE-3074
 name: EtcdStorageVersion3Migration
 message: Updating from etcd 3.5.25 or older to 3.6 without passing through 4.5.26 or later can cause the 3.6 etcd to attempt to contact old, non-existent members tracked in v2 storage.


### PR DESCRIPTION
5d1f60cef0 (#9101) pointed out that we were waiting for a 4.21.z that picked up the 4.20.15 build floor.  4.21.9 is that release:

```console
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.21.9-x86_64 | grep Upgrades
  Upgrades: 4.20.15, 4.20.16, 4.20.17, 4.20.18, 4.21.0, 4.21.1, 4.21.2, 4.21.3, 4.21.4, 4.21.5, 4.21.6, 4.21.7, 4.21.8
```