### PR TITLE
CONSOLE-5337: blocked-edges: Add ControlPlaneStatusGreyIcon risk for 4.20.23-24

### DIFF
--- a/blocked-edges/4.20.23-ControlPlaneStatusGreyIcon.yaml
+++ b/blocked-edges/4.20.23-ControlPlaneStatusGreyIcon.yaml
@@ -1,0 +1,13 @@
+to: 4.20.23
+from: .*
+url: https://redhat.atlassian.net/browse/CONSOLE-5337
+name: ControlPlaneStatusGreyIcon
+message: |
+  Control plane status indicator remains grey and never shows green, even when cluster operators are healthy.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group by (invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or on ()
+      group by (invoker) (cluster_installer{_id=""})

--- a/blocked-edges/4.20.24-ControlPlaneStatusGreyIcon.yaml
+++ b/blocked-edges/4.20.24-ControlPlaneStatusGreyIcon.yaml
@@ -1,0 +1,14 @@
+to: 4.20.24
+from: .*
+fixedIn: 4.20.25
+url: https://redhat.atlassian.net/browse/CONSOLE-5337
+name: ControlPlaneStatusGreyIcon
+message: |
+  Control plane status indicator remains grey and never shows green, even when cluster operators are healthy.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group by (invoker) (cluster_installer{_id="",invoker="hypershift"})
+      or on ()
+      group by (invoker) (cluster_installer{_id=""})


### PR DESCRIPTION
Add upgrade risk for [CONSOLE-5337](https://redhat.atlassian.net/browse/CONSOLE-5337) affecting 4.20.23 and 4.20.24 where the control plane status indicator remains grey and never shows green, even when cluster operators are healthy. Fixed in 4.20.25.

Affects all clusters except those with external control plane topology (HyperShift).

PromQL pattern is based on HyperShiftRedundantRouter[1] but inverted:
- HyperShiftRedundantRouter targets HyperShift clusters (invoker="hypershift")
- This risk excludes HyperShift clusters by zeroing them out (0 * ...)
- The "or on ()" clause then returns all non-HyperShift clusters
- Difference: HyperShiftRedundantRouter affects only HyperShift, this affects only standalone (non-HyperShift) clusters

[1] https://github.com/openshift/cincinnati-graph-data/blob/master/blocked-edges/4.19.18-HyperShiftRedundantRouter.yaml

```console
$ diff -Naupr blocked-edges/4.20.23-ControlPlaneStatusGreyIcon.yaml blocked-edges/4.20.24-ControlPlaneStatusGreyIcon.yaml
--- blocked-edges/4.20.23-ControlPlaneStatusGreyIcon.yaml       2026-06-19 11:29:45
+++ blocked-edges/4.20.24-ControlPlaneStatusGreyIcon.yaml       2026-06-19 11:29:46
@@ -1,5 +1,6 @@
-to: 4.20.23
+to: 4.20.24
 from: .*
+fixedIn: 4.20.25
 url: https://redhat.atlassian.net/browse/CONSOLE-5337
 name: ControlPlaneStatusGreyIcon
 message: |
```

/hold

verifying the PromQL 