### PR TITLE
CORENET-6950: blocked-edges/4.21.12-PrecisionTimeProtocolDPLLPins: Not fixed in OCP

### DIFF
--- a/blocked-edges/4.21.12-PrecisionTimeProtocolDPLLPins.yaml
+++ b/blocked-edges/4.21.12-PrecisionTimeProtocolDPLLPins.yaml
@@ -1,0 +1,12 @@
+to: 4.21.12
+from: .*
+url: https://redhat.atlassian.net/browse/CORENET-6950
+name: PrecisionTimeProtocolDPLLPins
+message: Clusters using older PTP operators may struggle to synchronize system clocks and might not provide time to downstream clients.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      group by (_id, name) (csv_succeeded{_id="", name=~"ptp-operator[.]v4[.][0-9]*[.]0-(202[3-5]|20260[1-9])[0-9]*"})
+      or on (_id)
+      0 * label_replace(group by (_id) (csv_succeeded{_id=""}), "name", "ptp-operator.v4.y.0-20260331... or older not installed", "", "")


### PR DESCRIPTION
[OCPBUGS-81327][1] [shipped 2026-04-21][2].  But it ships via the ptp-operator, not OCP, so give an additional few days to allow folks to get the word out to ptp-operator users before dropping the risk.

[1]: https://redhat.atlassian.net/browse/OCPBUGS-81327
[2]: https://access.redhat.com/errata/RHBA-2026:8424