### PR TITLE
Set minimum version of 4.20 required to upgrade to 4.21

### DIFF
--- a/build-suggestions/4.21.yaml
+++ b/build-suggestions/4.21.yaml
@@ -1,5 +1,5 @@
 default:
-  minor_min: 4.20.15
+  minor_min: 4.20.25
   minor_max: 4.20.9999
   minor_block_list: []
   z_min: 4.21.0


### PR DESCRIPTION
Fixes: Related to fix #[OCPBUGS-83862](https://redhat.atlassian.net/browse/OCPBUGS-83862) to be applied before upgrading to 4.21

This change introduces a gate to block 4.20 clusters from upgrading to 4.21 until the prerequisite patch for Auto Node Sizing has been applied.

Requirement: The necessary 4.20 patch https://github.com/openshift/machine-config-operator/pull/5885 introduces a specific MachineConfig to enforce this disabled state for master and worker mcp. This is fixed in 4.20.25.

Goal: This PR ensures upgrade safety by confirming the presence of that MachineConfig before proceeding to 4.21.