### PR TITLE
OCPNODE-4579: blocked-edges/4.22.3-S390xContainerDataFailure: Not fixed yet

### DIFF
--- a/blocked-edges/4.22.3-S390xContainerDataFailure.yaml
+++ b/blocked-edges/4.22.3-S390xContainerDataFailure.yaml
@@ -1,0 +1,15 @@
+to: 4.22.3
+from: ^4[.](21[.].*|22[.]0-ec[.][0-2])[+].*$
+url: https://redhat.atlassian.net/browse/OCPNODE-4579
+name: S390xContainerDataFailure
+message: |
+  On s390x nodes, malformed container data prevents pod autoscaling, eviction, and metrics collection, affecting monitoring dashboards.
+matchingRules:
+  - type: PromQL
+    promql:
+      promql: |
+        topk(1,
+          group by (label_kubernetes_io_arch) (kube_node_labels{_id="",label_kubernetes_io_arch="s390x"})
+          or
+          0 * group by (label_kubernetes_io_arch) (kube_node_labels{_id=""})
+        )


### PR DESCRIPTION
[OCPBUGS-87805][1] is still `Assigned`.

[1]: https://redhat.atlassian.net/browse/OCPBUGS-87805