### PR TITLE
MON-4619: Declare KubeStateMetricsTimezonePanic risk for 4.20.z

### DIFF
--- a/blocked-edges/4.20.29-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.20.29-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.20.29
+from: 4[.](19[.].*|20[.](1?[0-9]|2[0-8]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.30-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.20.30-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.20.30
+from: 4[.](19[.].*|20[.](1?[0-9]|2[0-8]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.20.31-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.20.31-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,9 @@
+to: 4.20.31
+from: 4[.](19[.].*|20[.](1?[0-9]|2[0-8]))[+].*
+fixedIn: 4.20.32
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.21.24-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.21.24-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.21.24
+from: 4[.](20[.](1?[0-9]|2[0-8])|21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.21.25-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.21.25-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.21.25
+from: 4[.](20[.](1?[0-9]|2[0-8])|21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.21.26-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.21.26-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,9 @@
+to: 4.21.26
+from: 4[.](20[.](1?[0-9]|2[0-8])|21[.](1?[0-9]|2[0-3]))[+].*
+fixedIn: 4.21.27
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.0-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.0-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.0
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.1-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.1-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.1
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.2-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.2-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.2
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.3-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.3-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.3
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.4-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.4-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.4
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.5-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.5-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.5
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.6-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.6-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,8 @@
+to: 4.22.6
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always

--- a/blocked-edges/4.22.7-KubeStateMetricsTimezonePanic.yaml
+++ b/blocked-edges/4.22.7-KubeStateMetricsTimezonePanic.yaml
@@ -1,0 +1,9 @@
+to: 4.22.7
+from: 4[.](21[.](1?[0-9]|2[0-3]))[+].*
+fixedIn: 4.22.8
+url: https://redhat.atlassian.net/browse/MON-4619
+name: KubeStateMetricsTimezonePanic
+message: |
+  Clusters with CronJobs using .spec.timeZone may experience kube-state-metrics crash loops due to missing timezone data in the container image, breaking monitoring and potentially stalling upgrades.
+matchingRules:
+- type: Always


### PR DESCRIPTION
## Summary

Adds conditional update risk for all 4.20.z GA releases (4.20.0 through 4.20.30) to warn clusters upgrading from 4.19.z that kube-state-metrics may crash loop if CronJobs with `.spec.timeZone` are present.

Root cause: `/usr/share/zoneinfo/` is missing from the kube-state-metrics container image. The statically-compiled Go binary panics when `time.LoadLocation()` fails for timezone-aware CronJobs.

- **Affected**: 4.20.z, 4.21.z, 4.22.z (confirmed by Benjamin Affolter and Simon Pasquier)
- **Not affected**: 4.19.z
- **Blocked-edges for 4.20.z only**: upgrading from 4.20→4.21 or 4.21→4.22 does not increase exposure (affected→affected)
- **No `fixedIn`**: fix PRs [openshift/kube-state-metrics#147](https://github.com/openshift/kube-state-metrics/pull/147) and [#150](https://github.com/openshift/kube-state-metrics/pull/150) still open
- **`type: Always`**: no PromQL metric for CronJob timezone usage

## Bug

- https://redhat.atlassian.net/browse/OCPBUGS-87957
- Impact statement: https://redhat.atlassian.net/browse/MON-4619

## Test plan

- [x] `./hack/validate-blocked-edges.py` passes