### PR TITLE
OCPNODE-4579: Extend risk/S390xContainerDataFailure to 4.22.2

### DIFF
--- a/blocked-edges/4.22.2-S390xContainerDataFailure.yaml
+++ b/blocked-edges/4.22.2-S390xContainerDataFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.22.2
+from: ^4[.](21[.].*|22[.]0-ec[.][0-2])[+].*$
+url: https://redhat.atlassian.net/browse/OCPNODE-4579
+name: S390xContainerDataFailure
+message: |
+  On s390x nodes, malformed container data prevents pod autoscaling, eviction, and metrics collection, affecting monitoring dashboards.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          group by (label_kubernetes_io_arch) (kube_node_labels{_id="",label_kubernetes_io_arch="s390x"})
+          or
+          0 * group by (label_kubernetes_io_arch) (kube_node_labels{_id=""})
+        )


### PR DESCRIPTION
The underlying bug https://redhat.atlassian.net/browse/OCPBUGS-87805 is still Assigned.

``` console
$ diff -Naupr blocked-edges/4.22.1-S390xContainerDataFailure.yaml blocked-edges/4.22.2-S390xContainerDataFailure.yaml
--- blocked-edges/4.22.1-S390xContainerDataFailure.yaml 2026-06-19 08:18:47
+++ blocked-edges/4.22.2-S390xContainerDataFailure.yaml 2026-06-19 08:22:13
@@ -1,4 +1,4 @@
-to: 4.22.1
+to: 4.22.2
 from: ^4[.](21[.].*|22[.]0-ec[.][0-2])[+].*$
 url: https://redhat.atlassian.net/browse/OCPNODE-4579
 name: S390xContainerDataFailure
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added detection and handling for an s390x-specific container data issue on release 4.22.2 that was preventing pod autoscaling, pod eviction, and metrics collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->