### PR TITLE
OTA-1988: hack/release-ga: Check openshift-eng/ga-regression-reports

### DIFF
--- a/hack/release-ga.sh
+++ b/hack/release-ga.sh
@@ -37,6 +37,9 @@ then
 	exit 1
 fi
 
+REGRESSION_REPORT="https://github.com/openshift-eng/ga-regression-reports/blob/main/openshift/${MAJOR}.${MINOR}-ga-regression-report.md"
+curl -s --fail "${REGRESSION_REPORT}" || (echo "failed to retrieve regression report required for GA: ${REGRESSION_REPORT}" >&2; exit 1)
+
 if test "$((MINOR % 2))" -eq 0
 then
 	# 4.even get extended update support: https://issues.redhat.com/browse/OTA-1599


### PR DESCRIPTION
As described in [the new repository][1], an approved regression report is now required before a new OpenShift release can go Generally Available.  We might grow presubmit coverage for centralized enforcement later, but for now, update the script that maintainers run locally to check for a report.

[1]: https://github.com/openshift-eng/ga-regression-reports