### PR TITLE
NO-JIRA: blocked-edges/4.14.66-MultusUpgradeBlocked: Declare fixed in 4.14.67

### DIFF
--- a/blocked-edges/4.14.66-MultusUpgradeBlocked.yaml
+++ b/blocked-edges/4.14.66-MultusUpgradeBlocked.yaml
@@ -1,5 +1,6 @@
 to: 4.14.66
 from: 4[.]13[.].*
+fixedIn: 4.14.67
 url: https://redhat.atlassian.net/browse/OCPBUGS-85381
 name: MultusUpgradeBlocked
 message: Upgrades from 4.13 to 4.14 will result in upgrade deadlocks due to Multus CNI rejecting the KubeConfig with brackets.


### PR DESCRIPTION
The 4.14.z bug [[1]] is currently in Verified.

The 4.14.67 release does contain the fix [[2]]:

```
multus-cni
OCPBUGS-85381: Sanitize bracketed hostnames in kubeconfig server URLs #295
```

This PR references https://redhat.atlassian.net/browse/OCPBUGS-85381

[1]: https://redhat.atlassian.net/browse/OCPBUGS-85381
[2]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.14.67