### PR TITLE
OTA-1975: add product-life-cycle to graph-data image

### DIFF
--- a/deploy/2-build-config.yaml
+++ b/deploy/2-build-config.yaml
@@ -13,7 +13,9 @@ spec:
       FROM registry.access.redhat.com/ubi8/ubi:8.1
       WORKDIR /home
       COPY . graph-data
-      RUN mkdir -p /var/lib/cincinnati/graph-data
+      RUN mkdir -p /var/lib/cincinnati/graph-data && \
+          curl -L -o graph-data/products.json https://access.redhat.com/product-life-cycles/api/v2/products || \
+          echo "{}" > graph-data/products.json
       CMD cp -rp graph-data/* /var/lib/cincinnati/graph-data
   strategy:
     type: Docker


### PR DESCRIPTION
Follow-on work to support https://github.com/openshift/cincinnati/pull/1072 and https://github.com/openshift/cincinnati-operator/pull/270