### PR TITLE
MultusUpgradeBlocked (OCPBUGS-85381) due to deadlock upgrading from 4.13

### DIFF
--- a/blocked-edges/4.14.65-MultusUpgradeBlocked.yaml
+++ b/blocked-edges/4.14.65-MultusUpgradeBlocked.yaml
@@ -1,0 +1,7 @@
+to: 4.14.65
+from: 4[.]13[.].*
+url: https://redhat.atlassian.net/browse/OCPBUGS-85381
+name: MultusUpgradeBlocked
+message: Upgrades from 4.13 to 4.14 will result in upgrade deadlocks due to Multus CNI rejecting the KubeConfig with brackets.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.14.66-MultusUpgradeBlocked.yaml
+++ b/blocked-edges/4.14.66-MultusUpgradeBlocked.yaml
@@ -1,0 +1,7 @@
+to: 4.14.66
+from: 4[.]13[.].*
+url: https://redhat.atlassian.net/browse/OCPBUGS-85381
+name: MultusUpgradeBlocked
+message: Upgrades from 4.13 to 4.14 will result in upgrade deadlocks due to Multus CNI rejecting the KubeConfig with brackets.
+matchingRules:
+- type: Always


### PR DESCRIPTION
4.13 and earlier versrions of the product produced KubeConfig files where the address was in brackets which breaks when fixes for CVE-2025-47912 are applied and binaries rebuilt. Additionally, when upgrading from 4.13 to 4.14 results in a transition from multus thin cni plugins to thick plugins. The combination of these two events prevents upgrades from 4.13 to 4.14 and will require additional changes to sanitize the KubeConfig. We will apply those fixes in the near future but we needed to ship 4.14.z kernel CVE fixes before that problem could be corrected.

As such, 4.14 to 4.14.z upgrades are fine. However 4.13 to 4.14.65 and later are problematic until the referenced bug is fixed. Note, the same is true of 4.14.64 however that release was tombstoned and thus never shipped.