### PR TITLE
CORENET-7361: Declare MultusCniVersionThirdPartyCniBreak risk for 4.22.3-5

### DIFF
--- a/blocked-edges/4.22.3-MultusCniVersionThirdPartyCniBreak.yaml
+++ b/blocked-edges/4.22.3-MultusCniVersionThirdPartyCniBreak.yaml
@@ -1,0 +1,13 @@
+to: 4.22.3
+from: 4[.](21[.].*|22[.][0-2])[+].*
+url: https://redhat.atlassian.net/browse/CORENET-7361
+name: MultusCniVersionThirdPartyCniBreak
+message: |
+  Clusters using third-party CNI plugins such as Cilium may completely fail after upgrading to this version due to a multus cniVersion incompatibility. Only host-network pods can be created. Clusters using OVN-Kubernetes are not affected. Update to 4.22.6 or later instead.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group(max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or
+      group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.22.4-MultusCniVersionThirdPartyCniBreak.yaml
+++ b/blocked-edges/4.22.4-MultusCniVersionThirdPartyCniBreak.yaml
@@ -1,0 +1,13 @@
+to: 4.22.4
+from: 4[.](21[.].*|22[.][0-2])[+].*
+url: https://redhat.atlassian.net/browse/CORENET-7361
+name: MultusCniVersionThirdPartyCniBreak
+message: |
+  Clusters using third-party CNI plugins such as Cilium may completely fail after upgrading to this version due to a multus cniVersion incompatibility. Only host-network pods can be created. Clusters using OVN-Kubernetes are not affected. Update to 4.22.6 or later instead.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group(max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or
+      group(max_over_time(apiserver_storage_objects{_id=""}[1h]))

--- a/blocked-edges/4.22.5-MultusCniVersionThirdPartyCniBreak.yaml
+++ b/blocked-edges/4.22.5-MultusCniVersionThirdPartyCniBreak.yaml
@@ -1,0 +1,14 @@
+to: 4.22.5
+from: 4[.](21[.].*|22[.][0-2])[+].*
+fixedIn: 4.22.6
+url: https://redhat.atlassian.net/browse/CORENET-7361
+name: MultusCniVersionThirdPartyCniBreak
+message: |
+  Clusters using third-party CNI plugins such as Cilium may completely fail after upgrading to this version due to a multus cniVersion incompatibility. Only host-network pods can be created. Clusters using OVN-Kubernetes are not affected. Update to 4.22.6 or later instead.
+matchingRules:
+- type: PromQL
+  promql:
+    promql: |
+      0 * group(max_over_time(apiserver_storage_objects{_id="",resource="egressips.k8s.ovn.org"}[1h]))
+      or
+      group(max_over_time(apiserver_storage_objects{_id=""}[1h]))


### PR DESCRIPTION
## Summary

Adds conditional update risk for 4.22.3, 4.22.4, and 4.22.5 to warn non-OVN clusters that third-party CNI plugins (Cilium, potentially others) may completely fail due to multus bumping cniVersion to 1.1.0.

- **Affected**: 4.22.3-5 (regression from 4.22.2 to 4.22.3)
- **Fixed in**: 4.22.6
- **Scope**: Non-OVN clusters only (PromQL uses EgressIP CRD check per Trevor's recommendation)
- **Impact**: cluster completely fails, only host-network pods can be created

## PromQL

Uses `apiserver_storage_objects{resource="egressips.k8s.ovn.org"}` to detect OVN clusters (safe) vs non-OVN (at risk). Pattern approved by @wking.

## Bug

- https://redhat.atlassian.net/browse/OCPBUGS-86033
- Impact statement: https://redhat.atlassian.net/browse/CORENET-7361

## Test plan

- [x] `./hack/validate-blocked-edges.py` passes