### PR TITLE
CORENET-6950: blocked-edges/4.21.9-PrecisionTimeProtocolDPLLPins: Extend the risk

### DIFF
--- a/blocked-edges/4.21.9-PrecisionTimeProtocolDPLLPins.yaml
+++ b/blocked-edges/4.21.9-PrecisionTimeProtocolDPLLPins.yaml
@@ -1,0 +1,12 @@
+to: 4.21.9
+from: .*
+url: https://redhat.atlassian.net/browse/CORENET-6950
+name: PrecisionTimeProtocolDPLLPins
+message: Clusters using older PTP operators may struggle to synchronize system clocks and might not provide time to downstream clients.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, name) (csv_succeeded{_id="", name=~"ptp-operator[.]v4[.][0-9]*[.]0-(202[3-5]|20260[1-3])[0-9]*"})
+      or on (_id)
+      0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "ptp-operator.v4.y.0-20260331... or older not installed", "", "")


### PR DESCRIPTION
This is unlikely to get fixed in the kernel API.  Instead, folks will have to update their PTP-operator to pick up [OCPBUGS-81558][1] or a backport.  So at the moment, we'll just carry this risk out to all new 4.19 and later. Eventually, we may do... something... like dropping the risk once we think enough of the PTP-operator fleet will have updated?

[1]: https://redhat.atlassian.net/browse/OCPBUGS-81558