### PR TITLE
OTA-646: Add GitHub App authentication support to stabilization bot

### DIFF
--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -632,7 +632,8 @@ def notify(message, webhook=None):
 
 
 def promote(version, channel_name, channel_path, subject, body, upstream_github_repo, push_github_repo, github_token, upstream_branch, labels=None, github_app_id=None, github_app_private_key=None):
-    if github_token or github_app_id:
+    use_app_auth = github_app_id and github_app_private_key
+    if github_token or use_app_auth:
         upstream_remote = get_remote(repo=upstream_github_repo)
         subprocess.run(['git', 'fetch', upstream_remote], check=True)
         branch = 'promote-{}-to-{}'.format(version, channel_name)
@@ -659,7 +660,7 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
         yaml.safe_dump(data, f, default_flow_style=False)
     message = '{}\n\n{}\n'.format(subject, textwrap.fill(body, width=76))
 
-    if not github_token and not github_app_id:
+    if not github_token and not use_app_auth:
         pull = PullRequest(html_url='data://no-token-so-no-pull')
         return pull
 
@@ -668,34 +669,39 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
 
     subprocess.run(['git', 'commit', '--file', '-', channel_path], check=True, encoding='utf-8', input=message)
 
-    if github_app_id and github_app_private_key:
+    push_token = None
+    if use_app_auth:
         auth = AppAuth(int(github_app_id), github_app_private_key)
         integration = GithubIntegration(auth=auth)
-        owner = upstream_github_repo.split('/')[0]
+        upstream_owner = upstream_github_repo.split('/')[0]
         repo_name = upstream_github_repo.split('/')[1]
-        installation = integration.get_repo_installation(owner, repo_name)
+        installation = integration.get_repo_installation(upstream_owner, repo_name)
         github_object = integration.get_github_for_installation(installation_id=installation.id)
-        token = github_object._Github__requester._Requester__auth.token
-        push_uri_with_token = 'https://x-access-token:{}@github.com/{}.git'.format(token, push_github_repo)
+        push_token = integration.get_access_token(installation.id).token
+        push_uri_with_token = 'https://x-access-token:{}@github.com/{}.git'.format(push_token, push_github_repo)
     else:
         github_object = github.Github(github_token)
+        push_token = github_token
         push_uri_with_token = 'https://{}@github.com/{}.git'.format(github_token, push_github_repo)
 
     subprocess.run(['git', 'push', '-u', push_uri_with_token, branch], check=True)
 
-    owner = push_github_repo.split('/')[0]
+    push_owner = push_github_repo.split('/')[0]
 
     repo = github_object.get_repo(upstream_github_repo)
-    pull = repo.create_pull(title=subject, body=body, head='{}:{}'.format(owner, branch), base=upstream_branch, maintainer_can_modify=True)
+    pull = repo.create_pull(title=subject, body=body, head='{}:{}'.format(push_owner, branch), base=upstream_branch, maintainer_can_modify=True)
     if labels:
         pull.add_to_labels(*labels)
     return pull
 
 
-def sanitize(err, github_token=None):
-    if github_token is None:
-        return err
-    return str(err).replace(github_token, 'REDACTED')
+def sanitize(err, github_token=None, push_token=None):
+    result = str(err)
+    if github_token:
+        result = result.replace(github_token, 'REDACTED')
+    if push_token and push_token != github_token:
+        result = result.replace(push_token, 'REDACTED')
+    return result
 
 
 def semver_sort_key(version):

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -670,7 +670,7 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
     subprocess.run(['git', 'commit', '--file', '-', channel_path], check=True, encoding='utf-8', input=message)
 
     if use_app_auth:
-        auth = AppAuth(int(github_app_id), github_app_private_key)
+        auth = AppAuth(github_app_id, github_app_private_key)
         integration = GithubIntegration(auth=auth)
         upstream_owner = upstream_github_repo.split('/')[0]
         repo_name = upstream_github_repo.split('/')[1]
@@ -780,8 +780,9 @@ def main():
         '--github-app-id',
         dest='github_app_id',
         metavar='ID',
+        type=int,
         help='GitHub App ID for authentication. Use with --github-app-private-key-file as an alternative to --github-token.',
-        default=os.environ.get('GITHUB_APP_ID', ''),
+        default=os.environ.get('GITHUB_APP_ID') or None,
     )
     parser.add_argument(
         '--github-app-private-key-file',
@@ -806,11 +807,7 @@ def main():
 
     github_app_private_key = None
     if args.github_app_private_key_file:
-        key_path = args.github_app_private_key_file.strip()
-        if not os.path.exists(key_path):
-            _LOGGER.fatal('GitHub App private key file not found: {}'.format(key_path))
-            raise SystemExit(1)
-        with open(key_path) as f:
+        with open(args.github_app_private_key_file.strip()) as f:
             github_app_private_key = f.read()
 
     next_notification = datetime.datetime.now()
@@ -832,7 +829,7 @@ def main():
             upstream_github_repo=upstream_github_repo,
             push_github_repo=(args.push_github_repo or upstream_github_repo).strip(),
             github_token=args.github_token.strip() or None,
-            github_app_id=args.github_app_id.strip() or None,
+            github_app_id=args.github_app_id,
             github_app_private_key=github_app_private_key,
             labels=args.labels,
             webhook=args.webhook.strip(),

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -669,22 +669,24 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
 
     subprocess.run(['git', 'commit', '--file', '-', channel_path], check=True, encoding='utf-8', input=message)
 
-    push_token = None
     if use_app_auth:
         auth = AppAuth(int(github_app_id), github_app_private_key)
         integration = GithubIntegration(auth=auth)
         upstream_owner = upstream_github_repo.split('/')[0]
         repo_name = upstream_github_repo.split('/')[1]
         installation = integration.get_repo_installation(upstream_owner, repo_name)
-        github_object = integration.get_github_for_installation(installation_id=installation.id)
-        push_token = integration.get_access_token(installation.id).token
-        push_uri_with_token = 'https://x-access-token:{}@github.com/{}.git'.format(push_token, push_github_repo)
+        access_token = integration.get_access_token(installation.id).token
+        github_object = github.Github(access_token)
+        push_uri_with_token = 'https://x-access-token:{}@github.com/{}.git'.format(access_token, push_github_repo)
     else:
+        access_token = github_token
         github_object = github.Github(github_token)
-        push_token = github_token
         push_uri_with_token = 'https://{}@github.com/{}.git'.format(github_token, push_github_repo)
 
-    subprocess.run(['git', 'push', '-u', push_uri_with_token, branch], check=True)
+    try:
+        subprocess.run(['git', 'push', '-u', push_uri_with_token, branch], check=True)
+    except Exception as exc:
+        raise type(exc)(sanitize(exc, github_token=github_token, push_token=access_token)) from None
 
     push_owner = push_github_repo.split('/')[0]
 
@@ -804,7 +806,11 @@ def main():
 
     github_app_private_key = None
     if args.github_app_private_key_file:
-        with open(args.github_app_private_key_file) as f:
+        key_path = args.github_app_private_key_file.strip()
+        if not os.path.exists(key_path):
+            _LOGGER.fatal('GitHub App private key file not found: {}'.format(key_path))
+            raise SystemExit(1)
+        with open(key_path) as f:
             github_app_private_key = f.read()
 
     next_notification = datetime.datetime.now()

--- a/hack/stabilization-changes.py
+++ b/hack/stabilization-changes.py
@@ -19,9 +19,13 @@ import urllib.request
 
 try:
     import github
+    from github import GithubIntegration
+    from github.Auth import AppAuth
 except ModuleNotFoundError as error:
     github_import_error = error
     github = None
+    GithubIntegration = None
+    AppAuth = None
 
 import yaml
 
@@ -627,8 +631,8 @@ def notify(message, webhook=None):
     }).encode('utf-8'))
 
 
-def promote(version, channel_name, channel_path, subject, body, upstream_github_repo, push_github_repo, github_token, upstream_branch, labels=None):
-    if github_token:
+def promote(version, channel_name, channel_path, subject, body, upstream_github_repo, push_github_repo, github_token, upstream_branch, labels=None, github_app_id=None, github_app_private_key=None):
+    if github_token or github_app_id:
         upstream_remote = get_remote(repo=upstream_github_repo)
         subprocess.run(['git', 'fetch', upstream_remote], check=True)
         branch = 'promote-{}-to-{}'.format(version, channel_name)
@@ -655,7 +659,7 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
         yaml.safe_dump(data, f, default_flow_style=False)
     message = '{}\n\n{}\n'.format(subject, textwrap.fill(body, width=76))
 
-    if not github_token:
+    if not github_token and not github_app_id:
         pull = PullRequest(html_url='data://no-token-so-no-pull')
         return pull
 
@@ -663,12 +667,24 @@ def promote(version, channel_name, channel_path, subject, body, upstream_github_
         raise github_import_error
 
     subprocess.run(['git', 'commit', '--file', '-', channel_path], check=True, encoding='utf-8', input=message)
-    push_uri_with_token = 'https://{}@github.com/{}.git'.format(github_token, push_github_repo)
+
+    if github_app_id and github_app_private_key:
+        auth = AppAuth(int(github_app_id), github_app_private_key)
+        integration = GithubIntegration(auth=auth)
+        owner = upstream_github_repo.split('/')[0]
+        repo_name = upstream_github_repo.split('/')[1]
+        installation = integration.get_repo_installation(owner, repo_name)
+        github_object = integration.get_github_for_installation(installation_id=installation.id)
+        token = github_object._Github__requester._Requester__auth.token
+        push_uri_with_token = 'https://x-access-token:{}@github.com/{}.git'.format(token, push_github_repo)
+    else:
+        github_object = github.Github(github_token)
+        push_uri_with_token = 'https://{}@github.com/{}.git'.format(github_token, push_github_repo)
+
     subprocess.run(['git', 'push', '-u', push_uri_with_token, branch], check=True)
 
     owner = push_github_repo.split('/')[0]
 
-    github_object = github.Github(github_token)
     repo = github_object.get_repo(upstream_github_repo)
     pull = repo.create_pull(title=subject, body=body, head='{}:{}'.format(owner, branch), base=upstream_branch, maintainer_can_modify=True)
     if labels:
@@ -753,6 +769,20 @@ def main():
         default=os.environ.get('GITHUB_TOKEN', ''),
     )
     parser.add_argument(
+        '--github-app-id',
+        dest='github_app_id',
+        metavar='ID',
+        help='GitHub App ID for authentication. Use with --github-app-private-key-file as an alternative to --github-token.',
+        default=os.environ.get('GITHUB_APP_ID', ''),
+    )
+    parser.add_argument(
+        '--github-app-private-key-file',
+        dest='github_app_private_key_file',
+        metavar='PATH',
+        help='Path to the GitHub App private key PEM file. Use with --github-app-id.',
+        default=os.environ.get('GITHUB_APP_PRIVATE_KEY_FILE', ''),
+    )
+    parser.add_argument(
         '--labels',
         nargs='*',
         help='Set these labels on newly created pull request.  For example: "--labels lgtm approved".',
@@ -765,6 +795,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    github_app_private_key = None
+    if args.github_app_private_key_file:
+        with open(args.github_app_private_key_file) as f:
+            github_app_private_key = f.read()
 
     next_notification = datetime.datetime.now()
     while True:
@@ -785,6 +820,8 @@ def main():
             upstream_github_repo=upstream_github_repo,
             push_github_repo=(args.push_github_repo or upstream_github_repo).strip(),
             github_token=args.github_token.strip() or None,
+            github_app_id=args.github_app_id.strip() or None,
+            github_app_private_key=github_app_private_key,
             labels=args.labels,
             webhook=args.webhook.strip(),
             waiting_notifications=waiting_notifications,


### PR DESCRIPTION
## Summary

Adds GitHub App authentication as an alternative to PAT-based auth in `hack/stabilization-changes.py`. This is the code change needed to migrate `openshift-ota-bot` from a regular GitHub user account to a GitHub App, which fixes the Prow `trusted_apps` issue (Prow requires the `[bot]` suffix that only GitHub Apps have).

## Changes

- New flags: `--github-app-id` and `--github-app-private-key-file` (with `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_FILE` env var fallbacks)
- When app credentials are provided, uses PyGithub's `AppAuth` + `GithubIntegration` for API calls and `x-access-token:<installation_token>` for git push
- Backwards compatible: `--github-token` / `GITHUB_TOKEN` continues to work
- No new dependencies (PyGithub already supports GitHub App auth natively)

## Testing

- Created a dev GitHub App (`openshift-ota-bot-dev`, App ID: 4368317)
- Verified full flow: git push with `x-access-token` + PR creation via API
- PR correctly authored by `openshift-ota-bot-dev[bot]` (the `[bot]` suffix Prow needs)
- Test PR: https://github.com/shahsahil264/cincinnati-graph-data/pull/2 (closed)

## Remaining work (separate tickets)

1. Create production GitHub App and transfer to `openshift-eng` org
2. Install app on `openshift/cincinnati-graph-data`
3. Update PSI deployment secrets
4. Verify Prow `trusted_apps` works with `[bot]` suffix
5. Retire old user account

## Bug

https://redhat.atlassian.net/browse/OTA-646